### PR TITLE
Point schema-mismatch error at `project upgrade` before re-ingest (#95)

### DIFF
--- a/bartleby/db/connection.py
+++ b/bartleby/db/connection.py
@@ -81,7 +81,8 @@ def open_db(project_name: str | None = None) -> apsw.Connection:
         raise RuntimeError(
             f"Schema version mismatch for project '{name}': "
             f"database has version {db_version}, code expects {SCHEMA_VERSION}. "
-            "Re-ingest the project to upgrade."
+            f"Run `bartleby project upgrade {name}` to upgrade in place; if that "
+            "reports a non-additive bump, re-ingest the project instead."
         )
 
     return conn

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -100,6 +100,24 @@ def test_init_db_refuses_existing(tmp_path, monkeypatch):
         init_db("foo")
 
 
+def test_schema_mismatch_points_at_upgrade_first(tmp_path, monkeypatch):
+    monkeypatch.setattr("bartleby.db.connection.PROJECTS_DIR", tmp_path)
+    init_db("proj")
+    c = open_db("proj")
+    c.cursor().execute(
+        "UPDATE meta SET value = ? WHERE key = 'schema_version'",
+        (str(SCHEMA_VERSION + 1),),
+    )
+    c.close()
+
+    with pytest.raises(RuntimeError) as exc:
+        open_db("proj")
+    msg = str(exc.value)
+    # `project upgrade` is the first remedy, re-ingest the fallback (issue #95).
+    assert "bartleby project upgrade proj" in msg
+    assert msg.index("project upgrade") < msg.index("re-ingest")
+
+
 def test_insert_document_chunks_keeps_fts_and_vec_in_sync(conn):
     cur = conn.cursor()
     doc_id = _insert_doc(conn, "h1")


### PR DESCRIPTION
## Summary

The schema-version-mismatch error in `open_db` always told users to **re-ingest** — the most destructive recovery — even though most schema bumps are additive and `bartleby project upgrade <name>` brings the DB up to date in place. Re-ingest is only actually required for non-additive bumps, which `project upgrade` itself detects and refuses.

This reverses the guidance to lead with the lighter path:

**Before**
```
Schema version mismatch for project '<name>': database has version X, code expects Y. Re-ingest the project to upgrade.
```

**After**
```
Schema version mismatch for project '<name>': database has version X, code expects Y. Run `bartleby project upgrade <name>` to upgrade in place; if that reports a non-additive bump, re-ingest the project instead.
```

Wording mirrors the README's "After updating Bartleby" section, so the runtime error and the docs now agree. No behavior change beyond the message text.

## Acceptance criteria

- [x] The error names `bartleby project upgrade <name>` as the first remedy and re-ingest as the fallback.
- [x] Wording stays consistent with the README's "After updating Bartleby" section.

## Testing

- New `test_schema_mismatch_points_at_upgrade_first` (corrupts `meta.schema_version`, asserts the upgrade command is named and ordered before re-ingest).
- Full suite: 376 passed.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)