### PR TITLE
Sync contributor process docs with the current /ship workflow (#199)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,23 +42,31 @@ else's clone.
 Almost all work starts from a GitHub issue and ends as a PR that closes it. Typing
 `/ship #141` walks Claude through this, in order:
 
-1. **Sync `main`** and make sure the tree is clean.
+1. **Sync `main`, check the tree is clean, and scan for collisions** — a quick look
+   at the other open worktrees and PRs so you can spot overlapping in-flight work on
+   the same files and coordinate before two branches diverge.
 2. **Create a sibling worktree** for the issue — `../bartleby-issue-<N>-<slug>` on a
    branch `issue/<N>-<slug>`. We work in worktrees *next to* the main checkout,
    never nested inside it, and never `git checkout -b` on `main` itself.
-3. **PAUSE — plan.** For anything non-trivial, Claude lays out the plan (files,
+3. **Flesh out a thin issue.** If the body is empty or sketchy, Claude writes a
+   problem/approach/scope back to it with `gh issue edit` before touching code — so
+   the plan has something concrete to anchor to.
+4. **PAUSE — plan.** For anything non-trivial, Claude lays out the plan (files,
    approach, trade-offs) and waits for your OK before writing code.
-4. **Implement in logical units.** For *every* commit, in this exact order:
-   `uv run pytest` (must pass) → run the `simplify-refactor` agent over the touched
-   files → apply the suggestions worth taking → re-run the tests → commit.
-5. **Docs sweep.** Check whether the change needs README / `ARCHITECTURE.md` /
+5. **Implement in logical units.** For *every* commit, in this exact order:
+   `uv run pytest` (must pass — except down the two [skip paths](#skipping-the-test-gates)
+   below) → run the `simplify-refactor` agent over the touched files → apply the
+   suggestions worth taking → re-run the tests → commit.
+6. **Docs sweep.** Check whether the change needs README / `ARCHITECTURE.md` /
    `SKILL.md` updates (a new flag, changed behavior, a new `docs/decisions/` entry).
-6. **Reconcile** with `origin/main` so any merge conflict surfaces now, not in the PR,
+7. **Reconcile** with `origin/main` so any merge conflict surfaces now, not in the PR,
    then run the full test suite again.
-7. **PAUSE — PR.** Claude shows you the PR body and a final diff summary and waits
+8. **PAUSE — PR.** Claude shows you the PR body and a final diff summary and waits
    for your OK, then opens a PR with a `Closes #<N>` line.
 
-**Claude opens the PR; a human merges it.** That last step is always ours.
+**Claude opens the PR; a human merges it.** That last step is always ours. Once
+you've merged, Claude closes the loop — removing the sibling worktree, deleting the
+issue branch, and re-syncing the base.
 
 The two **PAUSE** points are real stops — Claude won't blow past them without your
 say-so. They're where you catch a wrong approach before it's code, and a wrong PR

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,8 +4,11 @@ Settled judgment calls, kept so we don't re-derive them. Each decision is one
 file, named `GH-<issue>-<slug>-<index>.md` — the issue number four-zero-padded
 (`GH-XXXX` when a decision predates the issue-tracked workflow or lands out of
 band), and a per-stem `<index>` that climbs only for phases of one issue or
-repeated hotfixes. The `GH-XXXX` bucket sorts last on disk, so **this index is
-the source of truth for chronological order**, newest first.
+repeated hotfixes. A hotfix folds into the `<slug>` as `hotfix-<descriptive-slug>` —
+`GH-XXXX-hotfix-embedding-oom-0003.md` out of band,
+`GH-0181-hotfix-vlm-fallback-0001.md` when it mends a specific issue's regression —
+never the bare `hotfix` token. The `GH-XXXX` bucket sorts last on disk, so **this
+index is the source of truth for chronological order**, newest first.
 
 Current-state architecture (invariants, conventions) lives in
 [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md); this folder is the *why* behind


### PR DESCRIPTION
Closes the doc-currency gaps in #199 — two pockets of contributor-facing doc that trailed the real `/ship` workflow.

## Part 1 — `CONTRIBUTING.md` "everyday loop"

Realigns the narrative with the 12-step `.claude/skills/ship/SKILL.md` (the source of truth), in brief in-voice beats rather than a re-spec:

- **Gate cross-reference.** The implement step read `uv run pytest` "(must pass)" unconditionally while the *Skipping the test gates* section right below waived it — a self-contradiction. Now `(must pass — except down the two skip paths below)`.
- **Collision scan** (SKILL step 4) folded into the sync step.
- **Flesh out a thin issue** (SKILL step 6) added before the plan.
- **Post-merge cleanup** (SKILL step 12) — the loop now closes at worktree/branch teardown instead of stopping at "a human merges it".

The list grows 7 → 8 steps; verified the "Step 2 above" back-reference and the `#skipping-the-test-gates` anchor still resolve.

## Part 2 — `docs/decisions/README.md`

Promotes the hotfix-slug naming convention (from #194) into the canonical convention doc, where it had been stranded in #194's body: a hotfix folds into `<slug>` as `hotfix-<descriptive-slug>` (`GH-XXXX-hotfix-embedding-oom-0003.md`, or `GH-0181-hotfix-vlm-fallback-0001.md` for an issue regression), never the bare `hotfix` token. `SKILL.md` step 9 stays the terse operational pointer.

Docs-only; no behavior change. Tests skipped (docs-only diff).

Part of #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)