### PR TITLE
Fix scribe crash on byte-identical duplicate files within one run

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -1031,16 +1031,24 @@ def _classify(
     sources: list[tuple[Path, str]],
     *,
     vision_enabled: bool,
-) -> tuple[list[ParseRequest], list[_ResumeItem], list[str]]:
+) -> tuple[list[ParseRequest], list[_ResumeItem], list[str], list[str]]:
     """Bucket each source by what the parse/caption drain still needs, all from
     DB state: already parsed+captioned (skip), parsed-but-uncaptioned (resume —
     no parse), or never parsed (hand to the pool). Summaries are not considered
     here — they're settled by their own pass over whatever the DB still lacks.
     Hashing + the resume lookups run here on the main process; only the parse
-    bucket crosses to workers."""
+    bucket crosses to workers.
+
+    A fourth bucket, ``duplicates``, catches two byte-identical files *within one
+    run*: ``documents.file_hash`` is UNIQUE, so only the first can persist. The
+    DB lookup can't see the in-run twin (neither is committed yet), so we track
+    hashes queued this run and divert the rest here rather than let the second
+    crash ``persist_parse`` (#225)."""
     to_parse: list[ParseRequest] = []
     to_resume: list[_ResumeItem] = []
     skipped: list[str] = []
+    duplicates: list[str] = []
+    queued_hashes: set[str] = set()
     for path, ext in sources:
         file_hash = _hash_file(path)
         document_id = writer.document_id_for(file_hash)
@@ -1050,15 +1058,19 @@ def _classify(
             else:
                 to_resume.append(_ResumeItem(document_id, path.name, file_hash))
             continue
+        if file_hash in queued_hashes:
+            duplicates.append(path.name)
+            continue
         if ext in IMAGE_EXTENSIONS and not vision_enabled:
             console.warn(
                 f"{path.name}: skipping image (no vision provider configured)."
             )
             continue
+        queued_hashes.add(file_hash)
         to_parse.append(
             ParseRequest(path=path, ext=ext, file_hash=file_hash, file_name=path.name)
         )
-    return to_parse, to_resume, skipped
+    return to_parse, to_resume, skipped, duplicates
 
 
 # -------------------- resolution / entry --------------------
@@ -1337,18 +1349,20 @@ def main(
         # that have never been parsed cross to the workers. Parsed-but-uncaptioned
         # docs resume on the main process — they need no parse, just the missing
         # captions. Summaries are settled afterwards by their own pass.
-        to_parse, to_resume, skipped = _classify(
+        to_parse, to_resume, skipped, duplicates = _classify(
             writer, sources,
             vision_enabled=parse_config.vision_enabled,
         )
         SKIP_DISPLAY_LIMIT = 3
-        for name in skipped[:SKIP_DISPLAY_LIMIT]:
-            console.info(f"Skipping {name} (already ingested)")
-        if len(skipped) > SKIP_DISPLAY_LIMIT:
-            console.info(
-                f"… and {len(skipped) - SKIP_DISPLAY_LIMIT} more file(s) "
-                f"skipped as already ingested"
-            )
+        for names, reason in ((skipped, "already ingested"),
+                              (duplicates, "duplicate content within this run")):
+            for name in names[:SKIP_DISPLAY_LIMIT]:
+                console.info(f"Skipping {name} ({reason})")
+            if len(names) > SKIP_DISPLAY_LIMIT:
+                console.info(
+                    f"… and {len(names) - SKIP_DISPLAY_LIMIT} more file(s) "
+                    f"skipped as {reason}"
+                )
 
         max_workers = _resolve_max_workers(config, timings=timings) if to_parse else 1
         caption_workers = _resolve_caption_workers(config, timings=timings)

--- a/bartleby/ingest/writer.py
+++ b/bartleby/ingest/writer.py
@@ -316,8 +316,16 @@ class Writer:
         separate unit. Image dedup is by byte-hash: an image already recorded
         by another document is reused, only the ``document_images`` join is
         added. Returns the new document_id.
+
+        Document dedup mirrors the image case: ``documents.file_hash`` is UNIQUE,
+        so a byte-identical document already persisted is reused rather than
+        crashed on the INSERT (#225). ``_classify`` already diverts in-run
+        duplicates up front; this is the belt-and-braces guard at the write itself.
         """
         with self.conn:
+            existing = self.document_id_for(parsed.file_hash)
+            if existing is not None:
+                return existing
             cur = self.conn.cursor()
             cur.execute(
                 "INSERT INTO documents "

--- a/docs/decisions/GH-0225-in-run-duplicate-files-dropped-with-count-0001.md
+++ b/docs/decisions/GH-0225-in-run-duplicate-files-dropped-with-count-0001.md
@@ -1,0 +1,33 @@
+# In-run duplicate files are dropped with a surfaced count, not aliased or provenance-tracked
+
+Issue #225. Two byte-identical files (same SHA-256 → same `file_hash`) in one
+ingest run used to crash on `documents.file_hash`'s UNIQUE constraint. The fix
+deduplicates within the run (`_classify` queued-hash bucket) and reuses the
+existing row at the write site (`persist_parse`). That left an open question:
+when the second file is detected as a duplicate, what do we do with it?
+
+Three options were on the table:
+
+- **(a)** Drop it, report a count (`Skipping <name> (duplicate content within
+  this run)`), record nothing.
+- **(b)** Record it somewhere as "duplicate-of `<document_id>`" for provenance.
+- **(c)** Add the duplicate's *filename* to the surviving document as an alias.
+
+## Decision
+
+Go with **(a)** — drop and count.
+
+It is the smallest fix that resolves the crash, needs no schema change, and
+keeps the existing reporting shape (it mirrors the `skipped` already-ingested
+tally right beside it). (b) and (c) both want a place to put data the schema
+doesn't have today, which is more than a bugfix should carry.
+
+## The tension, recorded so we don't forget it
+
+Dropping the duplicate's *name* is not obviously free. The
+corpus-filename-mislabeling history (ethics-agreement corpus, finding #22) shows
+filenames can carry signal a content hash can't — the same bytes filed under two
+different names may mean two different things to a researcher. So (b)/(c) remain
+legitimate follow-ups *if* provenance of dropped duplicates turns out to matter
+in practice. We are deferring them, not rejecting them; revisit if a corpus
+surfaces a case where the dropped filename was load-bearing.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -14,6 +14,7 @@ Current-state architecture (invariants, conventions) lives in
 [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md); this folder is the *why* behind
 past calls, read on demand.
 
+- [GH-0225 — In-run duplicate files are dropped with a surfaced count, not aliased or provenance-tracked (issue #225)](GH-0225-in-run-duplicate-files-dropped-with-count-0001.md)
 - [GH-0222 — Never send temperature to the OpenAI provider; GPT-5 rejects non-default values (issue #222)](GH-0222-omit-temperature-openai-0001.md)
 - [GH-0212 — Complete the v7→v8 additive upgrade rather than force a re-ingest (issue #212)](GH-0212-complete-v7-to-v8-additive-upgrade-0001.md)
 - [GH-0213 — Bound parse-worker memory so a long ingest doesn't OOM (issue #213)](GH-0213-bound-parse-worker-memory-0001.md)

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -187,6 +187,53 @@ def test_scribe_dedupes_identical_files(isolated_project, tmp_path, mock_embed):
         conn.close()
 
 
+def test_scribe_skips_within_run_duplicate(isolated_project, tmp_path, mock_embed):
+    """Two byte-identical files (different names) in ONE run persist a single
+    document instead of crashing on documents.file_hash UNIQUE (#225). The DB
+    lookup can't catch the in-run twin (neither is committed yet) — _classify's
+    queued-hash dedup does."""
+    a = _write_txt(tmp_path / "a.txt", "Same content")
+    b = _write_txt(tmp_path / "b.txt", "Same content")
+    scribe.main(project="test_proj", files=[str(a), str(b)])
+
+    conn = open_db("test_proj")
+    try:
+        n = conn.cursor().execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert n == 1
+    finally:
+        conn.close()
+
+
+def test_persist_parse_reuses_existing_file_hash(
+    isolated_project, tmp_path, mock_embed
+):
+    """persist_parse on a file_hash already in documents returns the existing id
+    rather than tripping the UNIQUE constraint — the write-site guard behind
+    _classify's dedup (#225)."""
+    from bartleby.commands import scribe as scribe_module
+
+    txt = _write_txt(tmp_path / "doc.txt", "A document body with real words to chunk.")
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    conn = open_db("test_proj")
+    try:
+        writer = scribe_module.Writer(conn)
+        parsed = scribe_module._parse_document(
+            txt, ".txt", file_hash="dup", file_name="doc.txt",
+            pdf_converter="pdfplumber", html_converter="docling",
+            sparse_text_threshold=100, ocr_min_confidence=30,
+            vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
+            archive_root=archive_root,
+        )
+        first = writer.persist_parse(parsed)
+        second = writer.persist_parse(parsed)
+        assert second == first
+        n = conn.cursor().execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert n == 1
+    finally:
+        conn.close()
+
+
 def test_scribe_writes_summary_when_provider_configured(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):


### PR DESCRIPTION
## Problem

A large ingest died mid-run with:

```
apsw.ConstraintError: UNIQUE constraint failed: documents.file_hash
```

`_classify` (the planner) deduped each source against the **DB** by hash, but never against the **other sources in the same run**. Two distinct files with byte-identical content both missed the DB lookup (neither committed yet), both queued, both reached `persist_parse`'s bare `INSERT INTO documents` — the second tripped the `NOT NULL UNIQUE` constraint and tore down the whole run. Observed on a ~9k-file PUC corpus (same filing across dockets / re-uploads), crashing ~5 hours of work at document 464.

The asymmetry was inside `persist_parse` itself: images already dedupe by hash and `document_images` uses `INSERT OR IGNORE`, but the top-level `documents` insert had no such guard.

## Fix

Two layers, mirroring the image-dedup pattern already in `persist_parse`:

1. **`_classify` dedupes within the run.** Tracks hashes queued this run; a source whose content is already queued goes to a new `duplicates` bucket, surfaced next to `skipped`, instead of being parsed twice and crashing.
2. **`persist_parse` tolerates an existing `file_hash`.** Reuses the existing `document_id` rather than a bare INSERT — belt-and-braces behind (1), covering replays.

Resume against an existing DB is unaffected — that path already skips/resumes by DB hash lookup. This is purely about two identical-content files in the *same* run.

The drop-with-count behavior (vs. recording provenance / aliasing the dropped filename) is recorded as a decision in `docs/decisions/` — the open question from the issue.

## Tests

- Two identical-content / different-name files in one `scribe.main` call → one `documents` row, no crash.
- `persist_parse` called twice with the same `file_hash` → second returns the existing id, one row.

No schema change (patch-level).

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
