### PR TITLE
Add CONTRIBUTING.md documenting the Claude-assisted workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,133 @@
+# Contributing
+
+Hello! This file is the short story of *how* Bartleby gets built, mostly aimed at
+the small circle of people who hack on it — and at anyone curious enough to look
+under the hood. It's a description of how we work, not a contract. If something
+here is unclear or seems wrong, that's a bug in this doc; say so.
+
+The one-sentence version: **we build Bartleby hand-in-hand with [Claude
+Code](https://claude.com/claude-code), and the workflow that makes that pleasant
+is version-controlled right in the repo** — so you inherit it for free.
+
+## How we build Bartleby
+
+Open the repo in Claude Code and the project's tooling loads automatically. There's
+nothing to install and nothing to copy: the `.claude/` directory ships in the repo,
+so a fresh clone already has the skills, the safety hook, and the helper agents we
+use day to day. (This is deliberate — see [#130](https://github.com/jswest/bartleby/issues/130)
+for when we version-controlled it.)
+
+You don't *have* to use any of this. Plain `git` and a text editor work fine, and
+the manual version of the loop is spelled out below. But if you're driving Claude,
+the tooling encodes the conventions so you don't have to keep them all in your head.
+
+## What's in `.claude/`
+
+| Piece | What it does |
+| --- | --- |
+| `skills/ship/SKILL.md` | The `/ship #<N>` command — runs an issue end-to-end into a tested PR (the loop below). |
+| `hooks/guard-main-write.sh` | A safety rail that refuses commits/pushes on `main`. |
+| `agents/simplify-refactor.md` | A subagent that does a quality/simplification pass over changed code. |
+| `agents/git-workflow-manager.md` | A subagent that turns a pile of changes into clean, atomic commits. |
+| `settings.json` | Wires the hook in. |
+
+The `.gitignore` is set up so exactly those shared pieces are tracked; the personal
+and transient bits (`settings.local.json`, `scratch/`, `worktrees/`, `agent-memory/`)
+stay out of version control. So your local experiments don't end up in everyone
+else's clone.
+
+## The everyday loop: `/ship #<N>`
+
+Almost all work starts from a GitHub issue and ends as a PR that closes it. Typing
+`/ship #141` walks Claude through this, in order:
+
+1. **Sync `main`** and make sure the tree is clean.
+2. **Create a sibling worktree** for the issue — `../bartleby-issue-<N>-<slug>` on a
+   branch `issue/<N>-<slug>`. We work in worktrees *next to* the main checkout,
+   never nested inside it, and never `git checkout -b` on `main` itself.
+3. **PAUSE — plan.** For anything non-trivial, Claude lays out the plan (files,
+   approach, trade-offs) and waits for your OK before writing code.
+4. **Implement in logical units.** For *every* commit, in this exact order:
+   `uv run pytest` (must pass) → run the `simplify-refactor` agent over the touched
+   files → apply the suggestions worth taking → re-run the tests → commit.
+5. **Docs sweep.** Check whether the change needs README / `ARCHITECTURE.md` /
+   `SKILL.md` updates (a new flag, changed behavior, a decision-log entry).
+6. **Reconcile** with `origin/main` so any merge conflict surfaces now, not in the PR,
+   then run the full test suite again.
+7. **PAUSE — PR.** Claude shows you the PR body and a final diff summary and waits
+   for your OK, then opens a PR with a `Closes #<N>` line.
+
+**Claude opens the PR; a human merges it.** That last step is always ours.
+
+The two **PAUSE** points are real stops — Claude won't blow past them without your
+say-so. They're where you catch a wrong approach before it's code, and a wrong PR
+before it's public.
+
+### The guard rail
+
+The `guard-main-write.sh` hook blocks `git commit` and `git push` whenever the
+branch is `main`. This is **intentional, not a bug.** If you hit
+`BLOCKED: refusing 'git commit'…`, it means you're on the wrong branch — switch to
+your issue's worktree branch and try again. (Step 2 above keeps you out of this;
+the hook is the backstop for when something slips.)
+
+### `with-playwright` (web changes only)
+
+For changes under `bartleby/web/`, you can append a `with-playwright` token —
+`/ship #<N> with-playwright` — to turn on a visual-verification loop: Claude drives
+a real browser, screenshots the affected routes before and after, and iterates on
+what looks wrong. It's **off by default** because browser automation is slow and
+burns image tokens, so you opt in per run when a change is actually worth eyeballing.
+Backend-only issues ignore the token even if you pass it.
+
+### The helper agents
+
+Two subagents do focused jobs so the main thread stays on the problem:
+
+- **`simplify-refactor`** — a quality pass: hunts duplication, needless abstraction,
+  and bloat in the code you just touched. It's about clarity, not correctness; it's
+  part of every commit's gate above.
+- **`git-workflow-manager`** — groups changes into small, clearly-messaged,
+  single-concern commits when a change has gotten tangled.
+
+## Working agreements
+
+The full set of invariants and the decision log live in
+[`ARCHITECTURE.md`](./ARCHITECTURE.md) — read that before changing anything
+load-bearing. The two that shape day-to-day work most:
+
+- **No backwards compatibility, by default.** We delete old code rather than leaving
+  dormant compat shims or feature-flagged old paths. The one sanctioned exception is
+  *additive-only* schema upgrades (new tables, indexes, nullable columns), which ship
+  with an entry in `bartleby/db/upgrades.py` so existing corpora can `bartleby project
+  upgrade` instead of re-ingesting.
+- **Schema bumps mean re-ingest.** A non-additive schema change bumps `SCHEMA_VERSION`
+  and tells users to re-ingest; there's no automatic migration for those. (This is also
+  why the release version's *minor* number is the schema version — see the README.)
+
+## Running the tests
+
+```
+uv run pytest
+```
+
+That's the whole suite. The per-commit gate above runs it before and after every
+change; run it yourself anytime.
+
+## Cutting a release
+
+Releases are a deliberate, batched act on `main` after a few changes have landed —
+not something done per-PR. The mechanics live in
+[`scripts/release.py`](./scripts/release.py) (dry-run first, then `--tag --push`),
+and the consumer side — pinning to and upgrading between releases — is documented in
+the README under [Pinning to a release](./README.md#pinning-to-a-release) and
+[Upgrading from a release](./README.md#upgrading-from-a-release).
+
+## A note for non-Claude contributors
+
+None of this requires Claude. The loop is just good hygiene: branch in a worktree,
+keep commits atomic and tested, run `uv run pytest` before you commit, open a PR that
+closes the issue, and let someone else merge it. `/ship` automates the bookkeeping;
+it doesn't replace your judgment. A machine-readable companion to this file — a
+repo-root `CLAUDE.md` that Claude auto-loads — is on its way
+([#140](https://github.com/jswest/bartleby/issues/140)).

--- a/README.md
+++ b/README.md
@@ -500,6 +500,17 @@ See [`./skill/README.md`](./skill/README.md) for the full story.
 
 ---
 
+## Contributing
+
+Bartleby is built hand-in-hand with Claude Code, and the workflow that makes that
+work — the `/ship` issue→PR loop, the worktree convention, the commit gates, the
+safety hook — is version-controlled right in the repo. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for how we develop here (and how to do it by
+hand if you'd rather). Architectural invariants and the decision log live in
+[`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+---
+
 ## License
 
 MIT.


### PR DESCRIPTION
## What

Adds a `CONTRIBUTING.md` that tells a human reader how Bartleby actually gets built — the Claude-assisted workflow the repo already ships in `.claude/` but never explained — plus a `## Contributing` pointer in the README.

## Why

Version-controlling `.claude/` (#130/#133) and extending `/ship` (#136/#139) put a real, opinionated dev workflow in-tree, but a fresh clone inherits the `/ship` skill, the `guard-main-write` hook, and the helper agents silently, with no map. `ARCHITECTURE.md` documents the *code*; the README is the *user* manual; neither covers the *process*.

## What's in it

Friendly, inner-circle narrative (not a formal CLA-style contract):

- **How we build Bartleby** + a tour of `.claude/` (ship skill, guard hook, simplify-refactor / git-workflow-manager agents, settings.json) and what the `.gitignore` tracks vs. ignores.
- **The `/ship #<N>` loop** — sync → sibling worktree → plan PAUSE → per-commit gates (pytest → simplify-refactor → re-test → commit) → docs sweep → reconcile → PR PAUSE → `Closes #<N>`. Claude opens the PR; a human merges.
- **The guard rail**, the opt-in **`with-playwright`** flag, the **helper agents**.
- **Working agreements** (no-backwards-compat + additive-upgrade exception; schema bump → re-ingest) — cross-linked to `ARCHITECTURE.md`, not duplicated.
- **`uv run pytest`**, a **release** pointer, and a **by-hand path** for non-Claude contributors.

## Scope

Docs only — no behavior, no tests affected (`uv run pytest` green, 433 passed). The machine-facing repo-root `CLAUDE.md` is scoped out to #140. Cross-links rather than restating `ARCHITECTURE.md` / README / the skill so the doc doesn't drift.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)