### PR TITLE
merge_findings: surface full session provenance in output (#75)

### DIFF
--- a/bartleby/skill_scripts/merge_findings.py
+++ b/bartleby/skill_scripts/merge_findings.py
@@ -18,7 +18,8 @@ plus ``merged_from``:
 
     {
       "finding_id": int,            # the surviving target
-      "session_id": int, "session_name": str,   # the target's author
+      "session_id": int,            # the target's author
+      "session_name": str, "model": str|null, "harness": str|null,
       "body": str,
       "chunk_ids": [int, ...],
       "citations": [{
@@ -46,6 +47,7 @@ from bartleby.skill_scripts._common import (
     rebuild_finding_chunks,
     replace_finding_citations,
     resolve_citations,
+    session_provenance,
     validated_replacement,
 )
 
@@ -120,14 +122,10 @@ def work(*, conn, args, session_id) -> dict:
             f"DELETE FROM findings WHERE finding_id IN ({src_ph})", sources,
         )
 
-    session_name = cur.execute(
-        "SELECT name FROM sessions WHERE session_id = ?", (owning_session_id,)
-    ).fetchone()[0]
-
     return {
         "finding_id": target,
         "session_id": owning_session_id,
-        "session_name": session_name,
+        **session_provenance(conn, owning_session_id),
         "body": body,
         "chunk_ids": chunk_ids,
         "citations": resolve_citations(conn, citations),

--- a/tests/test_skill_merge_findings.py
+++ b/tests/test_skill_merge_findings.py
@@ -78,7 +78,9 @@ def test_merge_folds_sources_into_target(seeded_project, tmp_path, capsys):
     assert out["body"] == merged_body
     assert out["merged_from"] == [src1, src2]
     assert [c["chunk_id"] for c in out["citations"]] == [c0, c1, c2]
+    # Output mirrors save/edit/read: full session provenance, not just the name.
     assert out["session_name"]
+    assert "model" in out and "harness" in out
 
     conn = open_db(project)
     try:
@@ -113,6 +115,36 @@ def test_merge_folds_sources_into_target(seeded_project, tmp_path, capsys):
             ).fetchone()[0] == 0
     finally:
         conn.close()
+
+
+def test_merge_surfaces_session_provenance(seeded_project, tmp_path, capsys):
+    """The merged target reports its authoring session's model + harness,
+    matching save/edit/read (issue #75)."""
+    from bartleby.session import set_session_provenance
+
+    project = seeded_project["project"]
+    chunks = _doc_chunk_ids(project, seeded_project["doc_a"])
+    c0, c1 = chunks[0], chunks[1]
+
+    target = _save(project, tmp_path, capsys, name="t", title="Keep", cite=c0)
+    src = _save(project, tmp_path, capsys, name="s", title="Dup", cite=c1)
+
+    # Stamp the authoring (active) session so model/harness are non-NULL.
+    set_session_provenance(project, model="qwen3.6:35b-mlx", harness="ollama-cli")
+
+    merged_file = tmp_path / "merged.md"
+    merged_file.write_text(f"# Consolidated\n\nTogether[^{c0}][^{c1}].",
+                           encoding="utf-8")
+    merge_findings.main([
+        "--project", project,
+        "--from", str(src),
+        "--into", str(target),
+        "--body-file", str(merged_file),
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    assert out["model"] == "qwen3.6:35b-mlx"
+    assert out["harness"] == "ollama-cli"
 
 
 def test_merge_missing_source_reports_ids(seeded_project, tmp_path, capsys):


### PR DESCRIPTION
## Problem

`merge_findings` returned a finding payload whose shape diverged from its sibling finding scripts. `save_finding`, `edit_finding`, and `read_finding` all surface provenance by spreading `**session_provenance(conn, session_id)` (which adds `session_name`, `model`, and `harness`). `merge_findings` instead hand-queried just `session_name` and omitted `model` / `harness`.

An agent reading a merged finding's output got a different field set than from save/edit/read — and `SKILL.md` already documents `merge_findings` output as mirroring `save_finding`.

## Fix

Replace the manual `session_name` query with `**session_provenance(conn, owning_session_id)`, so the output carries `session_name` / `model` / `harness` like the other finding scripts. The now-unused manual query is dropped, and the docstring lists the full provenance field set.

This *adds output fields* — an intentional behavior change (kept out of the #74 no-behavior-change sweep). `SKILL.md` needed no edit: its `merge_findings` row already claims the target keeps its provenance and that output mirrors `save_finding`; this aligns the actual output with that claim.

## Tests

`tests/test_skill_merge_findings.py`:
- Existing merge test now asserts `model` / `harness` keys are present.
- New `test_merge_surfaces_session_provenance` stamps the authoring session (`set_session_provenance`) and asserts the merged output reflects the recorded `model` / `harness` — mirroring the sibling provenance test in `test_skill_save_finding.py`.

Full suite: **377 passed**.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)