### PR TITLE
Drop bartleby/web/ from the /ship skip-tests guard (#195)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -77,19 +77,24 @@ omitted when **either** of these holds — evaluate both against
    can't be affected, so the gates skip on their own; no `skip-tests` token needed.
 2. **`skip-tests` token (opt-in).** The argument carries the `skip-tests` token
    (only that exact token) **and** the diff touches no test-affecting source — no
-   `*.py`, no `pyproject.toml`, no file under `bartleby/web/`. The token is a
-   convenience for work that's docs-adjacent but falls outside the path-1 set (e.g.
-   a top-level `.sh` script or a `.txt` asset), **not** a way to land untested code. If the token
-   is present but the diff *does* touch test-affecting source, **ignore the token
-   and run the tests anyway**, and say why ("`skip-tests` requested but the diff
-   changes `bartleby/commands/ready.py` — running tests anyway").
+   `*.py` and no `pyproject.toml`. The token is a convenience for work that's
+   test-irrelevant but falls outside the path-1 docs set: a frontend-only change
+   under `bartleby/web/` (Svelte/CSS/vite config — that tree holds no Python), a
+   top-level `.sh` script, a `.txt` asset. It is **not** a way to land untested
+   code. If the token is present but the diff *does* touch `*.py` or
+   `pyproject.toml`, **ignore the token and run the tests anyway**, and say why
+   ("`skip-tests` requested but the diff changes `bartleby/commands/ready.py` —
+   running tests anyway"). One accepted gap: a *structural* `bartleby/web/` change
+   (move `src/`, drop `package.json`) can still fail the Python suite via
+   `tests/test_serve.py`, which asserts the packaged UI layout — `skip-tests` won't
+   catch that, so don't pair the token with a web restructure.
 
 Re-check **both** paths at **each** gate, not just once: a docs PR that grows a
 code change mid-stream must start running tests from that point, and a diff that
 narrows back to docs-only resumes path-1 skipping (token or not). When tests are genuinely skipped,
 **say so** in the step-11 PR summary and the final report, naming the path —
-"Tests skipped — docs-only diff" (path 1) or "Tests skipped — `skip-tests`, diff
-touches no code" (path 2) — so a skipped suite never reads as a green one. The
+"Tests skipped — docs-only diff" (path 1) or "Tests skipped — `skip-tests`, no
+`.py`/`pyproject.toml` touched" (path 2) — so a skipped suite never reads as a green one. The
 simplify-refactor pass (step 8) still runs regardless.
 
 ## 1. Preconditions
@@ -139,8 +144,8 @@ Work in logical units. If `with-playwright` is active, bracket each web-touching
 unit with before/after screenshots (see the flag note above). For **every**
 code-producing commit, in this exact order:
 1. `uv run pytest` — must pass. (Skipped when either skip path holds — a docs-only
-   diff or `skip-tests` with no code touched; see the "Skipping the pytest gates"
-   note above and re-check both paths here.)
+   diff or `skip-tests` with no `.py`/`pyproject.toml` touched; see the "Skipping
+   the pytest gates" note above and re-check both paths here.)
 2. Run the `simplify-refactor` agent against the just-touched files.
 3. Apply the suggestions you agree with; push back on the rest.
 4. Re-run `uv run pytest` — must still pass. (Same skip condition as 1.)
@@ -157,7 +162,7 @@ documentation set keeps a diff docs-only, so path 1 still skips).
 Bring the branch up to date so conflicts surface here, not in the PR:
 `git fetch origin && git merge origin/<base>` (or rebase). Resolve any conflicts,
 then run the **full** suite (`uv run pytest`) again — unless either skip path
-still holds (docs-only diff, or `skip-tests` with no code touched). Re-run the same
+still holds (docs-only diff, or `skip-tests` with no `.py`/`pyproject.toml` touched). Re-run the same
 `origin/<base>...HEAD` check from the flag note; because it's three-dot (the diff
 since the merge-base), merging `origin/<base>` in doesn't change what it sees.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ what looks wrong. It's **off by default** because browser automation is slow and
 burns image tokens, so you opt in per run when a change is actually worth eyeballing.
 Backend-only issues ignore the token even if you pass it.
 
-### Skipping the test gates (docs-only changes)
+### Skipping the test gates
 
 The `uv run pytest` runs that otherwise gate every commit are skipped down two
 paths — both a convenience for diffs that can't affect tests, **not** a way to land
@@ -91,11 +91,15 @@ untested code:
   `LICENSE`, or under `docs/` — README wording, an `ARCHITECTURE.md` note, a
   `SKILL.md` tweak — Claude skips the gates on its own. A pure prose change can't
   move the suite, so there's nothing to gate and no token to remember.
-- **`skip-tests` — opt-in, for docs-adjacent files outside that set.** For a change
-  that's still test-irrelevant but touches something other than docs (a shell
-  script, a `.txt` asset), append a `skip-tests` token (`/ship #<N> skip-tests`).
-  Claude honors it only when the branch diff touches no `*.py`, `pyproject.toml`, or
-  `bartleby/web/` file — otherwise it runs the tests anyway and tells you why.
+- **`skip-tests` — opt-in, for test-irrelevant files outside that set.** For a change
+  that can't affect the suite but touches something other than docs — a frontend-only
+  edit under `bartleby/web/` (that tree is all Svelte/vite, no Python), a shell
+  script, a `.txt` asset — append a `skip-tests` token (`/ship #<N> skip-tests`).
+  Claude honors it only when the branch diff touches no `*.py` or `pyproject.toml`
+  file — otherwise it runs the tests anyway and tells you why. (One caveat: a
+  *structural* `bartleby/web/` change (moving `src/`, dropping `package.json`) can
+  still break the Python suite via `tests/test_serve.py`, which checks the packaged
+  UI layout — don't `skip-tests` a web restructure.)
 
 Either way, Claude re-checks at every gate, so a docs PR that grows a code change
 mid-stream starts running tests from that point. When tests are genuinely skipped,


### PR DESCRIPTION
## What

The `skip-tests` token (path 2 of the skip-the-gates logic) forced the full
`uv run pytest` suite on any `bartleby/web/` touch — even though that tree is
all Svelte/vite with no Python. This narrows the guard: `skip-tests` is now
honored on a web-only diff that touches no `*.py` / `pyproject.toml`, so a
frontend-only change no longer drags in the Python suite.

`pyproject.toml` stays in the tests-forcing set (a dep/config bump is genuinely
test-affecting); only `bartleby/web/` was removed.

## Accepted trade-off

A *structural* `bartleby/web/` change (move `src/`, drop `package.json`) can
still fail `tests/test_serve.py`, which asserts the packaged UI layout. The
guard can't tell that from a cosmetic edit, so the rule is documented in both
files: don't pair `skip-tests` with a web restructure. Judged acceptable —
such changes are rare, `skip-tests` is opt-in, and the say-so flags the skip.

## Changes
- `.claude/skills/ship/SKILL.md` — drop `bartleby/web/` from path 2's guard;
  add the frontend-only example + the `test_serve.py` caveat; retarget the
  "no code touched" phrasings (steps 8/10 + path-2 say-so) to the now-accurate
  "no `.py`/`pyproject.toml`".
- `CONTRIBUTING.md` — mirror the narrowed behavior; drop the stale
  "(docs-only changes)" subhead since path 2 now covers non-docs files.

## Tests
Tests skipped — docs-only diff (path 1). No code touched.

Part of #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)