### PR TITLE
search: omit empty context_before/context_after at --add-context 0 (#101)

### DIFF
--- a/bartleby/skill_scripts/search.py
+++ b/bartleby/skill_scripts/search.py
@@ -28,6 +28,8 @@ Output:
         "chunk_index": int,
         "section_heading": str|null, "content_type": str|null,
         "text": str,
+        # context_before/context_after are present only with --add-context > 0;
+        # omitted entirely at the default --add-context 0.
         "context_before": [{"chunk_id": int, "chunk_index": int, "text": str}, ...],
         "context_after":  [{"chunk_id": int, "chunk_index": int, "text": str}, ...],
         "rank": int,                  # 1-indexed within this query's results
@@ -107,7 +109,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         dest="context",
         help=(
             "Number of neighbor chunks (0..5) to attach to each hit as "
-            "context_before/context_after. Default 0 (empty arrays). "
+            "context_before/context_after. Default 0 (keys omitted entirely). "
             "Each step roughly multiplies output size by (1 + 2N) — use sparingly."
         ),
     )
@@ -309,9 +311,10 @@ def _fetch_context(
 ) -> tuple[list[dict], list[dict]]:
     """Return neighbor chunks as {chunk_id, chunk_index, text} dicts so the
     agent can fetch a neighbor directly via ``read_chunks --chunks <id>``
-    instead of guessing the id from chunk_index ordering."""
-    if context <= 0:
-        return [], []
+    instead of guessing the id from chunk_index ordering.
+
+    Only called when ``context > 0`` — the caller omits the context keys
+    entirely at ``--add-context 0``."""
     lo = hit_index - context
     hi = hit_index + context
     rows = list(conn.cursor().execute(
@@ -403,9 +406,6 @@ def work(*, conn, args, session_id) -> dict:
     results = []
     for rank, (chunk_id, score) in enumerate(scored, start=1):
         _, source_kind, source_id, chunk_index, section_heading, content_type, text = rows[chunk_id]
-        before, after = _fetch_context(
-            conn, source_kind, source_id, chunk_index, args.context
-        )
         loc = locations.get(chunk_id, {"file_name": None, "page_number": None})
         hit = {
             "chunk_id": chunk_id,
@@ -418,12 +418,18 @@ def work(*, conn, args, session_id) -> dict:
             "section_heading": section_heading,
             "content_type": content_type,
             "text": text,
-            "context_before": before,
-            "context_after": after,
             "rank": rank,
             "score": score,
             "normalized_score": score / top_score,
         }
+        # Neighbor context is opt-in; at --add-context 0 (the triage default) the
+        # keys are omitted entirely rather than shipped as empty arrays.
+        if args.context > 0:
+            before, after = _fetch_context(
+                conn, source_kind, source_id, chunk_index, args.context
+            )
+            hit["context_before"] = before
+            hit["context_after"] = after
         if source_kind == "image":
             hit["image_id"] = source_id
             hit["image_file_path"] = image_paths.get(source_id, "")

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -119,7 +119,7 @@ Each result carries three signals you can use to triage:
 `search` results have three text fields per hit:
 
 - `text` — the chunk that matched. **Cite this chunk's `chunk_id`.**
-- `context_before` — empty by default. Populated when you pass `--add-context N`: the N chunks immediately before the hit, in document order, each as `{chunk_id, chunk_index, text}`. **Reading aid only.** Do not cite. Do not quote as if it were the hit.
+- `context_before` — **absent by default** (the key is omitted, not an empty array). Present only when you pass `--add-context N`: the N chunks immediately before the hit, in document order, each as `{chunk_id, chunk_index, text}`. **Reading aid only.** Do not cite. Do not quote as if it were the hit.
 - `context_after` — same shape, same rule.
 
 Default search returns no context — the hit text alone. Reach for `--add-context` only when chunks are short enough that the hit isn't self-explanatory; each step multiplies output size across *every* hit by roughly (1 + 2N). Once you have a `chunk_id` in hand and want context around just that one, `read_chunks --around-chunk <id> --window N` is far cheaper. If you discover the passage you actually want is in `context_before` or `context_after`, fetch it directly with `read_chunks --chunks <chunk_id>` using the neighbor's `chunk_id`, verify the text, and then cite that `chunk_id`. (Don't re-search and hope for the right hit — the neighbor's id is already in your hand.) Citations must represent chunks you've read and verified, whether they came in as a hit or as a context entry.
@@ -144,7 +144,7 @@ Two `content_type` values distinguish image chunks, and each image produces exac
 - `image_ocr` — text recovered from the image via Tesseract OCR. Used when the image is dominated by text (a slide of bullets, a screenshot of a document, a scanned page). Treat this like primary source text; cite it the same way.
 - `image_description` — the VLM's scene description. Used when the image is dominated by visual content (a chart, a photo, a diagram). **Treat this as model interpretation, not primary source.** When you cite an `image_description` chunk, make the interpretive nature explicit (e.g., "a model reading the chart's caption says X [chunk 1234]"), and lean on `read_chunks --chunks <id>` plus the image at `image_file_path` if the claim is consequential.
 
-Image chunks have empty `context_before` / `context_after` arrays — each image produces a single chunk, so there are no neighbors.
+Even with `--add-context N`, image hits come back with empty `context_before` / `context_after` arrays — each image produces a single chunk, so there are no neighbors. (At the default `--add-context 0`, the keys are omitted like everywhere else.)
 
 ## Tag rules
 

--- a/tests/test_skill_search.py
+++ b/tests/test_skill_search.py
@@ -87,17 +87,19 @@ def test_search_context_entries_resolve_via_read_chunks(seeded_project, capsys):
     assert fetched["chunks"][0]["text"] == neighbor["text"]
 
 
-def test_search_default_context_is_empty_arrays(seeded_project, capsys):
-    """Default (no --add-context) returns empty context arrays."""
+def test_search_default_context_omits_keys(seeded_project, capsys):
+    """Default (no --add-context) omits the context keys entirely rather than
+    shipping empty arrays."""
     _run([
         "--project", seeded_project["project"],
         "--full-text", "equity",
     ])
     out = json.loads(capsys.readouterr().out)
     assert out["context"] == 0
+    assert out["results"]  # sanity: there are hits to check
     for r in out["results"]:
-        assert r["context_before"] == []
-        assert r["context_after"] == []
+        assert "context_before" not in r
+        assert "context_after" not in r
 
 
 def test_search_context_clamps_at_source_boundary(seeded_project, capsys):


### PR DESCRIPTION
Closes #101.

Every `search` hit shipped `context_before`/`context_after` arrays even at the default `--add-context 0`, where they're always empty — pure noise on the most frequent (triage) call, on top of the full chunk `text` each hit already carries. Now the keys are **omitted entirely** unless `--add-context > 0`.

## Change

- In the hit-construction loop, the `_fetch_context` call and the two `hit[...]` assignments are gated on `args.context > 0`. The now-redundant `context <= 0` early-return inside `_fetch_context` is dropped — its sole caller owns the gating (a docstring note records the precondition).
- Docs tracked to the new shape: the `Output:` docstring, the `--add-context` help text, and `skill/SKILL.md` (including the image-hit note, which now clarifies that image hits return empty context arrays only *with* `--add-context > 0`).
- `test_search_default_context_omits_keys` (renamed from `..._is_empty_arrays`) now asserts the keys are **absent**, with a sanity check that there are hits to inspect.

Per the no-backwards-compat agreement, the shape just changes — no flag preserves the empty arrays.

## Tests

Full suite **395 passing**. The `--add-context > 0` tests are unaffected (context still attaches as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)