### PR TITLE
Fix bartleby ready/--check version mismatch by healing the stale marker

### DIFF
--- a/bartleby/commands/ready.py
+++ b/bartleby/commands/ready.py
@@ -72,13 +72,23 @@ def _looks_like_skill_dir(dest: Path) -> bool:
     return (dest / "SKILL.md").is_file() or (dest / MARKER_NAME).is_file()
 
 
+def _write_marker(dest: Path, src_hash: str) -> None:
+    """Stamp the destination with this tool's version and the content hash.
+
+    Cheap enough to call on its own when only the version stamp is stale —
+    the skill content is already byte-identical, so a full reinstall would be
+    wasted work.
+    """
+    (dest / MARKER_NAME).write_text(
+        json.dumps({"version": __version__, "hash": src_hash}) + "\n"
+    )
+
+
 def _install(src: Path, dest: Path, src_hash: str) -> None:
     if dest.exists():
         shutil.rmtree(dest)
     shutil.copytree(src, dest)
-    (dest / MARKER_NAME).write_text(
-        json.dumps({"version": __version__, "hash": src_hash}) + "\n"
-    )
+    _write_marker(dest, src_hash)
 
 
 def main(*, dest: Path | None = None, check: bool = False, force: bool = False) -> None:
@@ -112,7 +122,17 @@ def main(*, dest: Path | None = None, check: bool = False, force: bool = False) 
         sys.exit(1)
 
     if up_to_date and not force:
-        console.complete(f"Skill already up to date (v{__version__}) at {dest}.")
+        if installed_version != __version__:
+            # Content is byte-identical but the marker predates this tool
+            # version (the common case — SKILL.md rarely changes across a bump).
+            # Refresh just the stamp so the version line stays truthful and
+            # `--check`, which reads it back, agrees. No full reinstall needed.
+            _write_marker(dest, src_hash)
+            console.big(
+                f"Updated skill marker v{installed_version or '?'} → v{__version__} at {dest}"
+            )
+        else:
+            console.complete(f"Skill already up to date (v{__version__}) at {dest}.")
         return
 
     if dest.exists() and any(dest.iterdir()) and not _looks_like_skill_dir(dest):

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -64,6 +64,45 @@ def test_drift_is_repaired_on_plain_rerun(dest):
     assert ready._hash_dir(dest) == ready._hash_dir(ready._source_dir())
 
 
+def test_stale_marker_refreshes_without_reinstall(dest, monkeypatch):
+    ready.main(dest=dest)
+    # Simulate a content-identical version bump: the skill files are byte-for-byte
+    # the same, but the marker was written by an older bartleby.
+    marker = _marker(dest)
+    (dest / ready.MARKER_NAME).write_text(
+        json.dumps({"version": "0.0.1", "hash": marker["hash"]}) + "\n"
+    )
+
+    calls = []
+    monkeypatch.setattr(ready, "_install", lambda *a, **k: calls.append(1))
+    ready.main(dest=dest)
+
+    assert calls == []  # marker-only refresh, never a full reinstall
+    assert _marker(dest)["version"] == ready.__version__
+
+
+def test_check_agrees_with_default_after_refresh(dest, monkeypatch):
+    ready.main(dest=dest)
+    marker = _marker(dest)
+    (dest / ready.MARKER_NAME).write_text(
+        json.dumps({"version": "0.0.1", "hash": marker["hash"]}) + "\n"
+    )
+
+    messages = []
+    for name in ("complete", "big", "warn"):
+        monkeypatch.setattr(ready.console, name, lambda m, _m=messages: _m.append(m))
+
+    ready.main(dest=dest)  # default path heals the stamp to the running version
+    assert messages == [
+        f"Updated skill marker v0.0.1 → v{ready.__version__} at {dest}"
+    ]
+
+    messages.clear()
+    ready.main(dest=dest, check=True)  # read-only; now reports the healed version
+
+    assert messages == [f"Skill is up to date (v{ready.__version__}) at {dest}."]
+
+
 def test_check_up_to_date_returns_without_error(dest):
     ready.main(dest=dest)
     ready.main(dest=dest, check=True)  # does not raise


### PR DESCRIPTION
## Problem
`bartleby ready` and `bartleby ready --check` reported different versions for
the same install. "Up to date" is decided by content hash alone, and the
`.bartleby-skill` marker's version stamp only refreshed on a full reinstall. So
a content-identical version bump (the common case — SKILL.md rarely changes)
left the marker stuck at the old version, while the default path printed the
running `__version__`. The two then disagreed (e.g. `ready` → v0.8.0,
`--check` → v0.1.0 for the same files).

## Fix
- Extract `_write_marker()` from `_install()`.
- In the `up_to_date and not force` branch, when `installed_version != __version__`,
  rewrite **just** the marker (cheap, no rmtree/copytree) and report the bump;
  otherwise keep the existing "already up to date" line.
- `--check` already reads the on-disk `installed_version` and stays read-only,
  so after one ordinary `bartleby ready` the two paths agree and track the tool
  version across future upgrades.

## Tests
Two added to `tests/test_ready.py`: a stale-marker rerun refreshes the stamp
**without** a full reinstall; and `--check` reports the same version as the
default path after the heal. Full suite: 504 passed.

Part of #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)