### PR TITLE
Open result titles in the document detail view at the cited page

### DIFF
--- a/web/src/lib/components/ScanMatch.svelte
+++ b/web/src/lib/components/ScanMatch.svelte
@@ -6,15 +6,15 @@
   }
 
   // Enriched server-side: match.title (summary title), match.description,
-  // match.href (source PDF at the cited page). Scan is documents-only.
+  // match.href (the document detail page at the cited page). Scan is documents-only.
   $: title = match.title ?? stripExt(match.file_name);
   $: truncated = match.text_length > match.text.length;
 </script>
 
 <li class="match">
   <h3 class="title">
-    <a href={match.href} target="_blank" rel="noopener noreferrer">
-      {title}<span class="open"> ↗{match.page_number ? ` p.${match.page_number}` : ""}</span>
+    <a href={match.href}>
+      {title}{#if match.page_number}<span class="page-hint"> p.{match.page_number}</span>{/if}
     </a>
   </h3>
 
@@ -53,7 +53,7 @@
   .title a:hover {
     color: var(--color-off);
   }
-  .title .open {
+  .title .page-hint {
     font-family: var(--font-sans);
     font-size: 0.75rem;
     font-weight: 600;

--- a/web/src/lib/components/SearchResult.svelte
+++ b/web/src/lib/components/SearchResult.svelte
@@ -6,10 +6,9 @@
   }
 
   // Enriched server-side: hit.title (summary/finding title), hit.description,
-  // hit.file_name (the originating file, shown as a subtitle), hit.href (source
-  // PDF at the cited page, or the finding page).
+  // hit.file_name (the originating file, shown as a subtitle), hit.href (the
+  // document detail page at the cited page, or the finding page).
   $: title = hit.title ?? stripExt(hit.file_name) ?? hit.source_name;
-  $: external = hit.source_kind !== "finding"; // findings link in-app, not to a file
   $: scorePct = Math.round((hit.normalized_score ?? 0) * 100);
 </script>
 
@@ -17,8 +16,8 @@
   <div class="head">
     <h3 class="title">
       {#if hit.href}
-        <a href={hit.href} target={external ? "_blank" : undefined} rel={external ? "noopener noreferrer" : undefined}>
-          {title}<span class="open">{external ? " ↗" : ""}{hit.page_number ? ` p.${hit.page_number}` : ""}</span>
+        <a href={hit.href}>
+          {title}{#if hit.page_number}<span class="page-hint"> p.{hit.page_number}</span>{/if}
         </a>
       {:else}
         {title}
@@ -71,7 +70,7 @@
   .title a:hover {
     color: var(--color-off);
   }
-  .title .open {
+  .title .page-hint {
     font-family: var(--font-sans);
     font-size: 0.75rem;
     font-weight: 600;

--- a/web/src/lib/server/queries.js
+++ b/web/src/lib/server/queries.js
@@ -116,11 +116,17 @@ function titleMeta(db, table, keyCol, ids) {
   return out;
 }
 
+// The document detail route (summary + PDF viewer), opened at the cited page
+// via ?page= — the [id] route seeds its viewer iframe from that param.
+function documentHref(documentId, pageNumber) {
+  return `/documents/${documentId}${pageNumber ? `?page=${pageNumber}` : ''}`;
+}
+
 // Enrich ranked `search` hits with a display title, description, and a single
-// destination href: the source PDF at the cited page for document-backed hits,
-// the finding page for findings. Keeps the result component free of source_kind
-// branching. (resolveSource already maps every kind → {document_id, file_name,
-// page_number}; we layer title/description on top.)
+// destination href: the document detail page at the cited page for
+// document-backed hits, the finding page for findings. Keeps the result
+// component free of source_kind branching. (resolveSource already maps every
+// kind → {document_id, file_name, page_number}; we layer title/description on top.)
 export function enrichHits(hits) {
   const { db } = getDb();
   const resolved = hits.map((h) => resolveSource(h.source_kind, h.source_id, h.page_number));
@@ -142,9 +148,7 @@ export function enrichHits(hits) {
     }
     const r = resolved[i];
     const meta = r.document_id != null ? summaries.get(r.document_id) : null;
-    const href = r.document_id != null
-      ? `/files/${r.document_id}${r.page_number ? `#page=${r.page_number}` : ''}`
-      : null;
+    const href = r.document_id != null ? documentHref(r.document_id, r.page_number) : null;
     return {
       ...h,
       title: meta?.title ?? null,
@@ -167,7 +171,7 @@ export function enrichScanMatches(matches) {
       ...m,
       title: meta?.title ?? null,
       description: meta?.description ?? null,
-      href: `/files/${m.document_id}${m.page_number ? `#page=${m.page_number}` : ''}`
+      href: documentHref(m.document_id, m.page_number)
     };
   });
 }

--- a/web/src/routes/documents/[id]/+page.svelte
+++ b/web/src/routes/documents/[id]/+page.svelte
@@ -1,10 +1,19 @@
 <script>
   import { marked } from "marked";
+  import { page } from "$app/stores";
   import { stripExt } from "$lib/format.js";
   export let data;
 
   $: doc = data.document;
   $: summaryHtml = doc.summary_text ? marked.parse(doc.summary_text) : null;
+
+  // ?page=N (set by search/scan result links) jumps the PDF viewer to the
+  // cited page. Sanitized to a positive integer; anything else opens page 1.
+  $: pageNum = (() => {
+    const n = parseInt($page.url.searchParams.get("page"), 10);
+    return Number.isInteger(n) && n > 0 ? n : null;
+  })();
+  $: viewerSrc = `/files/${doc.document_id}${pageNum ? `#page=${pageNum}` : ""}`;
 </script>
 
 <div class="split">
@@ -36,7 +45,9 @@
   </article>
 
   <aside class="viewer">
-    <iframe title="Source document" src="/files/{doc.document_id}"></iframe>
+    {#key viewerSrc}
+      <iframe title="Source document" src={viewerSrc}></iframe>
+    {/key}
   </aside>
 </div>
 


### PR DESCRIPTION
Follow-up to the search UI: clicking a result title should open the **document detail page** (`/documents/[id]` — summary on the left, PDF on the right) with the PDF pane **jumped to the cited page**, rather than opening the raw PDF file.

## Changes

- **Result href → detail route.** `enrichHits` / `enrichScanMatches` now build `/documents/[id]?page=N` (via a shared `documentHref` helper) instead of `/files/[id]#page=N`.
- **Detail route seeds its viewer from `?page=`.** `documents/[id]/+page.svelte` reads the param (sanitized to a positive integer), builds the iframe src as `/files/[id]#page=N`, and wraps the iframe in `{#key}` so it reloads if the page changes. Non-PDF documents ignore the hash harmlessly.
- **Drop external-link treatment.** Titles are now in-app routes, so `target=_blank` / the `↗` glyph are removed in both `SearchResult` and `ScanMatch`; the muted `p.N` hint stays. Finding links unchanged.

`vite build` clean. No Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)