### PR TITLE
Extend simplify-refactor to police CLAUDE.md bloat

### DIFF
--- a/.claude/agents/simplify-refactor.md
+++ b/.claude/agents/simplify-refactor.md
@@ -47,6 +47,26 @@ Now get into the details:
 - Reduce nesting depth. Prefer early returns and guard clauses.
 - Use language-appropriate idioms rather than generic patterns.
 
+### Instruction-File Bloat
+When the touched files include `CLAUDE.md`, apply the same "every line must earn
+its place" lens to its prose — instruction files accrete a line per incident and
+nobody pushes back. Flag and propose tightening for:
+- Redundancy or duplication within the file (two lines saying the same thing).
+- Rules already covered elsewhere (`ARCHITECTURE.md`, the decision log, the global
+  `CLAUDE.md`).
+- Verbose phrasing that could be said in fewer words.
+- Stale entries describing code or conventions that no longer exist.
+
+**Load-bearing guardrail:** unlike code, deleting a line here can silently remove
+an instruction the agent relies on. Tighten wording and dedupe; **never drop an
+actual rule or constraint just because it could be shortened.** Preserve meaning — when
+in doubt, flag the line as a question rather than cutting it.
+
+The same applies to other agent-facing instruction docs (`SKILL.md`,
+`CONTRIBUTING.md`), but `CLAUDE.md` is the primary target — don't turn this into
+general prose editing. And like all your findings, these stay advisory: surfaced
+for the human to accept or reject, never auto-applied.
+
 ## Anti-Patterns to Eliminate
 
 Actively hunt for and remove:


### PR DESCRIPTION
`CLAUDE.md` is loaded into every session's context, so bloat there is paid on every turn — and instruction files accrete a line per incident with nothing pushing back. The `simplify-refactor` agent already runs at every `/ship` commit gate and its creed is "every line must earn its place," but it's framed as code-only, so it never applies that lens to `CLAUDE.md`.

This adds an **Instruction-File Bloat** subsection to the agent: when `CLAUDE.md` is among the touched files, flag redundancy, rules already covered elsewhere (`ARCHITECTURE.md`, decision log, global `CLAUDE.md`), verbose phrasing, and stale entries.

**Load-bearing guardrail:** deleting a line here can silently remove an instruction the agent relies on — so the note forbids dropping any actual rule just because it could be shortened; tighten wording, preserve meaning, flag ambiguous cuts as questions. Scope extends to `SKILL.md`/`CONTRIBUTING.md` with `CLAUDE.md` primary; findings stay advisory.

_Tests skipped — docs-only diff (instruction-file change, no code touched)._

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)