### PR TITLE
ocr: make OCR tests hermetic to $TMPDIR; surface tesseract failures legibly

### DIFF
--- a/bartleby/ingest/ocr.py
+++ b/bartleby/ingest/ocr.py
@@ -12,6 +12,7 @@ and our renderer (pypdfium2 at 150 DPI) already produces clean inputs.
 from __future__ import annotations
 
 import io
+import os
 from dataclasses import dataclass
 
 from PIL import Image
@@ -27,9 +28,21 @@ class OcrResult:
 def run(image_bytes: bytes) -> OcrResult:
     """Run Tesseract on a PNG/JPEG. Returns the recognized text + avg confidence."""
     img = Image.open(io.BytesIO(image_bytes))
-    data = pytesseract.image_to_data(
-        img, output_type=pytesseract.Output.DICT,
-    )
+    try:
+        data = pytesseract.image_to_data(
+            img, output_type=pytesseract.Output.DICT,
+        )
+    except (pytesseract.TesseractError, UnicodeDecodeError) as e:
+        # pytesseract writes the image to a temp file under $TMPDIR and shells
+        # out to `tesseract`. When that subprocess can't read the temp file,
+        # tesseract emits a non-UTF-8 diagnostic and pytesseract crashes
+        # decoding it with a UnicodeDecodeError that buries the real cause.
+        # Re-raise something legible and point at the usual culprit. See #43.
+        raise RuntimeError(
+            f"Tesseract OCR failed ({type(e).__name__}: {e}). The tesseract "
+            f"subprocess may be unable to read its temp file under "
+            f"TMPDIR={os.environ.get('TMPDIR', '')!r}."
+        ) from e
     words: list[str] = []
     confidences: list[float] = []
     for word, conf in zip(data["text"], data["conf"]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,38 @@
 Skill scripts live in ``bartleby.skill_scripts`` and are reachable via normal
 package imports; nothing path-y needed here.
 """
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _canonical_tmpdir():
+    """Point ``$TMPDIR`` at a symlink-resolved path so the tesseract subprocess
+    can read pytesseract's temp images.
+
+    macOS's ``/tmp`` is a symlink to ``/private/tmp``, and the homebrew
+    tesseract's leptonica image loader fails to open files addressed *through*
+    that symlink ("image file not found"). pytesseract serializes the image to
+    a temp file under ``$TMPDIR`` and shells out to ``tesseract``, so a
+    ``/tmp``-based ``$TMPDIR`` (e.g. a CI/sandbox harness that sets
+    ``TMPDIR=/tmp/...``) silently breaks OCR — and pytesseract then masks the
+    failure with a ``UnicodeDecodeError``. Resolving ``$TMPDIR`` with
+    ``realpath`` sidesteps it; it's a no-op where ``$TMPDIR`` is already
+    canonical (Linux ``/tmp``, macOS ``/var/folders/...``). See issue #43.
+    """
+    original = os.environ.get("TMPDIR")
+    os.environ["TMPDIR"] = os.path.realpath(tempfile.gettempdir())
+    tempfile.tempdir = None  # drop the cached temp dir so $TMPDIR is re-read
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TMPDIR", None)
+        else:
+            os.environ["TMPDIR"] = original
+        tempfile.tempdir = None

--- a/tests/test_ingest_ocr.py
+++ b/tests/test_ingest_ocr.py
@@ -65,3 +65,32 @@ def test_run_on_blank_returns_no_text(_check_tesseract):
     assert result.text == ""
     # No words → sentinel confidence.
     assert result.avg_confidence == -1.0
+
+
+def test_run_surfaces_legible_error_on_decode_crash(monkeypatch):
+    """When tesseract emits non-UTF-8 stderr (e.g. it can't read its temp file),
+    pytesseract raises a bare UnicodeDecodeError. `run` must convert it into a
+    legible RuntimeError that names the likely TMPDIR cause (issue #43)."""
+    def _boom(*a, **k):
+        raise UnicodeDecodeError("utf-8", b"\x89PNG", 0, 1, "invalid start byte")
+    monkeypatch.setattr(ocr.pytesseract, "image_to_data", _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ocr.run(_blank_image())
+    msg = str(excinfo.value)
+    assert "Tesseract OCR failed" in msg
+    assert "TMPDIR" in msg
+    # The original cause is preserved for debugging.
+    assert isinstance(excinfo.value.__cause__, UnicodeDecodeError)
+
+
+def test_run_surfaces_legible_error_on_tesseract_error(monkeypatch):
+    """A normal TesseractError is likewise wrapped into the legible RuntimeError."""
+    def _boom(*a, **k):
+        raise ocr.pytesseract.TesseractError(1, "tesseract exploded")
+    monkeypatch.setattr(ocr.pytesseract, "image_to_data", _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ocr.run(_blank_image())
+    assert "Tesseract OCR failed" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, ocr.pytesseract.TesseractError)


### PR DESCRIPTION
Closes #43

## Root cause
The OCR/image-ingestion tests failed **only** under a `$TMPDIR` the `tesseract` subprocess can't read. I traced it to the macOS `/tmp` symlink:

- `/tmp` → `/private/tmp` on macOS. Homebrew tesseract's **leptonica** image loader fails to open files addressed *through* that symlink (`image file not found`), even though Python/`cat` read the same path fine. The same file via the resolved `/private/tmp/...` (or `/var/tmp`, or a repo-relative path) works. Permissions are irrelevant (a 0700 dir under `/var/tmp` works).
- `pytesseract` serializes the PIL image to a temp file under `$TMPDIR` and shells out to `tesseract <tmpfile>`. When the harness sets `TMPDIR=/tmp/...`, that temp file is unreadable to tesseract.
- tesseract then emits a **non-UTF-8** diagnostic (containing the PNG magic bytes), and pytesseract crashes UTF-8-decoding it with a `UnicodeDecodeError` that **masks** the real `TesseractError`.

Verification:
```
# resolved symlink works, /tmp path fails — same file, same user, sandbox on or off
tesseract /private/tmp/claude-501/probe.png stdout   # -> HELLOWORLD
tesseract /tmp/claude-501/probe.png stdout           # -> "image file not found"
```

## Fix
- **`tests/conftest.py`** — a session autouse fixture resolves `$TMPDIR` with `realpath` so pytesseract's temp images live under a path tesseract can open. No-op where `$TMPDIR` is already canonical (Linux `/tmp`, macOS `/var/folders/...`).
- **`bartleby/ingest/ocr.py`** — wrap the `pytesseract.image_to_data` call so a `TesseractError` *or* the masking `UnicodeDecodeError` becomes a legible `RuntimeError` that names the likely `TMPDIR` cause, preserving the original as `__cause__`. Improves production diagnosability, not just the tests.

## Acceptance (from the issue)
- ✅ Test reliability — the OCR/image tests no longer depend on the ambient `$TMPDIR` being tesseract-readable.
- ✅ Production diagnosability — a tesseract failure surfaces a clear message instead of an opaque `UnicodeDecodeError`.

## Testing
- `uv run --locked python -m pytest -q` → **266 passed** (no `TMPDIR` override; previously 7 failed under `TMPDIR=/tmp/claude-501`).
- The 7 originally-failing tests pass with the broken ambient `TMPDIR=/tmp/claude-501` in place, proving the conftest fix.
- Two new unit tests assert both exception arms are wrapped and the `__cause__` chain is preserved.

## Non-goals (per the issue)
- No change to OCR thresholds or pipeline behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)