### PR TITLE
scribe: accept multiple paths and a --only type filter (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,13 @@ The default policy is "no backwards compat" — schema bumps mean re-ingest. The
 Ingest HTML, MD, PDF, and TXT documents into the project database.
 
 ```
-bartleby scribe --files <path> [options]
+bartleby scribe --files <path> [<path> ...] [options]
 ```
 
 | Option | Description |
 | --- | --- |
-| `--files <path>` | Path to a file or directory of supported documents (required) |
+| `--files <path> [<path> ...]` | One or more files and/or directories of supported documents (required). Directories are walked recursively; a file reachable from more than one path is ingested once. |
+| `--only <type>` | Restrict ingestion to the given file type(s): `pdf`, `html`, `md`, `txt`, `image`. Repeatable and/or comma-separated (e.g. `--only pdf,html`). Filters on the *resolved* type, so a content-sniffed PDF with no extension is kept by `--only pdf`. |
 | `--project <name>` | Target project (defaults to active) |
 | `--model <name>` | Override LLM model for summarization |
 | `--provider <name>` | Override LLM provider |

--- a/bartleby/cli.py
+++ b/bartleby/cli.py
@@ -42,7 +42,19 @@ def main():
         "scribe",
         help="Ingest PDF, HTML, MD, TXT, and image files into a project",
     )
