### PR TITLE
Fix scoped semantic search starving to empty (#55)

### DIFF
--- a/bartleby/skill_scripts/search.py
+++ b/bartleby/skill_scripts/search.py
@@ -280,22 +280,20 @@ def _semantic_search(
     scope: dict[str, list[int] | None],
     limit: int,
 ) -> list[int]:
-    # sqlite-vec's MATCH operator cannot accept extra WHERE predicates on the
-    # vec0 virtual table, so we over-fetch nearest neighbors and filter them
-    # in the outer query against the chunks table.
+    # Push the scope predicate into the KNN via ``rowid IN (subquery)`` so the
+    # k neighbors vec0 returns are the k nearest *in-scope* chunks. A bare
+    # post-filter (fetch k globally-nearest, then drop out-of-scope rows)
+    # collapses to ~nothing whenever the scope is a small slice of the corpus,
+    # because the globally-nearest chunks rarely fall inside it — issue #55.
+    # vec0 accepts ``rowid IN`` alongside MATCH/k as of sqlite-vec 0.1.x.
+    # ``k`` already caps the row count, so no outer LIMIT is needed.
     scope_sql, scope_params = _scope_clause(scope)
     rows = conn.cursor().execute(
-        f"WITH nn AS ( "
-        f"  SELECT rowid AS chunk_id, distance FROM chunks_vec "
-        f"  WHERE embedding MATCH ? AND k = ? "
-        f"  ORDER BY distance "
-        f") "
-        f"SELECT nn.chunk_id FROM nn "
-        f"JOIN chunks ON chunks.chunk_id = nn.chunk_id "
-        f"WHERE {scope_sql} "
-        f"ORDER BY nn.distance "
-        f"LIMIT ?",
-        [query_bytes, limit, *scope_params, limit],
+        f"SELECT rowid FROM chunks_vec "
+        f"WHERE embedding MATCH ? AND k = ? "
+        f"  AND rowid IN (SELECT chunk_id FROM chunks WHERE {scope_sql}) "
+        f"ORDER BY distance",
+        [query_bytes, limit, *scope_params],
     )
     return [row[0] for row in rows]
 

--- a/tests/test_skill_search.py
+++ b/tests/test_skill_search.py
@@ -342,6 +342,75 @@ def test_search_in_documents_invalid_ids_returns_empty(seeded_project, capsys):
     assert out["results"] == []
 
 
+def test_search_semantic_scope_survives_global_nearest_elsewhere(
+    seeded_project, capsys, monkeypatch
+):
+    """Regression for #55: when more out-of-scope chunks than the over-fetch
+    window are nearer to the query than the in-scope chunks, a semantic search
+    scoped to doc_a must still return doc_a's chunks. The old post-filter
+    (fetch k globally-nearest, then drop out-of-scope rows) starved to [] here;
+    pushing the scope into the index fixes it."""
+    from bartleby.db.chunks import ChunkInput, insert_document_chunks
+
+    # Seed a decoy document with MORE near-query chunks than the over-fetch
+    # window, so every chunk in the global top-`overfetch` is out of scope and a
+    # post-filter to doc_a would wipe the result set to empty.
+    limit = 1  # mirror work()'s overfetch calc for this query's --limit
+    overfetch = max(
+        limit * search_script.OVERFETCH_MULTIPLIER, search_script.OVERFETCH_FLOOR
+    )
+    n_decoys = overfetch + 5
+    conn = open_db(seeded_project["project"])
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, page_count, token_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("h-decoy", "decoy.txt", "/tmp/decoy.txt", None, 0),
+        )
+        doc_c = conn.last_insert_rowid()
+        # Decoys cluster at seed ~1.0; doc_a's fixture chunks sit at seed 0.0-0.3.
+        insert_document_chunks(conn, doc_c, [
+            ChunkInput(
+                text=f"decoy chunk {i}",
+                embedding=[1.0 + 0.0001 * i + 0.001 * j for j in range(EMBEDDING_DIM)],
+                chunk_index=i,
+            )
+            for i in range(n_decoys)
+        ])
+    finally:
+        conn.close()
+
+    # Query vector near 1.05 ranks the decoys (and doc_b) as the global nearest;
+    # doc_a's chunks fall well outside the top-`overfetch` window.
+    near_decoys = struct.pack(
+        f"{EMBEDDING_DIM}f", *[1.05 + 0.001 * j for j in range(EMBEDDING_DIM)]
+    )
+    monkeypatch.setattr(search_script, "_embed_query", lambda q: near_decoys)
+
+    # Premise: unscoped, the global nearest hit is NOT in doc_a.
+    _run([
+        "--project", seeded_project["project"],
+        "--semantic", "--documents", "--limit", str(limit),
+        "anything",
+    ])
+    unscoped = json.loads(capsys.readouterr().out)
+    assert unscoped["results"][0]["source_id"] != seeded_project["doc_a"]
+
+    # Scoped to doc_a, the in-scope chunks must come back — not [].
+    _run([
+        "--project", seeded_project["project"],
+        "--semantic", "--documents", "--limit", str(limit),
+        "--in-documents", str(seeded_project["doc_a"]),
+        "anything",
+    ])
+    scoped = json.loads(capsys.readouterr().out)
+    assert scoped["results"], "scoped semantic search starved to empty (issue #55)"
+    for r in scoped["results"]:
+        assert r["source_kind"] == "document"
+        assert r["source_id"] == seeded_project["doc_a"]
+
+
 def test_search_includes_image_chunks_with_id_and_path(seeded_project, capsys):
     from tests._skill_fixtures import seed_image
     conn = open_db(seeded_project["project"])


### PR DESCRIPTION
## Problem

`bartleby skill search "<query>" --in-documents <ids>` silently returned **zero results** for queries with obvious matches in the named documents — worse than a loud error, because an empty result reads as "no such passage exists."

## Root cause

`_semantic_search` fetched the *k* globally-nearest chunks from `chunks_vec`, then post-filtered them to the requested scope in an outer `JOIN`/`WHERE`. On a corpus larger than the over-fetch window (`max(limit*5, 50)`), the globally-nearest chunks almost never fall inside a narrow `--in-documents`/`--tag` scope, so the post-filter collapsed to ~nothing. The tighter the scope, the more complete the wipeout.

(The issue's writeup diagnosed `k = limit` with no over-fetch; the over-fetch has actually existed since the v1 migration. But 100 global neighbors post-filtered to one document in a hundreds-of-docs corpus still starves — the band-aid never addressed the mechanism.)

## Fix

Push the scope predicate **into** the KNN via `rowid IN (SELECT chunk_id FROM chunks WHERE <scope>)`, which vec0 supports alongside `MATCH`/`k` as of sqlite-vec 0.1.x (verified against the installed 0.1.6). The *k* neighbors vec0 returns are now the *k* nearest **in-scope** chunks, so scoping narrows the result set instead of zeroing it. This also closes a latent variant where the default `source_kind` post-filter could starve unscoped searches. The outer `JOIN`/`WHERE`/`LIMIT` is gone — `k` already caps the row count.

This is the issue's "ideal direction" (push the filter into the index). Per discussion the scope was kept tight: the FTS leg's AND-of-literals behavior and the response shape are unchanged.

## Test

Added `test_search_semantic_scope_survives_global_nearest_elsewhere`: seeds more out-of-scope decoy chunks than the over-fetch window (count derived from the actual `OVERFETCH_*` constants) so the old post-filter provably starves to `[]`. Confirmed it fails on `main`'s logic (`assert []`) and passes with the fix. Full suite: 295 passed.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)