### PR TITLE
Skip sub-32px images so they never crash the VLM runner

### DIFF
--- a/bartleby/commands/ready.py
+++ b/bartleby/commands/ready.py
@@ -11,6 +11,7 @@ from bartleby.lib.consts import (
     DEFAULT_PDF_CONVERTER,
     DEFAULT_SPARSE_TEXT_THRESHOLD,
     DEFAULT_VISION_MAX_DIMENSION,
+    DEFAULT_VISION_MIN_DIMENSION,
 )
 from bartleby.providers import ALLOWED_PROVIDERS
 
@@ -236,13 +237,19 @@ def main():
             "Max image dimension (long edge in pixels before sending to VLM)",
             int(existing.get("vision_max_dimension", DEFAULT_VISION_MAX_DIMENSION)),
         )
+        config["vision_min_dimension"] = _prompt_positive_int(
+            "Min image dimension (skip images with an edge smaller than this; "
+            "avoids VLM crashes on thin slivers)",
+            int(existing.get("vision_min_dimension", DEFAULT_VISION_MIN_DIMENSION)),
+        )
         config["ocr_min_confidence"] = _prompt_positive_int(
             "Tesseract minimum avg confidence (0-100; fallback to VLM below this)",
             int(existing.get("ocr_min_confidence", DEFAULT_OCR_MIN_CONFIDENCE)),
         )
     else:
         for k in ("vision_provider", "vision_model",
-                 "vision_max_dimension", "ocr_min_confidence"):
+                 "vision_max_dimension", "vision_min_dimension",
+                 "ocr_min_confidence"):
             config.pop(k, None)
 
     console.print("\n[bold]Document reading[/bold]")

--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -63,6 +63,7 @@ from bartleby.lib.consts import (
     DEFAULT_PDF_CONVERTER,
     DEFAULT_SPARSE_TEXT_THRESHOLD,
     DEFAULT_VISION_MAX_DIMENSION,
+    DEFAULT_VISION_MIN_DIMENSION,
 )
 from bartleby.project import get_project_dir
 from bartleby.providers import Provider, get_provider
@@ -304,6 +305,7 @@ def _process_image(
     vision_provider: Provider,
     vision_model: str,
     vision_max_dimension: int,
+    vision_min_dimension: int,
 ) -> None:
     """Run the §7 image pipeline on one image and persist it.
 
@@ -311,10 +313,23 @@ def _process_image(
     identical image (across any document), reuse the ``images`` row and add a
     new ``document_images`` join. Chunks come along automatically since they
     point at ``image_id``.
+
+    Images with an edge below ``vision_min_dimension`` are skipped entirely —
+    no analysis, no archive, no rows — because VLMs crash on sub-patch-size
+    images and such slivers carry no describable content anyway.
     """
     prepared = image_pipeline.prepare_image(
         route.bytes_, max_dimension=vision_max_dimension,
     )
