### PR TITLE
Surface created_at in list_documents brief output

### DIFF
--- a/bartleby/skill_scripts/list_documents.py
+++ b/bartleby/skill_scripts/list_documents.py
@@ -2,8 +2,8 @@
 """list_documents — enumerate documents in the corpus.
 
 Default output is *brief*: id, file_name, title, description, authored_date,
-has_summary, image_count. Pass ``--verbose`` for the full row (adds
-page_count, token_count, chunk_count, created_at).
+created_at, has_summary, image_count. Pass ``--verbose`` for the full row
+(adds page_count, token_count, chunk_count).
 
 Output:
     {
@@ -35,7 +35,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument(
         "--verbose",
         action="store_true",
-        help="Include page_count, token_count, chunk_count, created_at.",
+        help="Include page_count, token_count, chunk_count.",
     )
     p.add_argument(
         "--tag",
@@ -101,6 +101,7 @@ def work(*, conn, args, session_id) -> dict:
             "title": title,
             "description": description,
             "authored_date": authored_date,
+            "created_at": created_at,
             "has_summary": bool(has_summary),
             "image_count": image_count,
         }
@@ -109,7 +110,6 @@ def work(*, conn, args, session_id) -> dict:
                 "page_count": page_count,
                 "token_count": token_count,
                 "chunk_count": chunk_count,
-                "created_at": created_at,
             })
         documents.append(doc)
 

--- a/tests/test_skill_list_documents.py
+++ b/tests/test_skill_list_documents.py
@@ -26,6 +26,7 @@ def test_list_documents_happy_path(seeded_project, capsys):
     assert by_name["alpha.pdf"]["title"] == "Alpha"
     assert by_name["alpha.pdf"]["description"] == "Test summary of alpha document."
     assert by_name["alpha.pdf"]["authored_date"] is None
+    assert by_name["alpha.pdf"]["created_at"] is not None
     assert by_name["beta.txt"]["has_summary"] is False
     assert by_name["beta.txt"]["image_count"] == 0
     # Unsummarized doc reports title/description/authored_date as null.


### PR DESCRIPTION
## Summary
- Moves `created_at` from `--verbose`-only into the default brief output of `list_documents`.

## Why
Agents using the skill have no signal for which documents are recent vs. archival without re-running with `--verbose`. The column was already selected by the query, just hidden from the brief dict.

## Test plan
- [x] `uv run pytest` — 226/226 passing
- [x] Brief output now includes `created_at` (ISO-8601)

Closes #22