### PR TITLE
Truncate filenames and show page count in scribe progress bar

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -576,6 +576,7 @@ def _ingest_pdf_pdfplumber(
     on_page_progress: Callable[[int, int], None] | None = None,
     on_image_progress: Callable[[int, int], None] | None = None,
     on_stage: Callable[[str], None] | None = None,
+    on_page_count: Callable[[int | None], None] | None = None,
 ) -> tuple[int, str]:
     if on_stage is not None:
         on_stage("extracting")
@@ -585,6 +586,8 @@ def _ingest_pdf_pdfplumber(
         ocr_min_confidence=ocr_min_confidence,
         on_progress=on_page_progress,
     )
+    if on_page_count is not None:
+        on_page_count(result.page_count)
     document_id = _insert_document(
         conn,
         file_hash=file_hash,
@@ -661,12 +664,15 @@ def _ingest_pdf_docling(
     vision_min_dimension: int,
     on_image_progress: Callable[[int, int], None] | None = None,
     on_stage: Callable[[str], None] | None = None,
+    on_page_count: Callable[[int | None], None] | None = None,
 ) -> tuple[int, str]:
     from bartleby.ingest import docling as docling_pipeline
 
     if on_stage is not None:
         on_stage("extracting")
     docling_result = docling_pipeline.convert(archived)
+    if on_page_count is not None:
+        on_page_count(docling_result.page_count)
     document_id = _insert_document(
         conn,
         file_hash=file_hash,
@@ -828,6 +834,7 @@ def _process_one(
     on_page_progress: Callable[[int, int], None] | None = None,
     on_image_progress: Callable[[int, int], None] | None = None,
     on_stage: Callable[[str], None] | None = None,
+    on_page_count: Callable[[int | None], None] | None = None,
 ) -> bool:
     """Returns True if a new document was ingested, False if the file was
     already ingested and skipped. Caller handles the user-facing message."""
@@ -872,6 +879,7 @@ def _process_one(
                 vision_min_dimension=vision_min_dimension,
                 on_image_progress=on_image_progress,
                 on_stage=on_stage,
+                on_page_count=on_page_count,
             )
         else:
             document_id, full_text = _ingest_pdf_pdfplumber(
@@ -886,6 +894,7 @@ def _process_one(
                 on_page_progress=on_page_progress,
                 on_image_progress=on_image_progress,
                 on_stage=on_stage,
+                on_page_count=on_page_count,
             )
     elif edgar_pipeline.detect(archived):
         # EDGAR full-submission SGML envelope — detected by content, so a `.txt`
@@ -1063,10 +1072,33 @@ def main(
             skipped_count = 0
 
             for src, src_ext in sources:
-                def _set_stage(stage: str, _src=src) -> None:
-                    bar.update(task, label=f"Ingesting {_src.name} · {stage}")
+                # Render the main row from the active stage + page count. The
+                # filename is truncated so a long name can't squeeze the bar
+                # (issue #85); the page count is appended once extraction knows
+                # it, for whichever converter ran.
+                state = {"stage": "starting", "pages": None}
 
-                _set_stage("starting")
+                def _render(_src=src, _state=state) -> None:
+                    name = console.truncate_filename(_src.name)
+                    pages = _state["pages"]
+                    page_str = (
+                        f" · {pages} page{'' if pages == 1 else 's'}"
+                        if pages else ""
+                    )
+                    bar.update(
+                        task,
+                        label=f"Ingesting {name}{page_str} · {_state['stage']}",
+                    )
+
+                def _set_stage(stage: str, _state=state, _render=_render) -> None:
+                    _state["stage"] = stage
+                    _render()
+
+                def _set_page_count(count: int | None, _state=state, _render=_render) -> None:
+                    _state["pages"] = count
+                    _render()
+
+                _render()
                 try:
                     was_ingested = _process_one(
                         conn, src, src_ext, archive_root,
@@ -1081,9 +1113,10 @@ def main(
                         max_summarize_tokens=max_summarize_tokens,
                         vision_provider=vision_provider,
                         vision_model=vision_model,
-                        on_page_progress=_phase_callback(f"  pages ({src.name})"),
-                        on_image_progress=_phase_callback(f"  images ({src.name})"),
+                        on_page_progress=_phase_callback("  pages"),
+                        on_image_progress=_phase_callback("  images"),
                         on_stage=_set_stage,
+                        on_page_count=_set_page_count,
                     )
                     if not was_ingested:
                         skipped_count += 1

--- a/bartleby/lib/console.py
+++ b/bartleby/lib/console.py
@@ -37,6 +37,28 @@ def _aligned(message: str) -> str:
     return message.replace("\n", "\n" + _CONT_INDENT)
 
 
+# Max width for a filename shown inline in the scribe progress bar. Beyond
+# this we middle-truncate so a long name can't squeeze the flexible bar down
+# to a sliver (issue #85).
+_FILENAME_MAX = 40
+
+
+def truncate_filename(name: str, max_len: int = _FILENAME_MAX) -> str:
+    """Middle-truncate ``name`` to ``max_len`` chars with an ellipsis.
+
+    Keeps the head and tail so the start of the name and its extension both
+    stay visible — the extension is often the only type signal for the
+    scraper-mangled filenames this corpus sees (cf. issue #78).
+    """
+    if len(name) <= max_len:
+        return name
+    ellipsis = "…"
+    keep = max_len - len(ellipsis)
+    head = (keep + 1) // 2
+    tail = keep - head
+    return name[:head] + ellipsis + name[-tail:]
+
+
 def splash() -> None:
     _console.print(SPLASH, style="magenta")
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,24 @@
+"""Unit tests for the console helpers used by the scribe progress bar."""
+
+from __future__ import annotations
+
+from bartleby.lib.console import truncate_filename
+
+
+def test_truncate_filename_passes_short_names_through():
+    assert truncate_filename("report.pdf") == "report.pdf"
+
+
+def test_truncate_filename_respects_exact_max():
+    name = "x" * 40
+    assert truncate_filename(name, max_len=40) == name
+
+
+def test_truncate_filename_middle_truncates_long_names():
+    name = "A_very_long_scraper_mangled_filename_that_keeps_going.PDF"
+    out = truncate_filename(name, max_len=40)
+    assert len(out) == 40
+    assert "…" in out
+    # Head and tail (extension) both survive the middle ellipsis.
+    assert out.startswith("A_very_long")
+    assert out.endswith(".PDF")

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -538,6 +538,48 @@ def test_scribe_stage_callback_progresses_through_phases(
     assert stages[-1] == "summarizing"
 
 
+def test_scribe_page_count_callback_fires_for_pdf(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """on_page_count receives the converter's page count (issue #85)."""
+    from bartleby.commands import scribe as scribe_module
+    from bartleby.db.connection import open_db
+
+    monkeypatch.setattr(
+        scribe_module, "load_config",
+        lambda: {
+            "summary_depth": "none",
+            "pdf_converter": "pdfplumber",
+            "html_converter": "docling",
+            "sparse_text_threshold": 100,
+        },
+    )
+
+    pdf = tmp_path / "doc.pdf"
+    _text_pdf(pdf)
+
+    counts: list[int | None] = []
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    conn = open_db("test_proj")
+    try:
+        scribe_module._process_one(
+            conn, pdf, ".pdf", archive_root,
+            pdf_converter="pdfplumber",
+            html_converter="docling",
+            sparse_text_threshold=100, ocr_min_confidence=30,
+            vision_max_dimension=1024, vision_min_dimension=32,
+            llm_provider=None, llm_model=None,
+            temperature=0.0, max_summarize_tokens=1000,
+            vision_provider=None, vision_model=None,
+            on_page_count=counts.append,
+        )
+    finally:
+        conn.close()
+
+    assert counts == [1]
+
+
 def test_scribe_image_progress_callback_fires_per_image(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):


### PR DESCRIPTION
## What

Two readability fixes for the `bartleby scribe` ingestion progress bar (issue #85).

**1. Truncate long filenames.** The active filename was written verbatim into the unbounded `TextColumn` label, pushing the flexible `BarColumn` down to a sliver on narrow terminals or long scraper-mangled names. A new `truncate_filename` helper (`bartleby/lib/console.py`) middle-truncates to 40 chars with an ellipsis, preserving the head and the extension (often the only type signal — cf. #78).

**2. Show page count per active document.** Previously a page total only appeared for the pdfplumber path, and only as a transient sub-bar. A new `on_page_count` callback is threaded through `_process_one` and both PDF ingest paths, so the active row reads e.g. `Ingesting foo.pdf · 24 pages · embedding` for **both** converters (pdfplumber and docling). Formats with no page count (images, txt/md) just omit it.

Also dropped the now-redundant filename from the sub-bar phase labels (`pages (foo.pdf)` → `pages`) — the main row is the canonical "what's active" line, which removes a second squash source.

## Testing

- New `tests/test_console.py` — unit tests for `truncate_filename` (passthrough, exact-max, middle-truncation keeps head + extension).
- New `test_scribe_page_count_callback_fires_for_pdf` — asserts `on_page_count` receives the converter's page count.
- Full suite green (357 passed).

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)