+    if image_pipeline.is_below_vlm_minimum(
+        prepared, min_dimension=vision_min_dimension
+    ):
+        page_str = f" (page {route.page_number})" if route.page_number else ""
+        console.warn(
+            f"Skipping image{page_str} — {prepared.width}x{prepared.height}px "
+            f"is below the {vision_min_dimension}px vision minimum."
+        )
+        return
     cur = conn.cursor()
 
     existing = cur.execute(
@@ -497,6 +512,7 @@ def _ingest_pdf_pdfplumber(
     vision_provider: Provider | None,
     vision_model: str | None,
     vision_max_dimension: int,
+    vision_min_dimension: int,
     on_page_progress: Callable[[int, int], None] | None = None,
     on_image_progress: Callable[[int, int], None] | None = None,
     on_stage: Callable[[str], None] | None = None,
@@ -564,6 +580,7 @@ def _ingest_pdf_pdfplumber(
         vision_provider=vision_provider,
         vision_model=vision_model,
         vision_max_dimension=vision_max_dimension,
+        vision_min_dimension=vision_min_dimension,
         on_progress=on_image_progress,
     )
 
@@ -581,6 +598,7 @@ def _ingest_pdf_docling(
     vision_provider: Provider | None,
     vision_model: str | None,
     vision_max_dimension: int,
+    vision_min_dimension: int,
     on_image_progress: Callable[[int, int], None] | None = None,
     on_stage: Callable[[str], None] | None = None,
 ) -> tuple[int, str]:
@@ -634,6 +652,7 @@ def _ingest_pdf_docling(
             vision_provider=vision_provider,
             vision_model=vision_model,
             vision_max_dimension=vision_max_dimension,
+            vision_min_dimension=vision_min_dimension,
             on_progress=on_image_progress,
         )
 
@@ -650,6 +669,7 @@ def _ingest_image_file(
     vision_provider: Provider,
     vision_model: str,
     vision_max_dimension: int,
+    vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
 ) -> tuple[int, str]:
     if on_stage is not None:
@@ -673,6 +693,7 @@ def _ingest_image_file(
         vision_provider=vision_provider,
         vision_model=vision_model,
         vision_max_dimension=vision_max_dimension,
+        vision_min_dimension=vision_min_dimension,
     )
     # For summarization purposes, hand the LLM the concatenated chunk text.
     cur = conn.cursor()
@@ -697,6 +718,7 @@ def _run_image_routes(
     vision_provider: Provider | None,
     vision_model: str | None,
     vision_max_dimension: int,
+    vision_min_dimension: int,
     on_progress: Callable[[int, int], None] | None = None,
 ) -> None:
     if not routes:
@@ -717,6 +739,7 @@ def _run_image_routes(
                 vision_provider=vision_provider,
                 vision_model=vision_model,
                 vision_max_dimension=vision_max_dimension,
+                vision_min_dimension=vision_min_dimension,
             )
         except Exception as e:
             page_str = f" (page {route.page_number})" if route.page_number else ""
@@ -742,6 +765,7 @@ def _process_one(
     sparse_text_threshold: int,
     ocr_min_confidence: int,
     vision_max_dimension: int,
+    vision_min_dimension: int,
     llm_provider: Provider | None,
     llm_model: str | None,
     temperature: float,
@@ -781,6 +805,7 @@ def _process_one(
             archive_root=archive_root,
             vision_provider=vision_provider, vision_model=vision_model,
             vision_max_dimension=vision_max_dimension,
+            vision_min_dimension=vision_min_dimension,
             on_stage=on_stage,
         )
     elif ext in PDF_EXTENSIONS:
@@ -792,6 +817,7 @@ def _process_one(
                 sparse_text_threshold=sparse_text_threshold,
                 vision_provider=vision_provider, vision_model=vision_model,
                 vision_max_dimension=vision_max_dimension,
+                vision_min_dimension=vision_min_dimension,
                 on_image_progress=on_image_progress,
                 on_stage=on_stage,
             )
@@ -804,6 +830,7 @@ def _process_one(
                 ocr_min_confidence=ocr_min_confidence,
                 vision_provider=vision_provider, vision_model=vision_model,
                 vision_max_dimension=vision_max_dimension,
+                vision_min_dimension=vision_min_dimension,
                 on_page_progress=on_page_progress,
                 on_image_progress=on_image_progress,
                 on_stage=on_stage,
@@ -936,6 +963,9 @@ def main(
         vision_max_dimension = int(
             config.get("vision_max_dimension", DEFAULT_VISION_MAX_DIMENSION)
         )
+        vision_min_dimension = int(
+            config.get("vision_min_dimension", DEFAULT_VISION_MIN_DIMENSION)
+        )
 
         # Share the console module's Rich Console so messages printed via
         # console.info/error during the bar's lifetime are inserted above
@@ -981,6 +1011,7 @@ def main(
                         sparse_text_threshold=sparse_text_threshold,
                         ocr_min_confidence=ocr_min_confidence,
                         vision_max_dimension=vision_max_dimension,
+                        vision_min_dimension=vision_min_dimension,
                         llm_provider=llm_provider, llm_model=llm_model,
                         temperature=temperature,
                         max_summarize_tokens=max_summarize_tokens,

--- a/bartleby/ingest/images.py
+++ b/bartleby/ingest/images.py
@@ -89,6 +89,19 @@ def prepare_image(image_bytes: bytes, *, max_dimension: int) -> PreparedImage:
     )
 
 
+def is_below_vlm_minimum(prepared: PreparedImage, *, min_dimension: int) -> bool:
+    """True when either edge is under ``min_dimension``.
+
+    VLM image processors (e.g. qwen3-vl) tile images into patches and crash
+    when an edge is smaller than the patch factor. Such images — thin rules,
+    banners, sliver crops — carry no describable scene, so the scribe skips
+    them entirely rather than sending them to the model. The check is on the
+    *post-scale* dimensions, since downscaling a tall-thin image can itself
+    push an edge below the minimum.
+    """
+    return min(prepared.width, prepared.height) < min_dimension
+
+
 def archive_image(prepared: PreparedImage, archive_root: Path) -> Path:
     """Write the prepared JPEG to ``<archive_root>/images/<hash>.jpg``.
 

--- a/bartleby/lib/consts.py
+++ b/bartleby/lib/consts.py
@@ -17,3 +17,8 @@ DEFAULT_HTML_CONVERTER = "docling"
 DEFAULT_SPARSE_TEXT_THRESHOLD = 100
 DEFAULT_OCR_MIN_CONFIDENCE = 30
 DEFAULT_VISION_MAX_DIMENSION = 1024
+# VLM image processors (e.g. qwen3-vl) tile images into fixed-size patches and
+# crash when an edge is smaller than the patch factor. Images below this on
+# either edge — thin rules, banners, sliver crops — are skipped before the VLM
+# call. 32 matches qwen3-vl's factor; raise it for models with larger patches.
+DEFAULT_VISION_MIN_DIMENSION = 32

--- a/tests/test_ingest_images.py
+++ b/tests/test_ingest_images.py
@@ -73,6 +73,26 @@ def test_prepare_image_rejects_zero_max_dimension():
         img_pipeline.prepare_image(_png_bytes(10, 10), max_dimension=0)
 
 
+def test_is_below_vlm_minimum_flags_thin_strips():
+    # A 512x24 strip (the qwen3-vl crash case) is below a 32px minimum.
+    strip = img_pipeline.prepare_image(_png_bytes(512, 24), max_dimension=1024)
+    assert img_pipeline.is_below_vlm_minimum(strip, min_dimension=32)
+    # A square comfortably above the minimum is not flagged.
+    square = img_pipeline.prepare_image(_png_bytes(100, 100), max_dimension=1024)
+    assert not img_pipeline.is_below_vlm_minimum(square, min_dimension=32)
+    # Exactly at the minimum on both edges is allowed (strictly-below check).
+    edge = img_pipeline.prepare_image(_png_bytes(32, 32), max_dimension=1024)
+    assert not img_pipeline.is_below_vlm_minimum(edge, min_dimension=32)
+
+
+def test_is_below_vlm_minimum_uses_post_scale_dimensions():
+    # 5000x100 downscaled to a 1024 long edge becomes 1024x20 — the short edge
+    # drops below 32 only *after* scaling, so the post-scale check must catch it.
+    prepared = img_pipeline.prepare_image(_png_bytes(5000, 100), max_dimension=1024)
+    assert prepared.height < 32
+    assert img_pipeline.is_below_vlm_minimum(prepared, min_dimension=32)
+
+
 def test_archive_image_writes_then_is_idempotent(tmp_path):
     prepared = img_pipeline.prepare_image(_png_bytes(50, 50), max_dimension=1024)
     p1 = img_pipeline.archive_image(prepared, tmp_path)

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -181,6 +181,7 @@ def test_ready_with_vision_writes_vision_keys(isolated_config, monkeypatch):
         "openai",              # Vision provider (same as LLM → no fresh api key)
         "gpt-5-mini",          # Vision model
         "1024",                # vision_max_dimension
+        "32",                  # vision_min_dimension
         "30",                  # ocr_min_confidence
         "50000",               # max_read_tokens
     ])
@@ -189,6 +190,7 @@ def test_ready_with_vision_writes_vision_keys(isolated_config, monkeypatch):
     assert cfg["vision_provider"] == "openai"
     assert cfg["vision_model"] == "gpt-5-mini"
     assert cfg["vision_max_dimension"] == 1024
+    assert cfg["vision_min_dimension"] == 32
     assert cfg["ocr_min_confidence"] == 30
     # openai_api_key already set from the LLM block; no double prompt.
     assert cfg["openai_api_key"] == "sk-openai"
@@ -213,6 +215,7 @@ def test_ready_vision_with_different_provider_prompts_for_fresh_key(
         "claude-haiku-4-5",
         "sk-anthro",
         "1024",
+        "32",
         "30",
         "50000",
     ])

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -362,6 +362,48 @@ def test_scribe_ingests_standalone_image_file(
         conn.close()
 
 
+def test_scribe_skips_sub_minimum_image_without_calling_vlm(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """A thin sub-32px strip is dropped before the VLM (no row, no crash)."""
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.load_config",
+        lambda: {
+            "summary_depth": "none",
+            "vision_provider": "stub",
+            "vision_model": "stub-vl:1",
+            "vision_max_dimension": 1024,
+            "vision_min_dimension": 32,
+        },
+    )
+    vision = _StubVisionProvider()
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.get_provider",
+        lambda name, **kwargs: vision,
+    )
+
+    img = tmp_path / "rule.png"
+    img.write_bytes(_png_bytes(width=512, height=24))
+
+    scribe.main(project="test_proj", files=str(img))
+
+    conn = open_db("test_proj")
+    try:
+        cur = conn.cursor()
+        # The document row exists, but the sub-minimum image is skipped entirely:
+        # no images row, no join, no image chunk.
+        assert cur.execute("SELECT COUNT(*) FROM images").fetchone()[0] == 0
+        assert cur.execute("SELECT COUNT(*) FROM document_images").fetchone()[0] == 0
+        assert cur.execute(
+            "SELECT COUNT(*) FROM chunks WHERE source_kind='image'"
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+    # The VLM was never called — no chance to crash the runner.
+    assert vision.calls == 0
+
+
 def test_scribe_skips_image_when_no_vision_provider(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):
@@ -464,7 +506,7 @@ def test_scribe_stage_callback_progresses_through_phases(
             pdf_converter="pdfplumber",
             html_converter="docling",
             sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_max_dimension=1024,
+            vision_max_dimension=1024, vision_min_dimension=32,
             llm_provider=stub_summary, llm_model="m",
             temperature=0.0, max_summarize_tokens=50_000,
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",
@@ -518,7 +560,7 @@ def test_scribe_image_progress_callback_fires_per_image(
             pdf_converter="pdfplumber",
             html_converter="docling",
             sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_max_dimension=1024,
+            vision_max_dimension=1024, vision_min_dimension=32,
             llm_provider=None, llm_model=None,
             temperature=0.0, max_summarize_tokens=1000,
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",


### PR DESCRIPTION
## What

Adds a `vision_min_dimension` config knob (default `32`) and skips any extracted image whose post-scale short edge falls below it — **before** analysis, archive, or chunking.

## Why

During ingest, Bartleby extracts thin image strips from PDFs (rules, banners, sliver crops) whose short edge can be below qwen3-vl's patch factor. The model's image processor (`SmartResize`) *panics* on such inputs and crashes the Ollama runner, surfacing as a generic, misleading 500:

```
Image analysis failed (page 1): model runner has unexpectedly stopped, this may be
due to resource limitations or an internal error ... (status code: 500)
```

Diagnosed from the Ollama server log: 13 panics in one run, all `height:{6,17,24,30} or width:~512 must be larger than factor:32`. Not a memory issue (reproduced on M4 Max / 128GB with the model resident at 27GB/100% GPU). See #79 for the full trace.

## How

- `DEFAULT_VISION_MIN_DIMENSION = 32` in `lib/consts.py`.
- `images.is_below_vlm_minimum(prepared, min_dimension=...)` predicate, checked on **post-scale** dimensions (downscaling a tall-thin image can itself push an edge under the minimum).
- `_process_image` guards before any DB/archive/VLM work, logs a `warn` with the dimensions, and returns.
- `vision_min_dimension` threaded through the ingest chain alongside the existing `vision_max_dimension`, read from config in `scribe.main`, and prompted by the `ready` wizard.

These slivers carry no describable scene, so dropping them loses nothing.

## Tests

- Predicate unit tests: thin strip flagged, square/exact-32 allowed, post-scale-derived shrink caught.
- End-to-end: a standalone 512×24 image is skipped entirely (no `images`/`document_images`/image-chunk rows) and the VLM is never called.
- Full suite: 341 passed.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)