-    scribe_parser.add_argument("--files", required=True, type=str)
+    scribe_parser.add_argument(
+        "--files", required=True, type=str, nargs="+", metavar="PATH",
+        help="One or more files and/or directories to ingest. Directories are "
+             "walked recursively; a file reachable from more than one path is "
+             "ingested once.",
+    )
+    scribe_parser.add_argument(
+        "--only", type=str, action="append", default=None, metavar="TYPE",
+        help="Restrict ingestion to the given file type(s): pdf, html, md, txt, "
+             "image. Repeatable and/or comma-separated (e.g. --only pdf,html). "
+             "Filters on the resolved type, so content-sniffed files are "
+             "included.",
+    )
     scribe_parser.add_argument("--project", type=str, default=None)
     scribe_parser.add_argument("--model", type=str, default=None)
     scribe_parser.add_argument(
@@ -144,6 +156,7 @@ def _scribe(args):
     scribe_main(
         project=args.project,
         files=args.files,
+        only=args.only,
         model=args.model,
         provider=args.provider,
         pdf_converter=args.pdf_converter,

--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -52,6 +52,7 @@ from bartleby.ingest.chunk import (
     chunk_markdown_string,
     convert_and_chunk,
     resolve_extension,
+    resolve_format_filter,
 )
 from bartleby.ingest.embed import embed_texts
 from bartleby.ingest.summarize import SummaryResult, count_tokens, summarize
@@ -89,33 +90,59 @@ def _archive(src: Path, archive_root: Path, file_hash: str, ext: str) -> Path:
     return dest
 
 
-def _collect_files(path: Path) -> tuple[list[tuple[Path, str]], list[Path]]:
-    """Resolve ``path`` to ingestible ``(file, extension)`` pairs.
+def _collect_files(
+    paths: list[Path], only: set[str] | None = None,
+) -> tuple[list[tuple[Path, str]], list[Path]]:
+    """Resolve ``paths`` to ingestible ``(file, extension)`` pairs.
+
+    Each path is a single file or a directory walked recursively; the results
+    are concatenated and de-duplicated by real path, so a file reachable from
+    two supplied roots (or named twice) is collected once (issue #89).
 
     The resolved extension is what the file should be *treated as* — the
     filename extension when it is supported, otherwise a content-sniffed one
-    (see :func:`resolve_extension`). Returns ``(sources, unidentified)`` where
-    ``unidentified`` lists directory entries that could not be resolved to a
-    supported type; the caller surfaces them so they are not dropped silently.
+    (see :func:`resolve_extension`). When ``only`` is given (a set of supported,
+    leading-dot extensions), files whose resolved type is not in it are dropped
+    from collection — silently, since the exclusion is intentional and not the
+    same as a file we couldn't identify.
+
+    Returns ``(sources, unidentified)`` where ``unidentified`` lists directory
+    entries that could not be resolved to a supported type at all; the caller
+    surfaces them so they are not dropped silently.
     """
-    if path.is_file():
-        ext = resolve_extension(path)
-        if ext is None:
-            raise ValueError(f"Unsupported file type: {path.name}")
-        return [(path, ext)], []
-    if path.is_dir():
-        sources: list[tuple[Path, str]] = []
-        unidentified: list[Path] = []
-        for p in sorted(path.rglob("*")):
-            if not p.is_file():
+    sources: list[tuple[Path, str]] = []
+    unidentified: list[Path] = []
+    seen: set[Path] = set()
+
+    def _first_seen(p: Path) -> bool:
+        key = p.resolve()
+        if key in seen:
+            return False
+        seen.add(key)
+        return True
+
+    for path in paths:
+        if path.is_file():
+            if not _first_seen(path):
                 continue
-            ext = resolve_extension(p)
+            ext = resolve_extension(path)
             if ext is None:
-                unidentified.append(p)
-            else:
-                sources.append((p, ext))
-        return sources, unidentified
-    raise ValueError(f"Path not found: {path}")
+                raise ValueError(f"Unsupported file type: {path.name}")
+            if only is None or ext in only:
+                sources.append((path, ext))
+        elif path.is_dir():
+            for p in sorted(path.rglob("*")):
+                if not p.is_file() or not _first_seen(p):
+                    continue
+                ext = resolve_extension(p)
+                if ext is None:
+                    unidentified.append(p)
+                elif only is None or ext in only:
+                    sources.append((p, ext))
+        else:
+            raise ValueError(f"Path not found: {path}")
+
+    return sources, unidentified
 
 
 def _document_already_ingested(conn, file_hash: str) -> int | None:
@@ -964,7 +991,8 @@ def _resolve_vision_provider(
 def main(
     *,
     project: str | None,
-    files: str | Path,
+    files: str | Path | list[str | Path],
+    only: list[str] | None = None,
     model: str | None = None,
     provider: str | None = None,
     pdf_converter: str | None = None,
@@ -1001,7 +1029,19 @@ def main(
             f"expected 'docling' or 'sec2md'."
         )
 
-    sources, unidentified = _collect_files(Path(files))
+    # `files` is one path or many (CLI passes a list via nargs="+"); normalize
+    # so collection always walks a list. `--only` names are comma-splittable and
+    # repeatable, resolved to the set of extensions to keep.
+    file_args = [files] if isinstance(files, (str, Path)) else files
+    only_filter: set[str] | None = None
+    if only:
+        names = [n for group in only for n in group.split(",") if n.strip()]
+        if names:
+            only_filter = resolve_format_filter(names)
+
+    sources, unidentified = _collect_files(
+        [Path(f) for f in file_args], only_filter,
+    )
     if unidentified:
         UNIDENTIFIED_DISPLAY_LIMIT = 10
         console.warn(

--- a/bartleby/ingest/chunk.py
+++ b/bartleby/ingest/chunk.py
@@ -49,6 +49,48 @@ def resolve_extension(path: Path) -> str | None:
     return sniffed if sniffed in SUPPORTED_EXTENSIONS else None
 
 
+# User-facing format names for the `scribe --only` filter, each mapped to the
+# set of *resolved* extensions it selects. Keyed off the same format buckets
+# scribe already thinks in (PDF / HTML / Markdown / text / image) so the filter
+# composes with content sniffing: a sniffed-as-PDF file with no extension is
+# selected by `--only pdf` just like a `.pdf` one (issue #89).
+FORMAT_ALIASES = {
+    "pdf": PDF_EXTENSIONS,
+    "html": {".html", ".htm"},
+    "htm": {".html", ".htm"},
+    "md": {".md"},
+    "markdown": {".md"},
+    "txt": TEXT_EXTENSIONS,
+    "text": TEXT_EXTENSIONS,
+    "image": IMAGE_EXTENSIONS,
+    "images": IMAGE_EXTENSIONS,
+}
+
+
+def resolve_format_filter(names: list[str]) -> set[str]:
+    """Map user-facing format names to the set of supported extensions to keep.
+
+    Each name is a format bucket (``pdf``, ``html``, ``md``, ``txt``, ``image``)
+    or a bare supported extension (``jpg``, ``.png``). Returns the union of the
+    extensions they select. Raises ``ValueError`` on an unrecognized name so a
+    typo'd filter fails loudly rather than silently matching nothing.
+    """
+    allowed: set[str] = set()
+    for name in names:
+        key = name.strip().lower()
+        dotted = key if key.startswith(".") else f".{key}"
+        if key in FORMAT_ALIASES:
+            allowed |= FORMAT_ALIASES[key]
+        elif dotted in SUPPORTED_EXTENSIONS:
+            allowed.add(dotted)
+        else:
+            raise ValueError(
+                f"Unknown file type filter {name!r}; expected one of "
+                f"{', '.join(sorted(FORMAT_ALIASES))} or a supported extension."
+            )
+    return allowed
+
+
 # Soft cap for agent-authored markdown chunks. Picked to stay well under the
 # embedder's 512-token max sequence; characters are a rough proxy.
 _MD_CHUNK_CHARS = 1600

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -1224,9 +1224,30 @@ def test_resolve_extension_returns_none_for_unidentifiable(tmp_path):
     assert resolve_extension(p) is None
 
 
+def test_resolve_format_filter_maps_buckets_and_extensions():
+    from bartleby.ingest.chunk import resolve_format_filter
+
+    assert resolve_format_filter(["pdf"]) == {".pdf"}
+    assert resolve_format_filter(["html"]) == {".html", ".htm"}
+    assert resolve_format_filter(["image"]) == {
+        ".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tiff", ".tif",
+    }
+    # Aliases, bare extensions, and a leading dot all resolve.
+    assert resolve_format_filter(["text", "MD", "jpg", ".png"]) == {
+        ".txt", ".md", ".jpg", ".png",
+    }
+
+
+def test_resolve_format_filter_rejects_unknown_name():
+    from bartleby.ingest.chunk import resolve_format_filter
+
+    with pytest.raises(ValueError):
+        resolve_format_filter(["spreadsheet"])
+
+
 def test_collect_files_single_extensionless_pdf(tmp_path):
     pdf = _text_pdf(tmp_path / "docket_no_ext")
-    sources, unidentified = scribe._collect_files(pdf)
+    sources, unidentified = scribe._collect_files([pdf])
     assert sources == [(pdf, ".pdf")]
     assert unidentified == []
 
@@ -1235,7 +1256,7 @@ def test_collect_files_single_unsupported_raises(tmp_path):
     p = tmp_path / "mystery"
     p.write_bytes(b"\x00\x01\x02\x03")
     with pytest.raises(ValueError):
-        scribe._collect_files(p)
+        scribe._collect_files([p])
 
 
 def test_collect_files_directory_sniffs_and_reports_unidentified(tmp_path):
@@ -1246,11 +1267,104 @@ def test_collect_files_directory_sniffs_and_reports_unidentified(tmp_path):
     junk = d / "notes"                                      # unidentifiable
     junk.write_bytes(b"\x00\x01\x02\x03")
 
-    sources, unidentified = scribe._collect_files(d)
+    sources, unidentified = scribe._collect_files([d])
 
     assert (pdf, ".pdf") in sources
     assert (named, ".pdf") in sources
     assert unidentified == [junk]
+
+
+def test_collect_files_unions_multiple_directories(tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    pdf_a = _text_pdf(a / "a.pdf")
+    pdf_b = _text_pdf(b / "b.pdf")
+
+    sources, unidentified = scribe._collect_files([a, b])
+
+    files = {p for p, _ in sources}
+    assert files == {pdf_a, pdf_b}
+    assert unidentified == []
+
+
+def test_collect_files_dedupes_overlapping_roots(tmp_path):
+    d = tmp_path / "docket"
+    d.mkdir()
+    pdf = _text_pdf(d / "report.pdf")
+
+    # The same file reachable both as an explicit file and under its directory.
+    sources, _ = scribe._collect_files([pdf, d])
+    assert sources.count((pdf, ".pdf")) == 1
+    assert len(sources) == 1
+
+
+def test_collect_files_only_filter_restricts_by_resolved_type(tmp_path):
+    d = tmp_path / "mixed"
+    d.mkdir()
+    pdf = _text_pdf(d / "report.pdf")
+    txt = _write_txt(d / "notes.txt", "plain text")
+    png = d / "image.png"
+    png.write_bytes(_png_bytes())
+
+    sources, unidentified = scribe._collect_files([d], only={".pdf"})
+
+    assert sources == [(pdf, ".pdf")]
+    # txt and png are intentional exclusions — not lumped into unidentified.
+    assert unidentified == []
+    assert txt not in {p for p, _ in sources}
+    assert png not in {p for p, _ in sources}
+
+
+def test_collect_files_only_filter_matches_sniffed_type(tmp_path):
+    d = tmp_path / "docket"
+    d.mkdir()
+    sniffed = _text_pdf(d / "ATTACHMENT 7 - LOADING FORMS")  # extensionless PDF
+    _write_txt(d / "notes.txt", "plain text")
+
+    sources, _ = scribe._collect_files([d], only={".pdf"})
+
+    # The content-sniffed PDF is kept by `--only pdf` just like a named one.
+    assert sources == [(sniffed, ".pdf")]
+
+
+def test_scribe_only_filter_end_to_end(isolated_project, tmp_path, mock_embed):
+    d = tmp_path / "mixed"
+    d.mkdir()
+    _text_pdf(d / "report.pdf")
+    _write_txt(d / "notes.txt", "Plain text that should be skipped.")
+
+    scribe.main(project="test_proj", files=[str(d)], only=["pdf"])
+
+    conn = open_db("test_proj")
+    try:
+        names = [
+            r[0] for r in conn.cursor().execute("SELECT file_name FROM documents")
+        ]
+        assert names == ["report.pdf"]
+    finally:
+        conn.close()
+
+
+def test_scribe_multiple_paths_end_to_end(isolated_project, tmp_path, mock_embed):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    _write_txt(a / "one.txt", "First document.")
+    _write_txt(b / "two.txt", "Second document.")
+
+    scribe.main(project="test_proj", files=[str(a), str(b)])
+
+    conn = open_db("test_proj")
+    try:
+        names = {
+            r[0] for r in conn.cursor().execute("SELECT file_name FROM documents")
+        }
+        assert names == {"one.txt", "two.txt"}
+    finally:
+        conn.close()
 
 
 def test_scribe_ingests_extensionless_pdf_by_sniffing(


### PR DESCRIPTION
## Summary

Implements GH #89. `bartleby scribe` gains two ingestion conveniences:

1. **Multiple paths.** `--files` now takes more than one path (`nargs="+"`) — any mix of files and directories:
   ```
   bartleby scribe --files data/spacex-a data/spacex-b data/spacex-c
   ```
   Results from every path are unioned and **de-duplicated by resolved real path**, so a file reachable from two roots (or named twice) is collected once. Per-file content-hash idempotency already made overlapping roots safe — this just removes the need to invoke the command N times.

2. **Type filter.** A new `--only <type>` restricts collection to the requested format bucket(s) — `pdf`, `html`, `md`, `txt`, `image` — repeatable and/or comma-separated (`--only pdf,html`). It filters on the **resolved** type, so a content-sniffed PDF with a missing extension (#78) is kept by `--only pdf` exactly like a `.pdf` one. Files dropped by the filter are intentional exclusions and are **not** lumped into the "could not identify" warning.

## Design choices

- **CLI shape:** `--files` with `nargs="+"` (smallest change, keeps the existing flag name; single-path invocations are unchanged).
- **Filter syntax:** type/bucket names over globs — they map cleanly onto scribe's existing format buckets and compose with the type-resolution/sniffing logic. `resolve_format_filter()` also accepts bare supported extensions (`jpg`, `.png`) and fails loudly on an unknown name.

## Acceptance criteria

- [x] `scribe` accepts multiple paths (files and/or dirs) and ingests the union
- [x] A file reachable from more than one path is collected once
- [x] A type filter restricts ingestion to the requested type(s), leaving other supported files untouched
- [x] The filter is based on the *resolved* type, so sniffed files (#78) filter consistently
- [x] Existing single-path invocations keep working unchanged

## Tests

New coverage in `tests/test_scribe.py`: multi-directory union, overlapping-root dedup, `--only` filtering (named + content-sniffed types, exclusions not reported as unidentified), end-to-end multi-path and filter runs, and `resolve_format_filter` unit tests. Full suite: **365 passed**.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)