### PR TITLE
Route parse-worker warnings to the parent instead of the console

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -35,7 +35,7 @@ import sys
 import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, as_completed, wait
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
@@ -229,20 +229,23 @@ def _parse_image_routes(
     vision_enabled: bool,
     vision_max_dimension: int,
     vision_min_dimension: int,
+    on_warn: Callable[[str], None] | None = None,
 ) -> list[ParsedImage]:
     """Scale + archive each route into a ParsedImage (no VLM, no DB).
 
     Sub-minimum images are dropped here, exactly as before: VLM image processors
     crash on sub-patch-size edges and such slivers carry no describable content.
     With no vision provider there's nothing to caption, so routes produce no
-    rows (a warning, then skipped).
+    rows (a warning, then skipped). Notices go to ``on_warn`` (routed to the
+    parent), never the console — this runs in a spawn worker with no Live.
     """
     if not routes:
         return []
     if not vision_enabled:
-        console.warn(
-            f"Skipping {len(routes)} image(s) — no vision provider configured."
-        )
+        if on_warn is not None:
+            on_warn(
+                f"Skipping {len(routes)} image(s) — no vision provider configured."
+            )
         return []
     parsed: list[ParsedImage] = []
     for route in routes:
@@ -253,10 +256,11 @@ def _parse_image_routes(
             prepared, min_dimension=vision_min_dimension
         ):
             page_str = f" (page {route.page_number})" if route.page_number else ""
