### PR TITLE
Code and doc sweep for v0.8.0 (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Interactive configuration wizard. Asks for:
 | Summary depth | `one-shot` | `none` or `one-shot` |
 | Temperature | 0 | 0 = deterministic, 1 = creative |
 | Max summarize tokens | 50000 | If a document exceeds this, only the first N tokens are summarized (with a note appended) |
+| Summarize workers | 4 | How many documents summarize in parallel after parsing. The LLM call is network-bound, so it runs as its own stage — raise it for a rate-tolerant cloud provider, keep it low for a single-GPU local Ollama (which serializes anyway) |
 | PDF converter | `pdfplumber` | `pdfplumber` (fast, default) or `docling` (slower, more structurally aware) |
 | HTML converter | `docling` | `docling` (default; also handles `.md`) or `sec2md` (routes iXBRL EDGAR filings to sec2md, other HTML to docling) |
 | Sparse-text threshold | 100 | Pages with fewer extracted chars are treated as scanned; OCR then VLM fallback |
@@ -304,6 +305,7 @@ Interactive configuration wizard. Asks for:
 | Vision provider | (off) | Off by default; opt in during the wizard. If enabled, choose `anthropic`, `openai`, or `ollama` (plus `wsjpt`, WSJ-internal) |
 | Vision model | varies by provider | e.g., `claude-haiku-4-5`, `gpt-5-mini`, `qwen3-vl:30b` |
 | Max image dimension | 768 | Long-edge pixels before sending an image to the VLM |
+| Min image dimension | 64 | Images with a shorter edge than this are skipped — avoids wasting VLM calls (and crashes) on thin slivers |
 | Tesseract min confidence | 30 | Avg confidence (0-100) below which we fall back to the VLM on sparse pages |
 | Caption workers | 4 | How many images caption in parallel after parsing. VLM calls are network-bound, so this runs separately from parse workers — raise it for a rate-tolerant cloud provider, keep it low for a single-GPU local Ollama (which serializes anyway) |
 | Max read tokens | 50000 | Threshold above which the skill's `read_document` requires `--force` |

--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -555,16 +555,22 @@ def _parse_image_file(
     file_hash: str,
     file_name: str,
     archive_root: Path,
+    vision_enabled: bool,
     vision_max_dimension: int,
     vision_min_dimension: int,
+    on_stage: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     """A standalone image: one route, no document chunks. The summarizer (if
-    enabled) builds its input from the image chunk once captioned."""
+    enabled) builds its input from the image chunk once captioned. With vision
+    off the route produces no rows (warned + skipped in ``_parse_image_routes``),
+    so the document lands empty rather than stranding an uncaptionable row."""
+    if on_stage is not None:
+        on_stage("extracting")
     route = _ImageRoute(
         bytes_=archived.read_bytes(), page_number=None, image_index_on_page=0,
     )
     images = _parse_image_routes(
-        [route], archive_root=archive_root, vision_enabled=True,
+        [route], archive_root=archive_root, vision_enabled=vision_enabled,
         vision_max_dimension=vision_max_dimension,
         vision_min_dimension=vision_min_dimension,
     )
@@ -594,9 +600,10 @@ def _parse_document(
     if ext in IMAGE_EXTENSIONS:
         return _parse_image_file(
             archived, file_hash=file_hash, file_name=file_name,
-            archive_root=archive_root,
+            archive_root=archive_root, vision_enabled=vision_enabled,
             vision_max_dimension=vision_max_dimension,
             vision_min_dimension=vision_min_dimension,
+            on_stage=on_stage,
         )
     if ext in PDF_EXTENSIONS:
         if pdf_converter == "docling":
@@ -661,6 +668,26 @@ class _DocUnit:
     stages: dict[str, float] | None = None
 
 
+class _ProgressTally:
+    """Counts completed work units and forwards ``(done, total)`` to a progress
+    callback — the shared meter for the caption (#166) and summarize (#188)
+    stages, which both report identically against a fixed-size work-list."""
+
+    def __init__(
+        self, total: int, on_progress: Callable[[int, int], None] | None
+    ) -> None:
+        self._total = total
+        self._on_progress = on_progress
+        self._done = 0
+        if on_progress is not None:
+            on_progress(0, total)
+
+    def advance(self) -> None:
+        self._done += 1
+        if self._on_progress is not None:
+            self._on_progress(self._done, self._total)
+
+
 def _caption_all(
     writer: Writer,
     units: list[_DocUnit],
@@ -708,16 +735,7 @@ def _caption_all(
         )
         return
 
-    total = len(pending)
-    done = 0
-    if on_progress is not None:
-        on_progress(0, total)
-
-    def _advance() -> None:
-        nonlocal done
-        done += 1
-        if on_progress is not None:
-            on_progress(done, total)
+    progress = _ProgressTally(len(pending), on_progress)
 
     # Capped rows (failed MAX_INGEST_ATTEMPTS× already) are skipped, not retried.
     to_caption: dict[int, PendingImage] = {}
@@ -727,7 +745,7 @@ def _caption_all(
                 f"{owner[image_id].file_name}: skipping image — failed "
                 f"{MAX_INGEST_ATTEMPTS}× already; not retrying."
             )
-            _advance()
+            progress.advance()
         else:
             to_caption[image_id] = pi
 
@@ -766,7 +784,7 @@ def _caption_all(
                 unit.stages["caption"] = (
                     unit.stages.get("caption", 0.0) + (time.perf_counter() - t0)
                 )
-            _advance()
+            progress.advance()
         return
 
     with ThreadPoolExecutor(max_workers=caption_workers) as pool:
@@ -780,7 +798,7 @@ def _caption_all(
                 _persist(image_id, fut.result())
             except Exception as e:
                 _fail(image_id, e)
-            _advance()
+            progress.advance()
 
 
 def _summarize_all(
@@ -817,18 +835,9 @@ def _summarize_all(
     second map is populated only under ``timings`` (which forces one worker, so
     the per-document seconds stay a clean sequential baseline).
     """
-    total = len(pending)
-    done = 0
     incomplete = 0
     times: dict[int, tuple[str, float]] = {}
-    if on_progress is not None:
-        on_progress(0, total)
-
-    def _advance() -> None:
-        nonlocal done
-        done += 1
-        if on_progress is not None:
-            on_progress(done, total)
+    progress = _ProgressTally(len(pending), on_progress)
 
     # Capped docs (failed MAX_INGEST_ATTEMPTS× already) are surfaced, not retried.
     work: list[PendingSummary] = []
@@ -839,7 +848,7 @@ def _summarize_all(
                 f"{MAX_INGEST_ATTEMPTS}× already; not retrying."
             )
             incomplete += 1
-            _advance()
+            progress.advance()
         else:
             work.append(ps)
 
@@ -876,7 +885,7 @@ def _summarize_all(
                 _fail(ps, e)
             if t0 is not None:
                 times[ps.document_id] = (ps.file_name, time.perf_counter() - t0)
-            _advance()
+            progress.advance()
         return incomplete, times
 
     # Pooled: keep at most ``summarize_workers`` inputs in flight (see docstring) —
@@ -895,7 +904,7 @@ def _summarize_all(
                     _persist(ps, fut.result())
                 except Exception as e:
                     _fail(ps, e)
-                _advance()
+                progress.advance()
                 nxt = next(it, None)
                 if nxt is not None:
                     in_flight[


### PR DESCRIPTION
## Code and doc sweep (#172) — final pass before v0.8.0

Part of #169. Last item in the omnibus: sweeps the merged final shape of the
concurrent-ingestion work for concision, DRY-ness, consistency, and accuracy.

### Code (`bartleby/commands/scribe.py`)
- **Normalized the `_parse_*` family** to one consistent keyword order. The image
  parser was the lone outlier — it hardcoded `vision_enabled=True` and omitted
  `on_stage`. Both are now threaded through `_parse_document` like the PDF
  parsers, so a standalone image under vision-off warns-and-skips (landing an
  empty document) instead of stranding a permanently-uncaptionable row, and it
  emits the same "extracting" progress event as every other parser. This aligns
  the code with the existing README claim that images are analyzed only "with a
  vision provider configured."
- **Extracted `_ProgressTally`** for the identical done/total/advance scaffolding
  that was duplicated across `_caption_all` and `_summarize_all`.

### Docs
- **README config table** — added `summarize_workers` (#188) and
  `vision_min_dimension` (#179); the wizard already prompted for both. All 19
  wizard knobs are now documented.
- Re-verified ARCHITECTURE / CLAUDE / CONTRIBUTING / BENCHMARKS against the
  merged code — accurate, no stale serial `_process_one` narrative, no broken
  symbol refs; no changes needed.

### Deliberately not done
- `_caption_all` / `_summarize_all` kept as two functions — their concurrency
  strategies genuinely differ (caption: submit-all + `as_completed`; summarize:
  bounded-in-flight top-up over a DB-resident payload). Merging would be worse.
- No forced-uniform parse signature (subset-per-need stays).
- The issue's "batch toggles" doc bullet is a no-op: #168 (Batch API) was
  descoped from this omnibus, so there are no batch knobs to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
