### PR TITLE
Build describe_corpus's parser via build_arg_parser (fixes --help)

### DIFF
--- a/bartleby/skill_scripts/describe_corpus.py
+++ b/bartleby/skill_scripts/describe_corpus.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import argparse
 
-from bartleby.skill_runner import run
+from bartleby.skill_runner import build_arg_parser, run
 
 
 def _positive_int(value: str) -> int:
@@ -56,7 +56,7 @@ def _positive_int(value: str) -> int:
 
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(prog="describe_corpus")
+    p = build_arg_parser("describe_corpus", __doc__)
     p.add_argument("--project", type=str, default=None)
     p.add_argument(
         "--top-n", type=_positive_int, default=5, dest="top_n",


### PR DESCRIPTION
## Summary

`describe_corpus` (#49) and the `--help` response-shape work (#47) merged in parallel, so `describe_corpus` kept a bare `argparse.ArgumentParser` while the other 18 skill scripts adopted `skill_runner.build_arg_parser`. The skew left a **failing test on `main`**: `test_help_prints_module_docstring[describe_corpus]` — its `--help` printed only the usage line, omitting the docstring summary and the `Output:` JSON contract agents depend on.

This switches it to `build_arg_parser("describe_corpus", __doc__)` like every other script (a 2-line change). `--help` now renders the full docstring (response shape included), and the parametrized help-shape test passes.

## Testing

- `uv run pytest tests/test_skill_help_response_shape.py` — 23 passed (was failing for `describe_corpus` on `main`).
- `uv run pytest` — **294 passed, 0 failed** (the earlier OCR/Tesseract failures are now resolved on `main` via #52).
- Manually confirmed `bartleby skill describe_corpus --help` prints the docstring + `Output:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)