### PR TITLE
Close the /ship omnibus loop: tracking update + promotion mode (#191)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Implement a GitHub issue end-to-end the way this repo expects: sync the base
   branch, sibling worktree, pre-commit gates, conflict reconciliation, and a PR
   that closes the issue. Invoke as `/ship #<N>` (or `/ship <N>`); add `onto
-  #<omnibus>` to ship onto an omnibus branch instead of `main`. Use whenever
-  asked to ship, implement, or do a numbered issue in bartleby.
+  #<omnibus>` to ship onto an omnibus branch instead of `main`, or pass an omnibus
+  issue alone to open its promotion PR to `main`. Use whenever asked to ship,
+  implement, or do a numbered issue in bartleby.
 ---
 
 # ship — issue → tested PR
@@ -14,7 +15,9 @@ Argument is one GitHub issue number (`#118`, `118`), optionally followed by any
 of three opt-in tokens — `onto #<omnibus>`, `with-playwright`, and `skip-tests`
 (e.g. `/ship #134 with-playwright`, `/ship #170 onto #169 skip-tests`, in any
 order) — see below. Run the steps in order. Two hard stops are marked **PAUSE**:
-do not pass them without the user's OK.
+do not pass them without the user's OK. One exception: if the lone issue is itself
+an *omnibus issue* (no `onto`), `/ship` runs **omnibus-promotion mode** — opening
+the omnibus → `main` PR instead of implementing anything (see below).
 
 Throughout, **base** is the integration branch this issue targets: `main` by
 default, or the omnibus branch when `onto #<omnibus>` is given (see below).
@@ -64,6 +67,34 @@ branch name. When present:
   PRs.)
 - The guard hook still protects `main` only; the omnibus branch is not
   hook-protected. Composes with `with-playwright` and `skip-tests`.
+
+**Omnibus-promotion mode (`/ship #<omnibus>`, no `onto`).** When the lone argument
+is itself an *omnibus issue* — its title parses as `vX.Y.Z — …` **and** an
+`omnibus/vX.Y.Z` branch exists with commits ahead of `origin/main` — `/ship`
+implements nothing (the bundle already landed on that branch). It opens the
+**omnibus → `main` PR** that promotes the whole bundle. If the title looks
+omnibus-shaped but the branch is missing or not ahead of `main`, **report and
+stop** — don't guess. The flow is reduced:
+- **Steps 1–2 only.** Preconditions (clean main) and sync (`git fetch origin`, ff
+  `main`). **No worktree, no code, no per-commit gates, no reconcile** — steps
+  3–10 are N/A.
+- **Build the `Closes` enumeration.** Take the bundle's issue numbers from the
+  omnibus issue's sub-issue checklist, then **reconcile against the sub-PRs
+  actually merged into the branch**
+  (`gh pr list --base omnibus/vX.Y.Z --state merged --json number,title`, cross-
+  checked with `git log origin/main..origin/omnibus/vX.Y.Z`). Emit `Closes #<N>`
+  for every sub-issue whose work is on the branch. If the checklist and the
+  merged-PR set disagree, **report the discrepancy** and let the user reconcile — a
+  hand-edit slip must not silently add or drop a `Closes`.
+- **PAUSE — PR (step 11).** Same PAUSE contract as step 11, but the body is the
+  `Closes #<N>` list + a one-line bundle summary and the diff is `git diff --stat
+  origin/main...origin/omnibus/vX.Y.Z`. Then `gh pr create --base main --head
+  omnibus/vX.Y.Z`. **Do not merge** — the human merge auto-closes the whole bundle
+  (every sub-issue and the omnibus issue).
+- **Cleanup (step 12).** After the user confirms the merge, there's no worktree to
+  remove; just `git pull --ff-only origin main` in the main checkout. Cutting the
+  release is the separate, later `/release` act on `main` — promotion PR → human
+  merge → `/release`, never folded into this step.
 
 **Optional `with-playwright`.** The argument may carry a `with-playwright` token
 after the issue number (only that exact token). It turns on a visual-verification

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -50,6 +50,18 @@ branch name. When present:
   **"Part of #<omnibus>"** with **no `Closes` keyword**; sub-issues close when the
   omnibus → main PR (which enumerates `Closes #<N>` for the bundle) merges. Do not
   put `Closes #<N>` on a sub-PR in this mode.
