### PR TITLE
Complete `_upgrade_v7_to_v8`: add ingests table + ingest_run_id columns

### DIFF
--- a/bartleby/db/upgrades.py
+++ b/bartleby/db/upgrades.py
@@ -61,11 +61,15 @@ def _upgrade_v6_to_v7(conn: apsw.Connection) -> None:
 
 
 def _upgrade_v7_to_v8(conn: apsw.Connection) -> None:
+    # Schema v8 is the resumable/provenance bump (#164 + #171): a
+    # failed_ingests retry ledger, an ingests provenance table, and an
+    # ingest_run_id stamp on every per-unit table. All purely additive — no
+    # reingest. Keep this DDL in lockstep with db/schema.py.
+    cur = conn.cursor()
     # failed_ingests records a per-unit ingest failure (parse / caption /
     # summary) so resumable ingest can cap retries on a deterministically
-    # failing unit instead of attempting it every run. Purely additive — no
-    # reingest. Keep this DDL in lockstep with db/schema.py.
-    conn.cursor().execute(
+    # failing unit instead of attempting it every run.
+    cur.execute(
         "CREATE TABLE failed_ingests ("
         "  file_hash TEXT NOT NULL, "
         "  file_name TEXT NOT NULL, "
@@ -77,6 +81,25 @@ def _upgrade_v7_to_v8(conn: apsw.Connection) -> None:
         "  PRIMARY KEY (file_hash, stage)"
         ")"
     )
+    # ingests provenance table (mirrors schema.py). Old rows pre-date any run,
+    # so their ingest_run_id stays NULL — which the chunk helpers expect.
+    cur.execute(
+        "CREATE TABLE ingests ("
+        "  run_id INTEGER PRIMARY KEY, "
+        "  started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+        "  finished_at TEXT, "
+        "  config_json TEXT NOT NULL, "
+        "  bartleby_version TEXT, "
+        "  schema_version INTEGER NOT NULL"
+        ")"
+    )
+    # per-unit provenance columns (mirror schema.py). Nullable with no
+    # default, so the FK-bearing ADD COLUMN is legal on a populated table.
+    for table in ("documents", "summaries", "chunks"):
+        cur.execute(
+            f"ALTER TABLE {table} ADD COLUMN "
+            "ingest_run_id INTEGER REFERENCES ingests(run_id)"
+        )
 
 
 _UPGRADES: dict[int, Callable[[apsw.Connection], None]] = {

--- a/docs/decisions/GH-0212-complete-v7-to-v8-additive-upgrade-0001.md
+++ b/docs/decisions/GH-0212-complete-v7-to-v8-additive-upgrade-0001.md
@@ -1,0 +1,46 @@
+# Complete the v7→v8 additive upgrade rather than force a re-ingest (issue #212)
+
+> Source: [#212](https://github.com/jswest/bartleby/issues/212)
+
+supersedes the upgrade-handling plan in
+[GH-0171](GH-0171-unit-ingest-provenance-config-drift-warnings-0001.md).
+
+#171 deferred the upgrade-chain entry for the `ingests` table + `ingest_run_id`
+columns to "one consolidated `_upgrade_v8_to_v9` at the #169 release". That entry
+never materialized the way it was planned: the concurrent-ingestion omnibus
+shipped *staying at* schema v8 (no v8→v9 bump), and `_upgrade_v7_to_v8` — added by
+#164 when v8 meant only `failed_ingests` — was never extended to cover the
+provenance DDL #171 later folded into v8. The result was a half-additive upgrade:
+`project upgrade` on a v7 corpus stamped the DB v8 while omitting `ingests` and
+the three `ingest_run_id` columns. Because *no read path* touches provenance, the
+DB read green until the first write — and every chunk insert unconditionally names
+`ingest_run_id`, so `save_finding` / `save_summary` / re-running `scribe` all
+raised `no such column: ingest_run_id`. An upgrade entry *existing* meant
+`project upgrade` didn't refuse; it ran the partial migration and reported
+success — exactly the silently-half-migrated-reads-green trap the resumable-ingest
+work set out to kill.
+
+Two directions were weighed:
+
+- **A — complete the additive upgrade (chosen).** The missing DDL is genuinely
+  additive (a new table + nullable FK columns), so finish `_upgrade_v7_to_v8`:
+  `CREATE TABLE ingests` + `ALTER TABLE {documents,summaries,chunks} ADD COLUMN
+  ingest_run_id INTEGER REFERENCES ingests(run_id)`. SQLite permits the inline FK
+  on `ADD COLUMN` because the column is nullable with no non-NULL default; columns
+  append at end-of-table so an upgraded DB is schema-equivalent to a fresh v8.
+  Old rows carry `ingest_run_id = NULL`, which the chunk helpers already expect.
+  No `SCHEMA_VERSION` change — stays v8, patch-level (fits v0.8.1).
+- **B — delete the v7→v8 entry so `project upgrade` refuses → re-ingest.** Cleaner
+  if provenance is held to be strictly re-ingest-only, but it strands v7 corpora:
+  re-ingesting every file (multi-hour on a real corpus) only to reach a working v8
+  whose sole gap is retroactively-unknowable provenance. Rejected — the DDL is
+  additive and the only real harm is the missing-column crash, which A fixes
+  directly.
+
+The pre-upgrade "loss" under A is that rows ingested before the upgrade carry no
+provenance — inherently unknowable retroactively, the same NULL state #171 already
+defined for pre-feature units. The lockstep between this chain and `db/schema.py`
+is guarded by `tests/test_project.py::test_upgrade_chain_walks_from_v4_through_current`,
+extended here to drop the v8 provenance when simulating v4, assert it returns,
+check the upgraded DB is schema-equivalent to a fresh v8, and regression-test
+saving a finding on an upgraded DB (the exact write that used to crash).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,7 @@ Current-state architecture (invariants, conventions) lives in
 [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md); this folder is the *why* behind
 past calls, read on demand.
 
+- [GH-0212 — Complete the v7→v8 additive upgrade rather than force a re-ingest (issue #212)](GH-0212-complete-v7-to-v8-additive-upgrade-0001.md)
 - [GH-0213 — Bound parse-worker memory so a long ingest doesn't OOM (issue #213)](GH-0213-bound-parse-worker-memory-0001.md)
 - [GH-0170 — Scribe progress UX under the worker pool (issue #170)](GH-0170-scribe-progress-ux-worker-pool-0001.md)
 - [GH-0188 — Parallelize the summarize pass (issue #188)](GH-0188-parallelize-summarize-pass-0001.md)

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -7,7 +7,11 @@ import pytest
 import bartleby.config
 import bartleby.db.connection
 import bartleby.project
-from bartleby.db.chunks import ChunkInput, insert_document_chunks
+from bartleby.db.chunks import (
+    ChunkInput,
+    insert_document_chunks,
+    insert_finding_chunks,
+)
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM, SCHEMA_VERSION
 
@@ -124,6 +128,10 @@ def test_upgrade_chain_walks_from_v4_through_current(projects_root):
     conn = apsw.Connection(str(db_path))
     try:
         cur = conn.cursor()
+        # v8 provenance (drop the FK-bearing columns before the table).
+        for table in ("documents", "summaries", "chunks"):
+            cur.execute(f"ALTER TABLE {table} DROP COLUMN ingest_run_id")
+        cur.execute("DROP TABLE ingests")
         cur.execute("DROP TABLE failed_ingests")
         cur.execute("ALTER TABLE sessions DROP COLUMN harness")
         cur.execute("ALTER TABLE sessions DROP COLUMN model")
@@ -163,7 +171,51 @@ def test_upgrade_chain_walks_from_v4_through_current(projects_root):
         ]
         assert "model" in session_cols
         assert "harness" in session_cols
-        # v8 table landed.
+        # v8 retry ledger + provenance landed (the half-migration this fixes:
+        # the upgrade used to stamp v8 but omit ingests + ingest_run_id).
         assert "failed_ingests" in names
+        assert "ingests" in names
+        for table in ("documents", "summaries", "chunks"):
+            tcols = [r[1] for r in cur.execute(f"PRAGMA table_info({table})")]
+            assert "ingest_run_id" in tcols, table
+    finally:
+        conn.close()
+
+    # The upgraded DB must be schema-equivalent to a freshly-created v8: same
+    # tables, same columns per table. This is the regression gate that keeps
+    # the upgrade chain in lockstep with db/schema.py.
+    bartleby.project.create_project("beta")
+
+    def _schema(conn):
+        tables = [
+            row[0] for row in conn.cursor().execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        ]
+        return {
+            t: sorted(
+                r[1] for r in conn.cursor().execute(f"PRAGMA table_info({t})")
+            )
+            for t in tables
+        }
+
+    upgraded, fresh = open_db("alpha"), open_db("beta")
+    try:
+        assert _schema(upgraded) == _schema(fresh)
+    finally:
+        upgraded.close()
+        fresh.close()
+
+    # The crash this fixes: chunk inserts unconditionally name ingest_run_id,
+    # so saving a finding on the upgraded DB used to raise "no such column".
+    conn = open_db("alpha")
+    try:
+        insert_finding_chunks(conn, 1, [
+            ChunkInput(text="finding body", embedding=_emb(), chunk_index=0),
+        ])
+        count = conn.cursor().execute(
+            "SELECT count(*) FROM chunks WHERE source_kind = 'finding'"
+        ).fetchone()[0]
+        assert count == 1
     finally:
         conn.close()


### PR DESCRIPTION
`project upgrade` on a v7 corpus stamped the DB v8 but created only `failed_ingests`, omitting the `ingests` provenance table and the `ingest_run_id` columns on `documents`/`summaries`/`chunks` that #171 also folded into v8. No read path touches provenance, so the DB read green — until the first write: every chunk insert names `ingest_run_id`, so `save_finding`/`save_summary`/re-running `scribe` crashed with `no such column: ingest_run_id`.

Completes the additive upgrade (new table + nullable FK columns; old rows carry `ingest_run_id = NULL`, as the code already expects). No `SCHEMA_VERSION` change — stays v8, patch-level.

Extends the upgrade-chain test to drop the v8 provenance when simulating v4, assert it returns, check the upgraded DB is schema-equivalent to a fresh v8, and regression-test saving a finding on an upgraded DB. Records the A-over-B decision in `docs/decisions/GH-0212` (supersedes the deferred-upgrade plan in GH-0171).

Full suite: 510 passed.

Part of #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)