### PR TITLE
Show finding_id in the findings UI

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -56,6 +56,15 @@ p.meta {
   color: var(--color-off);
 }
 
+/* The finding_id, surfaced so users can match what the agent says in chat
+   ("finding 42") to a row or page here. The display font + a weight bump (the
+   parent .meta is 200) reads it as an identifier without breaking out of the
+   muted .meta line. */
+.finding-id {
+  font-family: var(--font-display);
+  font-weight: 400;
+}
+
 /* Shared markdown-body styles — used by both /findings/[id] and /documents/[id].
    Targets descendants of .markdown-body so we don't accidentally restyle the
    page chrome (titles, meta, etc.) that lives outside the rendered markdown. */

--- a/web/src/routes/findings/+page.svelte
+++ b/web/src/routes/findings/+page.svelte
@@ -12,9 +12,8 @@
       <li class="entity">
         <h2><a href="/findings/{f.finding_id}">{f.title}</a></h2>
         <p class="meta">
-          {f.session_name} · {f.citation_count} citation{f.citation_count === 1
-            ? ""
-            : "s"} · {f.created_at}
+          <span class="finding-id">#{f.finding_id}</span> · {f.session_name} · {f.citation_count}
+          citation{f.citation_count === 1 ? "" : "s"} · {f.created_at}
         </p>
         <p class="desc">{f.description}</p>
       </li>

--- a/web/src/routes/findings/[id]/+page.svelte
+++ b/web/src/routes/findings/[id]/+page.svelte
@@ -81,7 +81,7 @@
   <article class="report" bind:this={container}>
     <h1>{data.finding.title}</h1>
     <p class="meta">
-      {data.finding.session_name} · {data.finding.created_at}
+      <span class="finding-id">#{data.finding.finding_id}</span> · {data.finding.session_name} · {data.finding.created_at}
     </p>
     <p class="desc">{data.finding.description}</p>
 


### PR DESCRIPTION
## What

Surfaces each finding's `finding_id` in the web UI so users can match what the agent says in chat ("I saved that as finding 42") to a row in the findings list or to the open detail page. Previously the id appeared nowhere in the UI except buried in the URL.

## Changes

- `/findings` list and `/findings/[id]` detail now render the id as a muted `#N` prefix on the existing `.meta` line.
- Shared `.finding-id` rule in `app.css` (display font + a weight bump over the 200-weight meta line) so it reads as an identifier without competing with the title.

No DB, query, or server changes — `finding_id` was already present in both pages' data; this is purely presentational.

## Testing

- `uv run pytest` → 302 passed (unchanged; no Python touched).
- `npm run build` in `web/` → builds clean.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)