### PR TITLE
Fix unparseable pyproject.toml / uv.lock from wsjpt merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ docling = [
 ]
 wsjpt = [
     "wsjpt @ git+ssh://git@github.dowjones.net/data/wsjpt.git",
+]
 sec2md = [
     "sec2md==0.1.22",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -381,6 +381,7 @@ docling = [
 ]
 wsjpt = [
     { name = "wsjpt" },
+]
 sec2md = [
     { name = "sec2md" },
 ]
@@ -414,7 +415,7 @@ requires-dist = [
     { name = "wsjpt", marker = "extra == 'wsjpt'", git = "ssh://git@github.dowjones.net/data/wsjpt.git" },
 ]
 
-provides-extras = ["docling", "sec2md", "wsjpt]
+provides-extras = ["docling", "sec2md", "wsjpt"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4531,6 +4532,9 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "sec2md"
 version = "0.1.22"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
## Problem
The wsjpt-provider merge (#39) left `pyproject.toml` **and** `uv.lock` with malformed TOML, so `uv` cannot parse either file and **no `uv` command — including the test suite — can run on `main`**:

- `pyproject.toml`: the `wsjpt` optional-dependency array was never closed with `]`, swallowing the start of the `sec2md` entry.
- `uv.lock`: the same unclosed-`wsjpt` / clobbered-`sec2md` pattern in `[package.optional-dependencies]`, a truncated `provides-extras = [..., "wsjpt]` string, and a missing `]` + `[[package]]` boundary between `secretstorage` and `sec2md`.

## Fix
Close the arrays and restore the boundaries so both files parse. `wsjpt` remains an optional extra (not in the default dev group), so this does **not** require access to the private `wsjpt` repo — `uv run --locked` resolves cleanly without it.

## Verification
- `python -c "import tomllib; tomllib.load(...)"` parses both files.
- `uv run --locked python -m pytest -q` runs (244 passed). 7 pre-existing failures remain in OCR/image ingestion tests (`UnicodeDecodeError` in the image-analysis path) — unrelated to this change and on code this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)