### PR TITLE
Reserve a couple cores in scribe auto worker-sizing (#211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Interactive configuration wizard. Asks for:
 | PDF converter | `pdfplumber` | `pdfplumber` (fast, default) or `docling` (slower, more structurally aware) |
 | HTML converter | `docling` | `docling` (default; also handles `.md`) or `sec2md` (routes iXBRL EDGAR filings to sec2md, other HTML to docling) |
 | Sparse-text threshold | 100 | Pages with fewer extracted chars are treated as scanned; OCR then VLM fallback |
-| Parse workers | auto | How many documents to parse in parallel. `0` = auto (`min(CPU cores, free RAM ÷ ~2.5 GB)`); raise for a faster bulk ingest on a big machine, lower if memory is tight |
+| Parse workers | auto | How many documents to parse in parallel. `0` = auto (`min(CPU cores − 2 reserved, free RAM ÷ ~2.5 GB)`) — the auto-pick leaves a couple of cores for the OS so a long ingest doesn't saturate the machine; a value you set here can use every core. Raise for a faster bulk ingest on a big machine, lower if memory is tight |
 | Vision provider | (off) | Off by default; opt in during the wizard. If enabled, choose `anthropic`, `openai`, or `ollama` (plus `wsjpt`, WSJ-internal) |
 | Vision model | varies by provider | e.g., `claude-haiku-4-5`, `gpt-5-mini`, `qwen3-vl:30b` |
 | Max image dimension | 768 | Long-edge pixels before sending an image to the VLM |

--- a/bartleby/commands/config.py
+++ b/bartleby/commands/config.py
@@ -172,8 +172,9 @@ def _prompt_max_workers(existing: dict) -> int | None:
     """Returns the worker count, or None for auto (omit the key from config)."""
     _help(
         "How many documents scribe parses in parallel. 0 = auto: the min of your "
-        "CPU cores and what free RAM allows.\nRaise it for a faster bulk ingest "
-        "on a big machine; lower it if memory is tight."
+        "CPU cores (less a couple held back for the OS) and what free RAM allows."
+        "\nRaise it for a faster bulk ingest on a big machine — note a value you "
+        "set here can use every core; lower it if memory is tight."
     )
     current = existing.get("max_workers")
     while True:

--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -90,6 +90,7 @@ from bartleby.lib.consts import (
     DOCLING_HF_REPOS,
     EMBEDDING_MODEL,
     PER_WORKER_GB,
+    RESERVED_CORES,
 )
 from bartleby.project import get_project_dir
 from bartleby.providers import Provider, get_provider
@@ -1100,11 +1101,11 @@ def _resolve_max_workers(config: dict, *, timings: bool) -> int:
     """Resolve how many parse workers to run.
 
     An explicit ``max_workers`` in config wins (warning when it exceeds what the
-    machine can safely hold); otherwise auto-pick ``min(cpu_count, free_ram_gb //
-    PER_WORKER_GB)``, floored at 1, so a CPU-rich but RAM-poor box doesn't launch
-    more workers than memory can hold and OOM. ``--timings`` forces 1: the
-    per-stage breakdown it produces is a sequential baseline, meaningless once
-    documents parse concurrently and overlap.
+    machine can safely hold); otherwise auto-pick ``min(cpu_count -
+    RESERVED_CORES, free_ram_gb // PER_WORKER_GB)``, floored at 1 (see those
+    consts for the why). ``--timings`` forces 1: the per-stage breakdown it
+    produces is a sequential baseline, meaningless once documents parse
+    concurrently and overlap.
     """
     if timings:
         if int(config.get("max_workers") or 1) > 1:
@@ -1115,7 +1116,8 @@ def _resolve_max_workers(config: dict, *, timings: bool) -> int:
 
     cores = os.cpu_count() or 1
     free_gb = psutil.virtual_memory().available / 1024**3
-    auto = max(1, min(cores, int(free_gb // PER_WORKER_GB)))
+    usable = max(1, cores - RESERVED_CORES)
+    auto = max(1, min(usable, int(free_gb // PER_WORKER_GB)))
 
     configured = config.get("max_workers")
     if configured is None:
@@ -1124,8 +1126,8 @@ def _resolve_max_workers(config: dict, *, timings: bool) -> int:
     if n > auto:
         console.warn(
             f"max_workers={n} exceeds what this machine can comfortably run "
-            f"({cores} cores, ~{free_gb:.0f}GB free → {auto} by the RAM cap); "
-            f"proceeding, but watch for memory pressure."
+            f"({cores} cores − {RESERVED_CORES} reserved, ~{free_gb:.0f}GB free "
+            f"→ {auto}); proceeding, but watch for memory pressure."
         )
     return n
 

--- a/bartleby/lib/consts.py
+++ b/bartleby/lib/consts.py
@@ -47,12 +47,19 @@ DEFAULT_VISION_MAX_DIMENSION = 768
 DEFAULT_VISION_MIN_DIMENSION = 64
 
 # Parse-pool sizing (#165). When `max_workers` is unset, scribe auto-picks
-# min(cpu_count, free_ram_gb // PER_WORKER_GB), floored at 1 — so a box that's
-# CPU-rich but RAM-poor doesn't launch more parse workers than memory can hold
-# and OOM. Each worker loads the embedding model and, for docling ingests, the
-# layout/table models; PER_WORKER_GB is a deliberately conservative resident-set
-# estimate for that footprint. `max_workers` in config overrides the auto-pick.
+# min(cpu_count - RESERVED_CORES, free_ram_gb // PER_WORKER_GB), floored at 1 —
+# so a box that's CPU-rich but RAM-poor doesn't launch more parse workers than
+# memory can hold and OOM, and the auto-pick always leaves a couple of cores for
+# the OS and the rest of the machine instead of pinning every core for hours.
+# Each worker loads the embedding model and, for docling ingests, the layout/table
+# models; PER_WORKER_GB is a deliberately conservative resident-set estimate for
+# that footprint. `max_workers` in config overrides the auto-pick (and may use
+# every core).
 PER_WORKER_GB = 2.5
+
+# Held back by the auto-pick only (#211); an explicit `max_workers` can still use
+# every core. (The why — OS/machine headroom — is in the PER_WORKER_GB block.)
+RESERVED_CORES = 2
 
 # Caption-pool sizing (#166). Captioning runs after parse as its own concurrent
 # stage: many VLM/OCR calls per document, network/IO-bound rather than RAM-bound,

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -2185,9 +2185,20 @@ def test_resolve_max_workers_auto_is_min_of_cores_and_ram(monkeypatch):
     # RAM-bound: 8 cores but only ~10GB free → 10 // 2.5 = 4 workers.
     _fake_machine(monkeypatch, cores=8, free_gb=10)
     assert scribe_module._resolve_max_workers({}, timings=False) == 4
-    # CPU-bound: 2 cores, plenty of RAM → 2 workers.
+    # CPU-bound: 16 cores, plenty of RAM → 16 − 2 reserved = 14 workers.
+    _fake_machine(monkeypatch, cores=16, free_gb=128)
+    assert scribe_module._resolve_max_workers({}, timings=False) == 14
+
+
+def test_resolve_max_workers_auto_reserves_cores_floored_at_one(monkeypatch):
+    from bartleby.commands import scribe as scribe_module
+    # RESERVED_CORES (2) is held back from the auto-pick, never below 1.
+    _fake_machine(monkeypatch, cores=4, free_gb=128)
+    assert scribe_module._resolve_max_workers({}, timings=False) == 2   # 4 − 2
     _fake_machine(monkeypatch, cores=2, free_gb=128)
-    assert scribe_module._resolve_max_workers({}, timings=False) == 2
+    assert scribe_module._resolve_max_workers({}, timings=False) == 1   # 2 − 2 → floor
+    _fake_machine(monkeypatch, cores=1, free_gb=128)
+    assert scribe_module._resolve_max_workers({}, timings=False) == 1   # 1 − 2 → floor
 
 
 def test_resolve_max_workers_auto_floors_at_one(monkeypatch):
@@ -2198,7 +2209,7 @@ def test_resolve_max_workers_auto_floors_at_one(monkeypatch):
 
 def test_resolve_max_workers_honors_explicit_value_over_auto_with_warning(monkeypatch):
     from bartleby.commands import scribe as scribe_module
-    _fake_machine(monkeypatch, cores=2, free_gb=128)   # auto = 2
+    _fake_machine(monkeypatch, cores=4, free_gb=128)   # auto = 4 − 2 = 2
     warned: list[str] = []
     monkeypatch.setattr(scribe_module.console, "warn", lambda m: warned.append(m))
     assert scribe_module._resolve_max_workers({"max_workers": 6}, timings=False) == 6


### PR DESCRIPTION
## Reserve a couple cores in scribe auto worker-sizing

Part of #210.

Auto-sized parse pools grabbed every core (RAM permitting), so a long ingest
pinned the whole machine — UI lag, thermal throttling, and often *slower* net
throughput from contention.

Auto-pick now holds back `RESERVED_CORES` (2):
`auto = max(1, min(cpu_count - RESERVED_CORES, free_ram_gb // PER_WORKER_GB))`,
floored at 1 so small boxes still run (4-core → 2, 2-core → 1, 1-core → 1).
**Auto path only** — an explicit `max_workers` still opts into every core (its
over-cap warning stays, now showing the reserved-core math).

Docs (README config table + `bartleby config` wizard help) and the consts comment
updated; `_resolve_max_workers` tests cover the reservation and the small-core
floor.

Companion to #213 (worker recycling / RAM-cap tuning) — together they make auto
worker-sizing safe on a real machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