-            console.warn(
-                f"Skipping image{page_str} — {prepared.width}x{prepared.height}px "
-                f"is below the {vision_min_dimension}px vision minimum."
-            )
+            if on_warn is not None:
+                on_warn(
+                    f"Skipping image{page_str} — {prepared.width}x{prepared.height}px "
+                    f"is below the {vision_min_dimension}px vision minimum."
+                )
             continue
         archived = image_pipeline.archive_image(prepared, archive_root)
         parsed.append(ParsedImage(
@@ -378,6 +382,7 @@ def _parse_edgar_submission(
     file_hash: str,
     file_name: str,
     on_stage: Callable[[str], None] | None = None,
+    on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     """EDGAR full-submission `.txt`: unwrap the SGML envelope and route each
     inner document to its converter, landing as one document row.
@@ -397,7 +402,8 @@ def _parse_edgar_submission(
         label = doc.type or doc.filename or "document"
         kind = edgar_pipeline.classify(doc)
         if kind == "skip":
-            console.warn(f"{file_name}: skipping inner document {label}.")
+            if on_warn is not None:
+                on_warn(f"{file_name}: skipping inner document {label}.")
             continue
         if kind == "html":
             result = sec2md_pipeline.convert_bytes(doc.text.encode("utf-8"))
@@ -439,6 +445,7 @@ def _parse_pdf_pdfplumber(
     vision_max_dimension: int,
     vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
+    on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     if on_stage is not None:
         on_stage("extracting")
@@ -487,6 +494,7 @@ def _parse_pdf_pdfplumber(
         image_routes, archive_root=archive_root, vision_enabled=vision_enabled,
         vision_max_dimension=vision_max_dimension,
         vision_min_dimension=vision_min_dimension,
+        on_warn=on_warn,
     )
     return ParsedDocument(
         file_hash=file_hash, file_name=file_name, archive_path=archived,
@@ -505,6 +513,7 @@ def _parse_pdf_docling(
     vision_max_dimension: int,
     vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
+    on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     from bartleby.ingest import docling as docling_pipeline
 
@@ -541,6 +550,7 @@ def _parse_pdf_docling(
         image_routes, archive_root=archive_root, vision_enabled=vision_enabled,
         vision_max_dimension=vision_max_dimension,
         vision_min_dimension=vision_min_dimension,
+        on_warn=on_warn,
     )
     return ParsedDocument(
         file_hash=file_hash, file_name=file_name, archive_path=archived,
@@ -560,6 +570,7 @@ def _parse_image_file(
     vision_max_dimension: int,
     vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
+    on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     """A standalone image: one route, no document chunks. The summarizer (if
     enabled) builds its input from the image chunk once captioned. With vision
@@ -574,6 +585,7 @@ def _parse_image_file(
         [route], archive_root=archive_root, vision_enabled=vision_enabled,
         vision_max_dimension=vision_max_dimension,
         vision_min_dimension=vision_min_dimension,
+        on_warn=on_warn,
     )
     return ParsedDocument(
         file_hash=file_hash, file_name=file_name, archive_path=archived,
@@ -596,6 +608,7 @@ def _parse_document(
     vision_min_dimension: int,
     archive_root: Path,
     on_stage: Callable[[str], None] | None = None,
+    on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     """Route an archived file to its converter and return a parsed result."""
     if ext in IMAGE_EXTENSIONS:
@@ -604,7 +617,7 @@ def _parse_document(
             archive_root=archive_root, vision_enabled=vision_enabled,
             vision_max_dimension=vision_max_dimension,
             vision_min_dimension=vision_min_dimension,
-            on_stage=on_stage,
+            on_stage=on_stage, on_warn=on_warn,
         )
     if ext in PDF_EXTENSIONS:
         if pdf_converter == "docling":
@@ -613,7 +626,7 @@ def _parse_document(
                 archive_root=archive_root, vision_enabled=vision_enabled,
                 vision_max_dimension=vision_max_dimension,
                 vision_min_dimension=vision_min_dimension,
-                on_stage=on_stage,
+                on_stage=on_stage, on_warn=on_warn,
             )
         return _parse_pdf_pdfplumber(
             archived, file_hash=file_hash, file_name=file_name,
@@ -623,13 +636,14 @@ def _parse_document(
             vision_enabled=vision_enabled,
             vision_max_dimension=vision_max_dimension,
             vision_min_dimension=vision_min_dimension,
-            on_stage=on_stage,
+            on_stage=on_stage, on_warn=on_warn,
         )
     if edgar_pipeline.detect(archived):
         # EDGAR full-submission SGML envelope — detected by content, so a `.txt`
         # wrapper is caught here instead of falling to the character chunker.
         return _parse_edgar_submission(
-            archived, file_hash=file_hash, file_name=file_name, on_stage=on_stage,
+            archived, file_hash=file_hash, file_name=file_name,
+            on_stage=on_stage, on_warn=on_warn,
         )
     if (
         ext in HTML_EXTENSIONS
@@ -952,6 +966,10 @@ class ParseOutcome:
     parse_stages: dict[str, float] | None = None  # canonical stage→seconds (--timings)
     error: str | None = None
     offline: bool = False  # the error was an offline-mode block (hint the user)
+    # User-facing notices collected during parse. A spawn worker has no access
+    # to the parent's Rich Live console, so it never prints — it routes them
+    # here and the main-process drain emits them (see _parse_request).
+    warnings: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -979,6 +997,10 @@ def _parse_request(
     current stage so the main process can render this worker's lane. The single
     ``on_stage`` the parsers already emit drives both the timer and ``report`` —
     one callback, two consumers.
+
+    User-facing notices (skipped images, skipped inner documents) accumulate via
+    ``on_warn`` and ride back on the outcome: a spawn worker has no Live console,
+    so the main-process drain is the only place that can print them.
     """
     timer = timing.StageTimer() if config.timings else None
     report("preparing")          # the lane shows the file the moment we pick it up
@@ -988,6 +1010,7 @@ def _parse_request(
             timer.mark(label)
         report(label)
 
+    warnings: list[str] = []
     try:
         parsed = _parse_document(
             _archive(request.path, config.archive_root, request.file_hash, request.ext),
@@ -999,17 +1022,21 @@ def _parse_request(
             vision_max_dimension=config.vision_max_dimension,
             vision_min_dimension=config.vision_min_dimension,
             archive_root=config.archive_root,
-            on_stage=on_stage,
+            on_stage=on_stage, on_warn=warnings.append,
         )
     except Exception as e:
         from bartleby.lib.quiet import offline_blocked
-        return ParseOutcome(request=request, error=str(e), offline=offline_blocked(e))
+        return ParseOutcome(
+            request=request, error=str(e), offline=offline_blocked(e),
+            warnings=warnings,
+        )
 
     if timer is not None:
         timer.finish()
     return ParseOutcome(
         request=request, parsed=parsed,
         parse_stages=dict(timer.totals) if timer is not None else None,
+        warnings=warnings,
     )
 
 
@@ -1407,6 +1434,11 @@ def main(
                 on_progress=lambda ev: parse_phase.lane(ev.worker, ev.item, ev.stage),
             ):
                 req = outcome.request
+                # Notices the worker collected (it has no Live console of its
+                # own); emit them here, where console.warn coordinates with the
+                # progress bar instead of stomping it.
+                for warning in outcome.warnings:
+                    console.warn(warning)
                 if outcome.error is not None:
                     writer.record_failure(
                         req.file_hash, req.file_name, "parse", outcome.error

--- a/docs/decisions/GH-0227-route-worker-warnings-to-parent-0001.md
+++ b/docs/decisions/GH-0227-route-worker-warnings-to-parent-0001.md
@@ -1,0 +1,37 @@
+# Parse workers route warnings to the parent; they never touch the console (issue #227)
+
+> Source: [#227](https://github.com/jswest/bartleby/issues/227)
+
+Parsing runs in a spawn worker pool (`bartleby/ingest/pool.py`, #165). Each
+worker is a **separate process** with its own `bartleby.lib.console` `Console`,
+which knows nothing about the **parent's** Rich `Live` progress region. So when
+worker-side parse code called `console.warn` directly — sub-minimum image skips
+and the "no vision provider" notice in `_parse_image_routes`, the inner-document
+skip in `_parse_edgar_submission` — the child's raw stderr write interleaved
+with the parent's `Live` frames and desynced its anchor: the `Run of show` /
+`Overall` header blocks stopped redrawing in place and stacked as fresh lines on
+a multi-thousand-file run.
+
+This is **distinct from #208** (which bounded the live region to the
+terminal *height* so it didn't self-stack). Same visual symptom, different
+cause: out-of-band writes from another process, not region overflow. It only
+manifests under the concurrent pool — at `max_workers <= 1` the parse runs inline
+in the main process, where `console.warn` coordinates with the `Live` correctly.
+
+**The fix routes worker notices back as data, mirroring how parse *failures*
+already return on `ParseOutcome.error`.** A new `on_warn` callback is threaded
+parallel to the existing `on_stage` through the `_parse_*` chain; `_parse_request`
+collects into a `warnings: list[str]` and returns it on the outcome (on both the
+success and the `except` path, so notices collected before a late failure aren't
+lost); the main-process drain emits each with `console.warn`, which inserts above
+the bar. Threading a second callback alongside `on_stage` was deliberate — it's
+the established worker→parent seam in this code, so no new mechanism is
+introduced.
+
+**Scope is parse-workers only.** Caption and summarize run in
+`ThreadPoolExecutor`s *in the main process* (`scribe.py`), so their `console.warn`
+calls — including `images._warn_ocr_degraded_once` (reached from the caption-phase
+`images.analyze`) — already coordinate with the `Live` and are left untouched.
+The invariant to preserve going forward: **code reachable from `_parse_request`
+must not call `console.*`** — it routes through `on_warn`. No schema change —
+patch-level.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,7 @@ Current-state architecture (invariants, conventions) lives in
 [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md); this folder is the *why* behind
 past calls, read on demand.
 
+- [GH-0227 — Parse workers route warnings to the parent; they never touch the console (issue #227)](GH-0227-route-worker-warnings-to-parent-0001.md)
 - [GH-0222 — Never send temperature to the OpenAI provider; GPT-5 rejects non-default values (issue #222)](GH-0222-omit-temperature-openai-0001.md)
 - [GH-0212 — Complete the v7→v8 additive upgrade rather than force a re-ingest (issue #212)](GH-0212-complete-v7-to-v8-additive-upgrade-0001.md)
 - [GH-0213 — Bound parse-worker memory so a long ingest doesn't OOM (issue #213)](GH-0213-bound-parse-worker-memory-0001.md)

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -1050,6 +1050,64 @@ def test_parse_document_reports_page_count(
     assert parsed.page_count == 1
 
 
+def test_parse_image_routes_routes_sub_minimum_warning_off_the_console(
+    tmp_path, monkeypatch
+):
+    """The observed #227 corruptor: a sub-minimum image notice must go to
+    ``on_warn`` (routed to the parent), never the console — this code runs in a
+    spawn worker with no Live display, so a console write would stomp the bar."""
+    from bartleby.commands import scribe as scribe_module
+
+    # Force every prepared image below the VLM minimum so the skip branch fires.
+    monkeypatch.setattr(
+        scribe_module.image_pipeline, "is_below_vlm_minimum", lambda *a, **k: True
+    )
+    # A worker must never touch the console; fail loudly if it tries.
+    monkeypatch.setattr(
+        scribe_module.console, "warn",
+        lambda *a, **k: pytest.fail("worker-side parse called console.warn"),
+    )
+
+    warnings: list[str] = []
+    route = scribe_module._ImageRoute(
+        bytes_=_png_bytes(), page_number=3, image_index_on_page=0,
+    )
+    images = scribe_module._parse_image_routes(
+        [route], archive_root=tmp_path / "archive", vision_enabled=True,
+        vision_max_dimension=1024, vision_min_dimension=128,
+        on_warn=warnings.append,
+    )
+
+    assert images == []
+    assert len(warnings) == 1
+    assert "page 3" in warnings[0]
+    assert "below the 128px vision minimum" in warnings[0]
+
+
+def test_parse_document_threads_on_warn_to_the_leaf(
+    isolated_project, tmp_path, mock_embed
+):
+    """on_warn reaches the leaf through the full dispatch chain: a standalone
+    image parsed with vision off surfaces the 'no vision provider' notice as a
+    routed warning, not a console write."""
+    from bartleby.commands import scribe as scribe_module
+
+    img = tmp_path / "pic.png"
+    img.write_bytes(_png_bytes())
+
+    warnings: list[str] = []
+    scribe_module._parse_document(
+        img, ".png", file_hash="h", file_name="pic.png",
+        pdf_converter="pdfplumber", html_converter="docling",
+        sparse_text_threshold=100, ocr_min_confidence=30,
+        vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=128,
+        archive_root=tmp_path / "archive",
+        on_warn=warnings.append,
+    )
+
+    assert warnings == ["Skipping 1 image(s) — no vision provider configured."]
+
+
 def test_caption_all_progress_callback_fires_per_image(
     isolated_project, tmp_path, mock_embed
 ):


### PR DESCRIPTION
Parse runs in spawn-pool worker processes, each with its own Console that
knows nothing about the parent's Rich Live progress region. When a worker
called console.warn directly (sub-minimum image skips, "no vision
provider", EDGAR inner-document skips), the raw stderr write interleaved
with the parent's frames and desynced the Live anchor — the "Run of show"
/ "Overall" headers stopped redrawing in place and stacked. Distinct from
#208 (which bounded the region's height); this is out-of-band writes from
another process.

Workers no longer touch the console. A new on_warn callback, threaded
parallel to the existing on_stage through the _parse_* chain, collects
notices into a warnings list that rides back on ParseOutcome; the
main-process drain emits them via console.warn, which coordinates with the
Live bar. Caption/summarize warnings already run in main-process threads
and are unchanged.

Invariant: code reachable from _parse_request must not call console.* — it
routes through on_warn.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)