### PR TITLE
Truncate long document names in "Largest documents" card

### DIFF
--- a/bartleby/web/src/routes/+page.svelte
+++ b/bartleby/web/src/routes/+page.svelte
@@ -135,7 +135,7 @@
             <ul class="rows">
               {#each corpus.largest_documents as d}
                 <li>
-                  <a href="/documents/{d.id}">{d.title ?? stripExt(d.file_name)}</a>
+                  <a href="/documents/{d.id}" title={d.title ?? stripExt(d.file_name)}>{d.title ?? stripExt(d.file_name)}</a>
                   <span class="muted">{d.token_count == null ? "—" : pluralize(d.token_count, "token")}</span>
                 </li>
               {/each}
@@ -273,11 +273,18 @@
     padding: var(--space-2xs) 0;
   }
   .rows a {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     color: var(--color-link);
     text-decoration: none;
   }
   .rows a:hover {
     text-decoration: underline;
+  }
+  .rows .muted {
+    flex-shrink: 0;
   }
 
   .histogram {


### PR DESCRIPTION
Long underscore-joined document names (e.g. PUC testimony filenames) have no spaces to wrap on, so the flex item kept its full intrinsic width, ate the row gap, and shoved the token count against the edge of the **Largest documents** card.

Constrain and ellipsis-truncate the name link (`min-width:0` + `overflow`/`text-overflow`/`white-space`) and keep the count from shrinking (`.rows .muted { flex-shrink:0 }`). Add `title=` so the full name is available on hover after truncation.

`.rows` is used only by this card, so no shared-rule fallout.

Tests skipped — `skip-tests`, no `.py`/`pyproject.toml` touched (frontend-only).

Part of #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)