### PR TITLE
Reject malformed [N] citation markers in save_finding/edit_finding

### DIFF
--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -18,6 +18,9 @@ from bartleby.skill_runner import SkillError
 
 # Inline citation marker: standard markdown footnote syntax with a chunk_id.
 _CITATION_MARKER = re.compile(r"\[\^(\d+)\]")
+# Bare ``[N]`` — looks like a citation, isn't one. Doesn't match ``[^N]`` because
+# the ``^`` sits between the bracket and the digits.
+_MALFORMED_MARKER = re.compile(r"\[(\d+)\]")
 
 
 def extract_citations(body: str) -> list[int]:
@@ -26,6 +29,25 @@ def extract_citations(body: str) -> list[int]:
     for m in _CITATION_MARKER.finditer(body):
         seen[int(m.group(1))] = None
     return list(seen)
+
+
+def reject_malformed_citations(body: str) -> None:
+    """Raise ``MALFORMED_CITATION`` if the body contains ``[N]`` (missing ``^``).
+
+    These markers render as bracketed prose but are silently ignored by the
+    citation extractor, so the claim ends up effectively uncited. Refuse
+    loudly so the agent fixes the typo before persisting.
+    """
+    bad = [m.group(0) for m in _MALFORMED_MARKER.finditer(body)]
+    if not bad:
+        return
+    deduped = list(dict.fromkeys(bad))
+    raise SkillError(
+        "MALFORMED_CITATION",
+        f"Found {len(bad)} citation-shaped markers missing the caret: "
+        f"{', '.join(deduped)}. Write citations as [^N], not [N].",
+        malformed_markers=deduped,
+    )
 
 
 def validate_chunk_ids_exist(conn, chunk_ids: list[int]) -> None:

--- a/bartleby/skill_scripts/edit_finding.py
+++ b/bartleby/skill_scripts/edit_finding.py
@@ -36,6 +36,7 @@ from bartleby.skill_runner import SkillError, run
 from bartleby.skill_scripts._common import (
     extract_citations,
     rebuild_finding_chunks,
+    reject_malformed_citations,
     replace_finding_citations,
     resolve_citations,
     validate_chunk_ids_exist,
@@ -72,6 +73,7 @@ def _load_new_body(body_file: str, conn) -> tuple[str, list[int]]:
     if not body.strip():
         raise SkillError("EMPTY_BODY", "Finding body is empty.")
 
+    reject_malformed_citations(body)
     citations = extract_citations(body)
     if not citations:
         raise SkillError(

--- a/bartleby/skill_scripts/save_finding.py
+++ b/bartleby/skill_scripts/save_finding.py
@@ -36,6 +36,7 @@ from bartleby.skill_runner import SkillError, run
 from bartleby.skill_scripts._common import (
     extract_citations,
     rebuild_finding_chunks,
+    reject_malformed_citations,
     replace_finding_citations,
     resolve_citations,
     validate_chunk_ids_exist,
@@ -66,6 +67,7 @@ def _read_body(body_file: str) -> str:
 
 def _citations_from_body(conn, body: str) -> list[int]:
     """Extract markers, require at least one, and verify each chunk exists."""
+    reject_malformed_citations(body)
     citations = extract_citations(body)
     if not citations:
         raise SkillError(

--- a/tests/test_skill_edit_finding.py
+++ b/tests/test_skill_edit_finding.py
@@ -227,6 +227,30 @@ def test_edit_finding_rejects_body_without_citations(
     assert out["code"] == "NO_INLINE_CITATIONS"
 
 
+def test_edit_finding_rejects_malformed_citation(
+    seeded_project, tmp_path, capsys
+):
+    """Bare ``[N]`` markers in a replacement body are refused before the
+    new body lands in the DB."""
+    saved = _seed_finding(seeded_project, tmp_path, capsys)
+    new_body_file = tmp_path / "typo.md"
+    new_body_file.write_text(
+        "Real[^1] but typoed[3] and again[42].",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        edit_finding.main([
+            "--project", seeded_project["project"],
+            "--finding-id", str(saved["finding_id"]),
+            "--body-file", str(new_body_file),
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "MALFORMED_CITATION"
+    assert out["malformed_markers"] == ["[3]", "[42]"]
+
+
 def test_edit_finding_rejects_unknown_chunk_marker(
     seeded_project, tmp_path, capsys
 ):

--- a/tests/test_skill_save_finding.py
+++ b/tests/test_skill_save_finding.py
@@ -168,6 +168,27 @@ def test_save_finding_no_inline_citations(seeded_project, tmp_path, capsys):
     assert out["code"] == "NO_INLINE_CITATIONS"
 
 
+def test_save_finding_rejects_malformed_citation(seeded_project, tmp_path, capsys):
+    """Bare ``[N]`` markers (missing the ``^``) are rejected loudly so the
+    agent fixes the typo instead of shipping silent phantom citations."""
+    body_file = tmp_path / "f.md"
+    body_file.write_text(
+        "Real claim[^1] and typoed claim[3] in the same body.",
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit) as exc:
+        save_finding.main([
+            "--project", seeded_project["project"],
+            "--title", "typo",
+            "--description", "x",
+            "--body-file", str(body_file),
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "MALFORMED_CITATION"
+    assert out["malformed_markers"] == ["[3]"]
+
+
 def test_save_finding_unknown_inline_marker(seeded_project, tmp_path, capsys):
     body_file = tmp_path / "f.md"
     body_file.write_text("body[^999999].", encoding="utf-8")


### PR DESCRIPTION
## Summary
- New `reject_malformed_citations(body)` helper in `_common.py` refuses bodies containing `[\d+]` markers (the proper form is `[^\d+]`).
- Wired into both `save_finding` and `edit_finding` before `extract_citations`.
- Error code `MALFORMED_CITATION` with a `malformed_markers` field listing the offenders.

## Why
`extract_citations` matches only `[^N]`. A bare `[N]` renders as bracketed text but is silently ignored — the claim appears cited while the chunk is never linked in `finding_chunks`. Render and data disagree, which is the worst possible failure mode for a tool whose entire pitch is grounded citations. Local-model agents drift on this exact punctuation.

## Test plan
- [x] `uv run pytest` — 228/228 passing (2 new error-path tests)
- [x] Verified the regex doesn't match `[^N]` (the `^` sits between bracket and digits, so `\[\d+\]` can't start matching at the `[`).

Closes #24