### PR TITLE
Single-source the four overlapping config/scribe definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Interactive configuration wizard. Asks for:
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| LLM provider | anthropic | `anthropic`, `openai`, or `ollama` |
+| LLM provider | anthropic | `anthropic`, `openai`, or `ollama` (plus `wsjpt`, WSJ-internal) |
 | Model | varies by provider | Model name (e.g., `claude-haiku-4-5`, `gpt-5-mini`, `qwen3-vl:30b`) |
 | API key | — | Required for Anthropic/OpenAI; can also use env vars |
 | Summary depth | `one-shot` | `none` or `one-shot` |
@@ -301,7 +301,7 @@ Interactive configuration wizard. Asks for:
 | HTML converter | `docling` | `docling` (default; also handles `.md`) or `sec2md` (routes iXBRL EDGAR filings to sec2md, other HTML to docling) |
 | Sparse-text threshold | 100 | Pages with fewer extracted chars are treated as scanned; OCR then VLM fallback |
 | Parse workers | auto | How many documents to parse in parallel. `0` = auto (`min(CPU cores, free RAM ÷ ~2.5 GB)`); raise for a faster bulk ingest on a big machine, lower if memory is tight |
-| Vision provider | (off) | Off by default; opt in during the wizard. If enabled, choose `anthropic`, `openai`, or `ollama` |
+| Vision provider | (off) | Off by default; opt in during the wizard. If enabled, choose `anthropic`, `openai`, or `ollama` (plus `wsjpt`, WSJ-internal) |
 | Vision model | varies by provider | e.g., `claude-haiku-4-5`, `gpt-5-mini`, `qwen3-vl:30b` |
 | Max image dimension | 768 | Long-edge pixels before sending an image to the VLM |
 | Tesseract min confidence | 30 | Avg confidence (0-100) below which we fall back to the VLM on sparse pages |

--- a/bartleby/cli.py
+++ b/bartleby/cli.py
@@ -1,6 +1,16 @@
 import argparse
 import sys
 
+# Cheap, dependency-free constants — safe to import at module load (and thus at
+# parser-build time) without pulling the provider package's pydantic cost into
+# every `bartleby` invocation. These keep scribe's `choices=` in lockstep with
+# what the config wizard accepts.
+from bartleby.lib.consts import (
+    ALLOWED_HTML_CONVERTERS,
+    ALLOWED_PDF_CONVERTERS,
+    ALLOWED_PROVIDERS,
+)
+
 
 def main():
     # `bartleby skill <name> [args]` bypasses argparse so we can pass the