+- **Keep the omnibus issue's tracking current.** Promotion mode draws its `Closes
+  #<N>` manifest from the omnibus issue's hand-curated sub-issue checklist, which
+  drifts unless each sub-ship updates it. So when the sub-PR is opened (step 11),
+  edit the omnibus issue (`#<omnibus>`) to reflect this landing: tick this issue's
+  box `[ ]→[x]`, annotate it with the sub-PR number and target in the existing
+  style (`— … (#NNN)`), and flip any dependency/order marker the omnibus tracks.
+  **Edit only the one checklist line, by anchored match** — never free-form rewrite
+  the hand-curated body — and show the proposed issue diff at the step-11 PAUSE next
+  to the PR draft. If the omnibus issue has no checklist line referencing `#<N>`,
+  **report it and leave the body untouched** rather than invent tracking. (Ticking
+  on sub-PR-open is safe — promotion reconciles `Closes` against actually-merged
+  PRs.)
 - The guard hook still protects `main` only; the omnibus branch is not
   hook-protected. Composes with `with-playwright` and `skip-tests`.
 
@@ -168,7 +180,8 @@ origin/<base>...HEAD`) and wait for their OK. Then push and `gh pr create`.
 - Normal case: target `main` (the default) with a `Closes #<N>` line.
 - Under `onto`: pass `--base <omnibus-branch>`, and write **"Part of #<omnibus>"**
   with **no `Closes`** (see the flag note) — the sub-issue closes at the omnibus →
-  main merge, not here.
+  main merge, not here. Also show and apply the omnibus-issue tracking edit here
+  (see *Keep the omnibus issue's tracking current*).
 
 ## 12. Cleanup (only after the user confirms the merge)
 From the main checkout: `git worktree remove ../bartleby-issue-<N>-<slug>`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,9 +114,19 @@ new long-lived branch. From there the whole loop retargets from `main` to the
 omnibus branch: worktree base, collision scan, reconcile, and PR base. The sub-PR
 says *"Part of #169"* rather than `Closes #170`, because GitHub only auto-closes
 from the default branch; the sub-issues all close when the omnibus → main PR (which
-lists every `Closes #<N>`) finally merges. The `main`-only guard rail is unchanged,
-so the omnibus branch itself isn't hook-protected — keeping work on sub-PRs is
-discipline, not enforcement. Composes with the two tokens above.
+lists every `Closes #<N>`) finally merges. As it opens that sub-PR, Claude ticks
+the issue's box on the omnibus checklist and notes the PR number, so the bundle's
+tracking stays current instead of drifting. The `main`-only guard rail is
+unchanged, so the omnibus branch itself isn't hook-protected — keeping work on
+sub-PRs is discipline, not enforcement. Composes with the two tokens above.
+
+When the bundle is ready, `/ship #169` — the omnibus issue **on its own, no
+`onto`** — opens that omnibus → main PR. Claude recognizes the omnibus issue (a
+`vX.Y.Z — …` title with a branch ahead of `main`), skips the implement machinery —
+the work already landed on the branch — and drafts the PR with a `Closes #<N>`
+line for every sub-issue, cross-checked against the PRs actually merged onto the
+branch. You approve and merge it; that one merge closes the whole bundle. Cutting
+the release is the later, separate `/release` step.
 
 ### The helper agents
 


### PR DESCRIPTION
**Part of #169.**

Closes the `/ship` omnibus loop at both ends (#191):

- **Producing end** (`onto #<omnibus>`): when the sub-PR opens at step 11, `/ship` also updates the omnibus issue's checklist — tick the box, annotate with the sub-PR number/target, flip dependency markers — by anchored single-line edit, shown for approval at the same PAUSE. Reports and leaves the body untouched if there's no checklist line for the sub-issue.
- **Consuming end** (`/ship #<omnibus>`, no `onto`): new omnibus-promotion mode — detects an omnibus issue (`vX.Y.Z — …` title + branch ahead of `main`), skips the implement machinery, opens the omnibus → `main` PR enumerating `Closes #<N>` from the checklist reconciled against the PRs actually merged on the branch.
- `CONTRIBUTING.md` updated to match.

Tests skipped — docs-only diff (`SKILL.md` + `CONTRIBUTING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
