### PR TITLE
Add 'smallest fix that fits' working agreement to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ skill scripts an agent over that DB. Two surfaces, one DB: the `bartleby` CLI
   error with `{"error": ..., "code": ...}`. Prose and progress go to stderr only.
 - **When unsure, stop and ask.** Most choices here have a prior conversation behind
   them. If something is ambiguous or uncovered, ask rather than wing it.
+- **Smallest fix that fits.** Prefer the simplest change that satisfies the
+  requirement; don't add abstractions, flags, or migrations unless asked.
 
 ## Workflow rails
 


### PR DESCRIPTION
Part of #169.

Adds one working-agreement line to CLAUDE.md capturing an explicit
anti-over-engineering default, next to "When unsure, stop and ask":

> **Smallest fix that fits.** Prefer the simplest change that satisfies
> the requirement; don't add abstractions, flags, or migrations unless asked.

Addresses recurring over-engineering friction surfaced by /insights:
the repo already says when *not* to act; this says how to act when you do.

Tests skipped — docs-only diff (CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)