@@ -82,16 +92,16 @@ def main():
     scribe_parser.add_argument("--model", type=str, default=None)
     scribe_parser.add_argument(
         "--provider", type=str,
-        choices=["anthropic", "openai", "ollama"], default=None,
+        choices=ALLOWED_PROVIDERS, default=None,
     )
     scribe_parser.add_argument(
         "--pdf-converter", type=str,
-        choices=["pdfplumber", "docling"], default=None,
+        choices=ALLOWED_PDF_CONVERTERS, default=None,
         help="PDF converter; overrides pdf_converter in ~/.bartleby/config.yaml.",
     )
     scribe_parser.add_argument(
         "--html-converter", type=str,
-        choices=["docling", "sec2md"], default=None,
+        choices=ALLOWED_HTML_CONVERTERS, default=None,
         help=(
             "HTML converter; overrides html_converter in ~/.bartleby/config.yaml. "
             "'sec2md' routes iXBRL EDGAR filings to sec2md and other HTML to docling."

--- a/bartleby/commands/config.py
+++ b/bartleby/commands/config.py
@@ -6,6 +6,8 @@ from rich.prompt import Confirm, FloatPrompt, IntPrompt, Prompt
 
 from bartleby.config import CONFIG_PATH, load_config, save_config
 from bartleby.lib.consts import (
+    ALLOWED_HTML_CONVERTERS,
+    ALLOWED_PDF_CONVERTERS,
     DEFAULT_CAPTION_WORKERS,
     DEFAULT_HTML_CONVERTER,
     DEFAULT_OCR_MIN_CONFIDENCE,
@@ -17,8 +19,6 @@ from bartleby.lib.consts import (
 from bartleby.providers import ALLOWED_PROVIDERS
 
 ALLOWED_SUMMARY_DEPTHS = ["none", "one-shot"]
-ALLOWED_PDF_CONVERTERS = ["pdfplumber", "docling"]
-ALLOWED_HTML_CONVERTERS = ["docling", "sec2md"]
 
 PROVIDER_DEFAULT_MODEL = {
     "anthropic": "claude-haiku-4-5",

--- a/bartleby/lib/consts.py
+++ b/bartleby/lib/consts.py
@@ -22,9 +22,16 @@ DOCLING_HF_REPOS = (
     "docling-project/docling-models",
 )
 
-# Ingest conversion / vision defaults, shared by the `ready` wizard (which
-# writes them into config) and `scribe` (which falls back to them when a knob
-# is absent from config). Keep the two in lockstep by sourcing both from here.
+# Ingest conversion / vision knobs shared by the `config` wizard (which writes
+# them into config) and `scribe` (which falls back to the DEFAULT_* values when a
+# knob is absent, and whose argparse `choices=` are built from the ALLOWED_*
+# lists). Sourcing both surfaces from here keeps them in lockstep — the values
+# scribe accepts can never drift from the ones the wizard validates. This module
+# imports nothing, so `cli.py` can read these at parser-build time without paying
+# the provider package's pydantic import cost on every invocation.
+ALLOWED_PROVIDERS = ("anthropic", "openai", "ollama", "wsjpt")
+ALLOWED_PDF_CONVERTERS = ["pdfplumber", "docling"]
+ALLOWED_HTML_CONVERTERS = ["docling", "sec2md"]
 DEFAULT_PDF_CONVERTER = "pdfplumber"
 DEFAULT_HTML_CONVERTER = "docling"
 DEFAULT_SPARSE_TEXT_THRESHOLD = 100

--- a/bartleby/providers/__init__.py
+++ b/bartleby/providers/__init__.py
@@ -6,11 +6,10 @@ text. Adding a fourth provider means writing one class plus an entry here.
 
 from __future__ import annotations
 
+from bartleby.lib.consts import ALLOWED_PROVIDERS
 from bartleby.providers.base import (
     DocumentSummary, ImageAnalysis, Provider, VlmDescription,
 )
-
-ALLOWED_PROVIDERS = ("anthropic", "openai", "ollama", "wsjpt")
 
 
 def get_provider(name: str, *, ollama_base_url: str | None = None) -> Provider:


### PR DESCRIPTION
Part of #169.

Closes the duplication called out in #175: scribe's `--provider` / `--pdf-converter` / `--html-converter` `choices=` were hardcoded in `cli.py` while `commands/config.py` validated against its own copies. The lists had already drifted — scribe's `--provider` omitted `wsjpt`, so a corpus configured with `provider: wsjpt` could ingest via the persisted default but **not** via the per-run override (argparse rejected `--provider wsjpt` before any provider code ran).

The three choice lists now live once, in the dependency-free `bartleby/lib/consts.py`, next to the converter defaults. `cli.py` builds its `choices=` from them; the wizard validates against them — the two surfaces can no longer disagree. `consts` imports nothing, so `cli.py` keeps its pydantic-free startup; `bartleby.providers` re-exports `ALLOWED_PROVIDERS` for its own callers.

Also documents the `wsjpt` provider in the config-wizard README tables (a terse WSJ-internal parenthetical), which previously listed only three providers though the wizard already accepted four.

Per the #175 decision: **kept both surfaces**, no registry, no new per-run overrides, no surface collapse — just one definition per setting.

## Verification
- `uv run pytest` → `488 passed`.
- `bartleby scribe --provider wsjpt …` now clears argparse (the live bug); `--help` lists all four providers.
- `import bartleby.cli` pulls in zero pydantic — startup stays light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)