### PR TITLE
Never send temperature to OpenAI; GPT-5 rejects non-default values

### DIFF
--- a/bartleby/providers/openai.py
+++ b/bartleby/providers/openai.py
@@ -7,11 +7,28 @@ import base64
 from openai import OpenAI
 from pydantic import BaseModel
 
+from bartleby.lib import console
 from bartleby.providers.base import DocumentSummary, VlmDescription
 from bartleby.providers.prompt import (
     IMAGE_DESCRIPTION_INSTRUCTIONS,
     build_summary_messages,
 )
+
+# OpenAI's models (the GPT-5 family) accept only the default temperature (1.0);
+# any other value is rejected outright. We never send the parameter — the API
+# default stands — and warn once per process if the caller configured a value
+# we're dropping, so a non-default temperature in config doesn't read as honored.
+_temperature_warned = False
+
+
+def _drop_temperature(temperature: float) -> None:
+    global _temperature_warned
+    if temperature != 1.0 and not _temperature_warned:
+        _temperature_warned = True
+        console.warn(
+            "OpenAI models accept only the default temperature (1.0); "
+            f"ignoring configured temperature={temperature}."
+        )
 
 
 class OpenAIProvider:
@@ -27,9 +44,9 @@ class OpenAIProvider:
         model: str,
         temperature: float,
     ) -> DocumentSummary:
+        _drop_temperature(temperature)
         response = self._client.chat.completions.parse(
             model=model,
-            temperature=temperature,
             messages=build_summary_messages(document_text),
             response_format=DocumentSummary,
         )
@@ -43,9 +60,9 @@ class OpenAIProvider:
         schema: type[BaseModel],
         temperature: float = 0.0,
     ) -> BaseModel:
+        _drop_temperature(temperature)
         response = self._client.chat.completions.parse(
             model=model,
-            temperature=temperature,
             messages=[{"role": "user", "content": prompt}],
             response_format=schema,
         )

