### PR TITLE
Stop the scribe progress region stacking on tall runs

### DIFF
--- a/bartleby/ingest/progress.py
+++ b/bartleby/ingest/progress.py
@@ -48,6 +48,11 @@ from bartleby.lib import console
 # are both built straight off this tuple.
 PHASES = ("parse", "caption", "summarize")
 
+# Rows the live region needs beyond its lanes: the run-of-show header, the
+# overall bar, and a line of breathing room. Lanes are capped to the terminal
+# height minus this so the whole region always fits the screen (#208).
+_RESERVED_ROWS = 4
+
 
 class ScribeProgress:
     """Live multi-worker progress for a scribe ingest run (see module docstring).
@@ -67,6 +72,17 @@ class ScribeProgress:
         self._active: str | None = None
 
         shared = console.get_console()
+
+        # Cap lanes so the live region (header + overall bar + one row per lane)
+        # can't outgrow the terminal. Rich's Live only redraws in place while its
+        # renderable fits the screen; once it's taller, the top scrolls out of
+        # reach and every refresh stacks a fresh frame below the last instead of
+        # overwriting it (#208). Only a real TTY redraws in place — off a terminal
+        # (pipe, CI log, tests) Live appends regardless, so leave the count alone.
+        if shared.is_terminal:
+            n_lanes = min(n_lanes, shared.size.height - _RESERVED_ROWS)
+        n_lanes = max(1, n_lanes)
+
         self._overall = Progress(
             TextColumn("[bold]{task.fields[label]}"),
             BarColumn(),
@@ -86,12 +102,17 @@ class ScribeProgress:
         )
         self._lane_tasks = [
             self._lanes.add_task("lane", label="", visible=False)
-            for _ in range(max(1, n_lanes))
+            for _ in range(n_lanes)
         ]
         self._free: list[int] = list(range(len(self._lane_tasks)))
         self._by_key: dict[object, int] = {}
 
-        self._live = Live(self, console=shared, refresh_per_second=8)
+        # crop (don't stack) if the region still overshoots — e.g. the window is
+        # resized shorter mid-run. Header + overall sit atop the group, so crop
+        # sheds excess lanes from the bottom first (#208).
+        self._live = Live(
+            self, console=shared, refresh_per_second=8, vertical_overflow="crop"
+        )
 
     # -- rendering -----------------------------------------------------------
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -7,7 +7,12 @@ observable from the object's state, so no terminal or render loop is needed.
 
 from __future__ import annotations
 
-from bartleby.ingest.progress import ScribeProgress
+import sys
+
+from rich.console import Console
+
+import bartleby.lib.console as console_mod
+from bartleby.ingest.progress import ScribeProgress, _RESERVED_ROWS
 
 
 def _overall(sp: ScribeProgress) -> tuple[float, float]:
@@ -66,6 +71,38 @@ def test_lanes_are_sticky_per_key_and_reset_between_phases():
     # A new phase frees every lane so caption rows don't show leftover parse files.
     sp.phase("caption").start(1)
     assert sp._by_key == {}
+
+
+def test_lanes_capped_to_terminal_height_on_a_tty(monkeypatch):
+    # On a short terminal the lane region is bounded so header + overall + lanes
+    # can't outgrow the screen and stack (#208). Force a 10-row TTY and ask for
+    # more workers than fit.
+    short_tty = Console(file=sys.stderr, force_terminal=True, height=10)
+    monkeypatch.setattr(console_mod, "get_console", lambda: short_tty)
+
+    sp = ScribeProgress(n_lanes=16)
+
+    assert len(sp._lane_tasks) == 10 - _RESERVED_ROWS          # capped to fit
+    # The whole region (lanes + the reserved header/overall rows) stays on screen.
+    assert len(sp._lane_tasks) + _RESERVED_ROWS <= short_tty.size.height
+
+
+def test_lanes_not_capped_off_a_terminal(monkeypatch):
+    # Off a TTY (pipe, CI log, tests) Live appends rather than redrawing, so the
+    # stacking bug can't occur and capping would only hide lanes — leave it alone.
+    not_a_tty = Console(file=sys.stderr, height=10)  # is_terminal False
+    monkeypatch.setattr(console_mod, "get_console", lambda: not_a_tty)
+
+    sp = ScribeProgress(n_lanes=16)
+
+    assert len(sp._lane_tasks) == 16
+
+
+def test_live_region_crops_rather_than_stacking():
+    # The Live is told to crop an over-tall region instead of stacking frames,
+    # covering a mid-run resize the construction-time cap can't foresee (#208).
+    sp = ScribeProgress(n_lanes=2)
+    assert sp._live.vertical_overflow == "crop"
 
 
 def test_lane_overflow_is_dropped_not_fatal():


### PR DESCRIPTION
## Problem
On a large `bartleby scribe` run the live progress view — run-of-show header +
overall bar + one lane per worker — stacked duplicate frames instead of
redrawing in place. Once the region outgrew the terminal height (up to 16+
lanes), Rich's `Live` could no longer move the cursor above a top that had
scrolled off, so each refresh printed a fresh frame below the last.

## Fix
Bound the region to the screen, in `bartleby/ingest/progress.py`:
- **Cap lanes** to `terminal_height − reserved` at construction, but only when
  `is_terminal` — off a TTY (pipe, CI, tests) Live appends regardless and
  capping would only hide lanes. The existing lane-overflow drop path absorbs
  workers beyond the cap.
- **`vertical_overflow="crop"`** on the `Live` as a safety net for a mid-run
  resize the construction-time cap can't foresee. Header + overall sit atop the
  group, so crop sheds excess lanes from the bottom first.

## Tests
`tests/test_progress.py`: lanes capped on a forced-short TTY; lanes *not* capped
off-TTY (preserves pipe/test behavior); `Live.vertical_overflow == "crop"`.
Full suite: 508 passed.

Part of #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)