### PR TITLE
Set SQLite busy_timeout to absorb back-to-back skill contention

### DIFF
--- a/bartleby/db/connection.py
+++ b/bartleby/db/connection.py
@@ -43,6 +43,7 @@ def _attach(conn: apsw.Connection) -> None:
     cur.execute("PRAGMA foreign_keys = ON")
     cur.execute("PRAGMA journal_mode = WAL")
     cur.execute("PRAGMA synchronous = NORMAL")
+    cur.execute("PRAGMA busy_timeout = 5000")
 
 
 def open_db(project_name: str | None = None) -> apsw.Connection:


### PR DESCRIPTION
## Summary
- Adds `PRAGMA busy_timeout = 5000` to `_attach()` so APSW connections wait up to 5s for a lock instead of refusing instantly.

## Why
Every skill invocation ends by writing to `audit_logs` (`db/audit.py:33`). When an agent runs back-to-back skill calls, process A's commit + WAL checkpoint can overlap process B's startup. APSW defaults to no busy_timeout, so process B sees `BusyError: database is locked` immediately at ~0.1s.

The cause is internal (`bartleby embed` does not open the DB), so this is contention between sequential skill processes, not external readers/writers.

## Test plan
- [x] `uv run pytest` — 226/226 passing
- [ ] Manual: run back-to-back `bartleby skill search` calls and confirm no `BusyError`

Closes #21