--- a/docs/decisions/GH-0222-omit-temperature-openai-0001.md
+++ b/docs/decisions/GH-0222-omit-temperature-openai-0001.md
@@ -1,0 +1,32 @@
+# Never send temperature to the OpenAI provider (issue #222)
+
+> Source: [#222](https://github.com/jswest/bartleby/issues/222)
+
+The OpenAI provider used to forward the user's configured `temperature` to
+`chat.completions.parse`. But the **GPT-5 family** (`gpt-5`, `gpt-5-mini`,
+`gpt-5-nano`) — the only models bartleby pairs with this provider — accepts
+**solely the API default of `1.0`**; any other value is rejected outright
+(`Unsupported value: 'temperature' does not support 0.0 with this model. Only
+the default (1) value is supported.`). With the stock config (default model
+`gpt-5-mini`, `DEFAULT_TEMPERATURE = 0.0`) this meant **every** summarize/classify
+call errored out of the box.
+
+**The fix is to omit the parameter entirely, not to clamp it to a value.** We
+never send `temperature` to OpenAI and let the API default stand. Two reasons to
+omit rather than hardcode `1.0`: (1) it's robust if OpenAI ever shifts the
+default, and (2) the discriminator is the *provider*, not the model string — the
+OpenAI provider only ever drives GPT-5 models here, so a per-model prefix check
+(`startswith("gpt-5")`) would be needless machinery for a distinction the
+provider boundary already makes. If a non-GPT-5 OpenAI model that honors
+`temperature` ever enters the picture, that's the moment to reintroduce a model
+check — not before.
+
+Dropping a configured value silently would mislead (a user sets `temperature:
+0.2`, sees no effect, and has no idea why), so the provider **warns once per
+process** when it drops a non-`1.0` value, via `console.warn` — which shares the
+scribe `Live` console so the notice inserts above the progress bar instead of
+stomping it, matching the `_warn_ocr_degraded_once` precedent in
+`bartleby/ingest/images.py`. Once-per-process, not once-per-call: summarize runs
+per-document, so a per-call warning would emit thousands of lines on a large
+ingest. `analyze_image` already omitted `temperature` and is unchanged. No schema
+change — patch-level.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,7 @@ Current-state architecture (invariants, conventions) lives in
 [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md); this folder is the *why* behind
 past calls, read on demand.
 
+- [GH-0222 — Never send temperature to the OpenAI provider; GPT-5 rejects non-default values (issue #222)](GH-0222-omit-temperature-openai-0001.md)
 - [GH-0212 — Complete the v7→v8 additive upgrade rather than force a re-ingest (issue #212)](GH-0212-complete-v7-to-v8-additive-upgrade-0001.md)
 - [GH-0213 — Bound parse-worker memory so a long ingest doesn't OOM (issue #213)](GH-0213-bound-parse-worker-memory-0001.md)
 - [GH-0170 — Scribe progress UX under the worker pool (issue #170)](GH-0170-scribe-progress-ux-worker-pool-0001.md)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -151,6 +151,52 @@ def test_openai_summarize_returns_parsed_pydantic(monkeypatch):
     result = p.summarize("doc", model="gpt-5-mini", temperature=0.0)
     assert result is parsed
     assert fake.last_call["response_format"] is DocumentSummary
+    # GPT-5 models reject any non-default temperature, so we never send it.
+    assert "temperature" not in fake.last_call
+
+
+def test_openai_classify_omits_temperature(monkeypatch):
+    class _Schema(BaseModel):
+        ok: bool
+
+    parsed = _Schema(ok=True)
+    fake = _install_openai(monkeypatch, _FakeOpenAIResponse(parsed=parsed))
+    from bartleby.providers.openai import OpenAIProvider
+    p = OpenAIProvider()
+    result = p.classify("prompt", model="gpt-5-nano", schema=_Schema, temperature=0.3)
+    assert result is parsed
+    assert "temperature" not in fake.last_call
+
+
+def test_openai_warns_once_on_dropped_temperature(monkeypatch):
+    from bartleby.providers import openai as mod
+    monkeypatch.setattr(mod, "_temperature_warned", False)
+    warnings: list[str] = []
+    monkeypatch.setattr(mod.console, "warn", warnings.append)
+    parsed = DocumentSummary(**_SUMMARY_INPUT)
+    _install_openai(monkeypatch, _FakeOpenAIResponse(parsed=parsed))
+
+    p = mod.OpenAIProvider()
+    p.summarize("doc", model="gpt-5-mini", temperature=0.0)
+    p.summarize("doc", model="gpt-5-mini", temperature=0.0)
+
+    # Warned about the dropped value, exactly once across both calls.
+    assert len(warnings) == 1
+    assert "temperature=0.0" in warnings[0]
+
+
+def test_openai_no_warning_when_temperature_is_default(monkeypatch):
+    from bartleby.providers import openai as mod
+    monkeypatch.setattr(mod, "_temperature_warned", False)
+    warnings: list[str] = []
+    monkeypatch.setattr(mod.console, "warn", warnings.append)
+    parsed = DocumentSummary(**_SUMMARY_INPUT)
+    _install_openai(monkeypatch, _FakeOpenAIResponse(parsed=parsed))
+
+    mod.OpenAIProvider().summarize("doc", model="gpt-5-mini", temperature=1.0)
+
+    # 1.0 is the API default — nothing is dropped, so no warning.
+    assert warnings == []
 
 
 def test_openai_analyze_image_returns_parsed_pydantic(monkeypatch):


### PR DESCRIPTION
The OpenAI provider forwarded the configured `temperature` to
`chat.completions.parse`, but the GPT-5 family (the only models bartleby
pairs with this provider) accepts solely the API default of `1.0` — any
other value is rejected outright. With the stock config (`gpt-5-mini` +
`DEFAULT_TEMPERATURE=0.0`) every summarize/classify call errored out of
the box, so this is a live default-config bug, not just hardening.

Fix: never send `temperature` to OpenAI — let the API default stand. The
discriminator is the provider, not the model string (this provider only
ever drives GPT-5 models), so there's no per-model prefix check. Warn once
per process via `console.warn` (which cooperates with the scribe `Live`
progress bar) when a non-1.0 value was configured and dropped, so an
ignored config value doesn't silently read as honored. `analyze_image`
already omitted `temperature` — unchanged.

Decision recorded in docs/decisions/GH-0222-omit-temperature-openai-0001.md.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)