### PR TITLE
Add concise help text to every prompt in the `ready` wizard (#83)

### DIFF
--- a/bartleby/commands/ready.py
+++ b/bartleby/commands/ready.py
@@ -42,12 +42,25 @@ DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
 console = Console()
 
 
-def _prompt_provider(existing: dict, *, label: str = "LLM provider",
+def _help(text: str) -> None:
+    """Print a concise, dim help blurb above the upcoming prompt.
+
+    The wizard's prompt labels stay short (Rich renders them on one line); the
+    orienting detail lives here, indented and dimmed so it reads as secondary.
+    Multi-line strings are printed line-for-line.
+    """
+    for line in text.split("\n"):
+        console.print(f"  {line}", style="dim")
+
+
+def _prompt_provider(existing: dict, *, help_text: str,
+                     label: str = "LLM provider",
                      key: str = "provider") -> str:
     default_provider = existing.get(key, "anthropic")
     if default_provider not in ALLOWED_PROVIDERS:
         default_provider = "anthropic"
     choices = " / ".join(ALLOWED_PROVIDERS)
+    _help(help_text)
     while True:
         provider = Prompt.ask(
             f"{label} ({choices})", default=default_provider
@@ -58,31 +71,37 @@ def _prompt_provider(existing: dict, *, label: str = "LLM provider",
 
 
 def _prompt_model(provider: str, existing: dict,
-                  *, key: str = "model",
+                  *, help_text: str, key: str = "model",
                   defaults: dict[str, str] = PROVIDER_DEFAULT_MODEL) -> str:
     default_model = existing.get(key) or defaults[provider]
+    _help(help_text)
     return Prompt.ask("Model name", default=default_model)
 
 
-def _prompt_api_key(provider: str, existing: dict) -> str | None:
+def _prompt_api_key(provider: str, existing: dict, *, help_text: str | None = None) -> str | None:
     field = f"{provider}_api_key"
     existing_key = existing.get(field, "")
+    _help(help_text or (
+        "Saved to the config file. Leave blank to fall back to the "
+        f"{provider.upper()}_API_KEY environment variable."
+    ))
     if existing_key:
         if Confirm.ask("API key already configured. Update it?", default=False):
             entered = Prompt.ask("API key", password=True)
             return entered or existing_key
         return existing_key
     entered = Prompt.ask(
-        "API key (optional, can also use env var)", password=True, default=""
+        "API key (optional)", password=True, default=""
     )
     return entered or None
 
 
-def _prompt_pdf_converter(existing: dict) -> str:
+def _prompt_pdf_converter(existing: dict, *, help_text: str) -> str:
     default = existing.get("pdf_converter", DEFAULT_PDF_CONVERTER)
     if default not in ALLOWED_PDF_CONVERTERS:
         default = DEFAULT_PDF_CONVERTER
     choices = " / ".join(ALLOWED_PDF_CONVERTERS)
+    _help(help_text)
     while True:
         b = Prompt.ask(
             f"PDF converter ({choices})", default=default
@@ -92,25 +111,25 @@ def _prompt_pdf_converter(existing: dict) -> str:
         console.print(f"[red]Invalid converter. Choose from: {choices}[/red]")
 
 
-def _prompt_html_converter(existing: dict) -> str:
+def _prompt_html_converter(existing: dict, *, help_text: str) -> str:
     default = existing.get("html_converter", DEFAULT_HTML_CONVERTER)
     if default not in ALLOWED_HTML_CONVERTERS:
         default = DEFAULT_HTML_CONVERTER
     choices = " / ".join(ALLOWED_HTML_CONVERTERS)
+    _help(help_text)
     while True:
         b = Prompt.ask(
-            f"HTML converter ({choices}; sec2md routes iXBRL filings, "
-            f"others stay on docling)",
-            default=default,
+            f"HTML converter ({choices})", default=default
         ).lower()
         if b in ALLOWED_HTML_CONVERTERS:
             return b
         console.print(f"[red]Invalid converter. Choose from: {choices}[/red]")
 
 
-def _prompt_summary_depth(existing: dict) -> str:
+def _prompt_summary_depth(existing: dict, *, help_text: str) -> str:
     default = existing.get("summary_depth", DEFAULT_SUMMARY_DEPTH)
     choices = " / ".join(ALLOWED_SUMMARY_DEPTHS)
+    _help(help_text)
     while True:
         depth = Prompt.ask(
             f"Summary depth ({choices})", default=default
@@ -120,18 +139,26 @@ def _prompt_summary_depth(existing: dict) -> str:
         console.print(f"[red]Invalid summary depth. Choose from: {choices}[/red]")
 
 
-def _prompt_temperature(existing: dict) -> float:
+def _prompt_temperature(existing: dict, *, help_text: str) -> float:
     default = float(existing.get("temperature", DEFAULT_TEMPERATURE))
+    _help(help_text)
     while True:
-        t = FloatPrompt.ask(
-            "Temperature (0=deterministic, 1=creative)", default=default
-        )
+        t = FloatPrompt.ask("Temperature", default=default)
         if 0 <= t <= 1:
             return t
         console.print("[red]Temperature must be between 0 and 1[/red]")
 
 
-def _prompt_positive_int(prompt: str, default: int) -> int:
+def _prompt_ollama_url(existing: dict) -> str:
+    _help("Where your local Ollama server listens.")
+    return Prompt.ask(
+        "Ollama server URL",
+        default=existing.get("ollama_base_url", DEFAULT_OLLAMA_BASE_URL),
+    )
+
+
+def _prompt_positive_int(prompt: str, default: int, *, help_text: str) -> int:
+    _help(help_text)
     while True:
         n = IntPrompt.ask(prompt, default=default)
         if n > 0:
@@ -153,15 +180,26 @@ def main():
         config["active_project"] = existing["active_project"]
 
     console.print("\n[bold]LLM Configuration[/bold] (for ingest-time summarization)")
+    _help(
+        "An LLM summarizes each document at ingest. Summaries are searchable "
+        "and shown when browsing.\nSkip this to ingest and index raw text only."
+    )
     use_llm = Confirm.ask(
         "Do you want to configure an LLM provider?",
         default=bool(existing.get("provider")),
     )
 
     if use_llm:
-        provider = _prompt_provider(existing)
+        provider = _prompt_provider(
+            existing,
+            help_text="The service that runs your summarization model.",
+        )
         config["provider"] = provider
-        config["model"] = _prompt_model(provider, existing)
+        config["model"] = _prompt_model(
+            provider, existing,
+            help_text="The summarization model. The default is a fast, "
+            "low-cost choice for this provider.",
+        )
 
         if provider in ("anthropic", "openai", "wsjpt"):
             key = _prompt_api_key(provider, existing)
@@ -171,19 +209,26 @@ def main():
             else:
                 config.pop(field, None)
         elif provider == "ollama":
-            config["ollama_base_url"] = Prompt.ask(
-                "Ollama server URL",
-                default=existing.get("ollama_base_url", DEFAULT_OLLAMA_BASE_URL),
-            )
+            config["ollama_base_url"] = _prompt_ollama_url(existing)
 
         console.print("\n[bold]Summarization[/bold]")
-        depth = _prompt_summary_depth(existing)
+        depth = _prompt_summary_depth(
+            existing,
+            help_text="none = skip summaries; one-shot = one summary per "
+            "document.\nSummaries are indexed for search/scan and shown in listings.",
+        )
         config["summary_depth"] = depth
         if depth == "one-shot":
-            config["temperature"] = _prompt_temperature(existing)
+            config["temperature"] = _prompt_temperature(
+                existing,
+                help_text="0 = deterministic, repeatable summaries; higher = "
+                "more varied wording.\nLeave at 0 unless summaries feel too rigid.",
+            )
             config["max_summarize_tokens"] = _prompt_positive_int(
-                "Max input tokens for summarization (longer documents are truncated)",
+                "Max summarization input tokens",
                 int(existing.get("max_summarize_tokens", DEFAULT_MAX_SUMMARIZE_TOKENS)),
+                help_text="Caps how much document text is sent to the summarizer; "
+                "longer documents are truncated.\nHigher = more context, higher cost.",
             )
         else:
             config.pop("temperature", None)
@@ -197,14 +242,30 @@ def main():
         config["summary_depth"] = "none"
 
     console.print("\n[bold]Converters[/bold]")
-    config["pdf_converter"] = _prompt_pdf_converter(existing)
-    config["html_converter"] = _prompt_html_converter(existing)
+    config["pdf_converter"] = _prompt_pdf_converter(
+        existing,
+        help_text="pdfplumber = fast text extraction; docling = slower but "
+        "layout-aware (tables, columns, reading order).",
+    )
+    config["html_converter"] = _prompt_html_converter(
+        existing,
+        help_text="docling handles general HTML/Markdown; sec2md is specialized "
+        "for iXBRL EDGAR filings (preserves SEC tables/headings, others stay on "
+        "docling).",
+    )
     config["sparse_text_threshold"] = _prompt_positive_int(
-        "Sparse-text threshold (chars/page below which a page is treated as scanned)",
+        "Sparse-text threshold",
         int(existing.get("sparse_text_threshold", DEFAULT_SPARSE_TEXT_THRESHOLD)),
+        help_text="Pages with fewer than this many extracted characters are "
+        "treated as scanned and routed to OCR/VLM.\nLower = more pages OCR'd "
+        "(slower, catches more).",
     )
 
     console.print("\n[bold]Image analysis[/bold] (VLM captions/OCR for embedded + standalone images)")
+    _help(
+        "A vision model captions and OCRs images (embedded figures and "
+        "standalone image files).\nSkip to leave images unanalyzed."
+    )
     use_vision = Confirm.ask(
         "Configure a vision provider for image analysis?",
         default=bool(existing.get("vision_provider")),
@@ -212,11 +273,14 @@ def main():
     if use_vision:
         vprovider = _prompt_provider(
             existing, label="Vision provider", key="vision_provider",
+            help_text="The service that runs your vision (image) model.",
         )
         config["vision_provider"] = vprovider
         config["vision_model"] = _prompt_model(
             vprovider, existing,
             key="vision_model", defaults=VISION_PROVIDER_DEFAULT_MODEL,
+            help_text="The vision model used to caption/OCR images. The default "
+            "is a fast, low-cost choice for this provider.",
         )
         # If the vision provider is the same as the LLM provider, reuse the
         # api key already prompted for above. Otherwise prompt fresh.
@@ -229,22 +293,24 @@ def main():
         elif vprovider == "ollama":
             # Reuse ollama_base_url if already set; otherwise prompt.
             if "ollama_base_url" not in config:
-                config["ollama_base_url"] = Prompt.ask(
-                    "Ollama server URL",
-                    default=existing.get("ollama_base_url", DEFAULT_OLLAMA_BASE_URL),
-                )
+                config["ollama_base_url"] = _prompt_ollama_url(existing)
         config["vision_max_dimension"] = _prompt_positive_int(
-            "Max image dimension (long edge in pixels before sending to VLM)",
+            "Max image dimension (px)",
             int(existing.get("vision_max_dimension", DEFAULT_VISION_MAX_DIMENSION)),
+            help_text="Images are downscaled so their long edge is at most this "
+            "many pixels before the VLM sees them.\nLower = faster/cheaper, less detail.",
         )
         config["vision_min_dimension"] = _prompt_positive_int(
-            "Min image dimension (skip images with an edge smaller than this; "
-            "avoids VLM crashes on thin slivers)",
+            "Min image dimension (px)",
             int(existing.get("vision_min_dimension", DEFAULT_VISION_MIN_DIMENSION)),
+            help_text="Images with an edge smaller than this are skipped — "
+            "avoids wasting VLM calls (and crashes) on thin slivers.",
         )
         config["ocr_min_confidence"] = _prompt_positive_int(
-            "Tesseract minimum avg confidence (0-100; fallback to VLM below this)",
+            "Tesseract min confidence",
             int(existing.get("ocr_min_confidence", DEFAULT_OCR_MIN_CONFIDENCE)),
+            help_text="Tesseract average confidence (0-100); pages scoring below "
+            "this fall back to the VLM.\nHigher = trust OCR less, use the VLM more.",
         )
     else:
         for k in ("vision_provider", "vision_model",
@@ -254,8 +320,11 @@ def main():
 
     console.print("\n[bold]Document reading[/bold]")
     config["max_read_tokens"] = _prompt_positive_int(
-        "Max tokens before `read_document` requires --force",
+        "Max read tokens",
         int(existing.get("max_read_tokens", DEFAULT_MAX_READ_TOKENS)),
+        help_text="An agent's `read_document` must pass --force to pull a "
+        "document larger than this many tokens.\nGuards against blowing the "
+        "context window on a huge file.",
     )
 
     save_config(config)


### PR DESCRIPTION
## Summary

The `bartleby ready` prompts were terse one-liners, and several knobs (`sparse_text_threshold`, `ocr_min_confidence`, `vision_max_dimension`/`vision_min_dimension`, `summary_depth`, `temperature`, `max_summarize_tokens`, `max_read_tokens`) are opaque without knowing the ingest pipeline. Every prompt now shows a concise, dim help line above it — orienting a newcomer without slowing a repeat run.

## Approach

- New shared `_help(text)` helper prints **dim, 2-space-indented** lines above the upcoming prompt via the existing Rich console — one mechanism, not ad-hoc prints scattered per call site.
- A required keyword-only `help_text` is threaded through the `_prompt_*` helpers; `_help(...)` is also called at the inline confirm sites (`use_llm` / `use_vision`).
- Prompt labels that had crammed-in explanation (temperature, the converters, the dimension/threshold/token knobs) are **shortened**, with the detail moved into the dim help line so the prompt label itself stays one short line.
- Self-evident prompts get a single line; tradeoff knobs get at most two.

Two small consolidations surfaced during review (both output-only):
- the two duplicated ollama-URL prompts → `_prompt_ollama_url`;
- the API-key env-var help string → defaulted inside `_prompt_api_key`, so it lives once next to the code that knows the `{provider}_api_key` field.

## Testing

- Help is **output-only** — the scripted-stdin input sequence is unchanged, so all 7 `tests/test_ready.py` cases pass untouched. Full suite: **376 passed**.
- Smoke-ran the whole wizard against a temp config (not the real `~/.bartleby/config.yaml`) to confirm each help block renders dim and directly above its prompt.

Per the issue: **no new tests** (asserting exact help strings is brittle/low-value), and **no README config-reference section** (kept in-wizard; possible follow-up).

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)