### PR TITLE
Thread Docling PDF page numbers through to chunks

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -493,7 +493,7 @@ def _ingest_pdf_docling(
             on_stage("embedding")
         rows = [
             ChunkRow(text=c.text, section_heading=c.section_heading,
-                     content_type=c.content_type)
+                     content_type=c.content_type, page_number=c.page_number)
             for c in docling_result.chunks
         ]
         embeddings = embed_texts([r.text for r in rows])

--- a/bartleby/ingest/chunk.py
+++ b/bartleby/ingest/chunk.py
@@ -49,7 +49,7 @@ def convert_and_chunk(path: Path) -> ConversionResult:
         result = docling_pipeline.convert(path)
         rows = [
             ChunkRow(text=c.text, section_heading=c.section_heading,
-                     content_type=c.content_type)
+                     content_type=c.content_type, page_number=c.page_number)
             for c in result.chunks
         ]
         return ConversionResult(

--- a/bartleby/ingest/docling.py
+++ b/bartleby/ingest/docling.py
@@ -26,6 +26,7 @@ class DoclingChunk:
     text: str
     section_heading: str | None
     content_type: str | None
+    page_number: int | None = None
 
 
 @dataclass
@@ -103,6 +104,25 @@ def _content_type(chunk) -> str | None:
     return str(label) if label is not None else None
 
 
+def _first_page(chunk) -> int | None:
+    """First page a chunk spans, via Docling's per-item provenance.
+
+    Docling's HybridChunker groups doc items by token budget and can straddle
+    page boundaries. We store the chunk's starting page — the schema is one
+    integer per chunk and the web view's #page anchor only takes one page
+    anyway. Markdown and HTML inputs have no provenance and return None.
+    """
+    meta = getattr(chunk, "meta", None)
+    if meta is None:
+        return None
+    pages = [
+        prov.page_no
+        for item in (getattr(meta, "doc_items", None) or [])
+        for prov in (getattr(item, "prov", None) or [])
+    ]
+    return min(pages) if pages else None
+
+
 def _iter_chunks(chunker, doc) -> Iterable[DoclingChunk]:
     for raw in chunker.chunk(dl_doc=doc):
         contextualized = chunker.contextualize(chunk=raw)
@@ -112,6 +132,7 @@ def _iter_chunks(chunker, doc) -> Iterable[DoclingChunk]:
             text=contextualized,
             section_heading=_section_heading(raw),
             content_type=_content_type(raw),
+            page_number=_first_page(raw),
         )
 
 

--- a/tests/test_ingest_docling.py
+++ b/tests/test_ingest_docling.py
@@ -1,0 +1,50 @@
+"""Unit tests for the Docling adapter's page-number extraction.
+
+These tests don't load Docling itself — they exercise the meta-shape parser
+against namespace objects shaped like Docling's chunk metadata. Real
+Docling integration is covered by `bartleby scribe` runs against PDFs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bartleby.ingest.docling import _first_page
+
+
+def _chunk(*page_lists: list[int]) -> SimpleNamespace:
+    """Build a fake Docling chunk where each doc_item has its own prov list."""
+    doc_items = [
+        SimpleNamespace(prov=[SimpleNamespace(page_no=p) for p in pages])
+        for pages in page_lists
+    ]
+    return SimpleNamespace(meta=SimpleNamespace(doc_items=doc_items))
+
+
+def test_first_page_returns_min_across_all_provenance():
+    """A chunk that straddles pages 3, 4, 5 starts on page 3."""
+    chunk = _chunk([3, 4], [4, 5])
+    assert _first_page(chunk) == 3
+
+
+def test_first_page_single_page_chunk():
+    chunk = _chunk([2])
+    assert _first_page(chunk) == 2
+
+
+def test_first_page_none_when_no_provenance():
+    """Markdown and HTML inputs produce chunks without prov data."""
+    chunk = _chunk()
+    assert _first_page(chunk) is None
+
+
+def test_first_page_none_when_doc_items_have_empty_prov():
+    chunk = SimpleNamespace(
+        meta=SimpleNamespace(doc_items=[SimpleNamespace(prov=[])])
+    )
+    assert _first_page(chunk) is None
+
+
+def test_first_page_none_when_meta_missing():
+    chunk = SimpleNamespace()
+    assert _first_page(chunk) is None


### PR DESCRIPTION
## Summary
- `DoclingChunk` carries a `page_number` field, populated from `chunk.meta.doc_items[*].prov[*].page_no`.
- `_first_page` returns `min(pages)` — chunks routinely straddle pages under `HybridChunker`'s token grouping; first-page matches the web view's `#page=` anchor and the citation-chip target.
- Threaded through both `ChunkRow` construction sites: `_ingest_pdf_docling` in `scribe.py` (PDFs) and `convert_and_chunk` in `chunk.py` (`.md`/`.html`, which legitimately yield `None`).

## Why
Citations from Docling-ingested PDFs were opening the iframe at page 1 instead of the cited page, because `page_number` was `NULL` in the DB. The pdfplumber backend already did the right thing; this is parity.

## Test plan
- [x] `uv run pytest` — 231/231 passing (5 new unit tests for `_first_page` using `SimpleNamespace` mocks)
- [ ] Re-ingest a real PDF via Docling and confirm citation chips show page labels and the iframe jumps to the correct page

## Migration
Re-ingest existing Docling-converted PDFs to backfill `page_number`. No schema change.

Closes #23