### PR TITLE
Drop temperature on Opus 4.7+ regardless of reasoning_effort (#232)

### DIFF
--- a/bartleby/providers/anthropic.py
+++ b/bartleby/providers/anthropic.py
@@ -86,11 +86,12 @@ class AnthropicProvider:
         )
         if reasoning_effort and _supports_effort(model):
             kwargs["output_config"] = {"effort": _EFFORT_MAP[reasoning_effort]}
-            # Opus 4.7+ rejects temperature; the older effort-capable models still
-            # accept it, so we only drop it where it would 400.
-            if _drops_temperature(model):
-                _warn_dropped_temperature(temperature, model)
-                del kwargs["temperature"]
+        # Opus 4.7+ rejects temperature outright — a property of the model, not of
+        # whether we sent effort — so drop it wherever it would 400, independent of
+        # reasoning_effort. The older effort-capable models still accept it.
+        if _drops_temperature(model):
+            _warn_dropped_temperature(temperature, model)
+            del kwargs["temperature"]
         response = self._client.messages.create(**kwargs)
         return _extract_tool_input(response, _SUMMARY_TOOL, DocumentSummary)
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -108,6 +108,14 @@ def test_anthropic_effort_skipped_for_uncapable_model(monkeypatch):
     assert fake.last_call["temperature"] == 0.0
 
 
+def test_anthropic_drops_temperature_on_47plus_without_effort(monkeypatch):
+    # Opus 4.7+ rejects temperature whether or not effort is configured — so an
+    # unset reasoning_effort must still drop it, or every summarize call 400s.
+    fake = _summarize_with_effort(monkeypatch, model="claude-opus-4-8", effort=None)
+    assert "output_config" not in fake.last_call
+    assert "temperature" not in fake.last_call
+
+
 def test_anthropic_minimal_effort_maps_to_low(monkeypatch):
     # Anthropic has no "minimal" — our enum's minimal maps to the lowest, "low".
     fake = _summarize_with_effort(monkeypatch, model="claude-opus-4-8", effort="minimal")


### PR DESCRIPTION
## What

The temperature-drop for Opus 4.7+ in `AnthropicProvider.summarize()` was gated behind `reasoning_effort` being set. But temperature being rejected (400) on Opus 4.7/4.8 is a property of the **model**, not of the request — so an Opus 4.7/4.8 summarize provider with no `reasoning_effort` configured still forwarded `temperature` and 400'd on every call.

This lifts the drop out of the effort branch so it keys on the model alone (`_drops_temperature`), and adds the missing no-effort + 4.7+ regression test (`test_anthropic_drops_temperature_on_47plus_without_effort`).

Not a regression introduced by #232 — Opus 4.7/4.8 summarize was already broken pre-#232 (temperature always sent). #232 fixed it only when effort was set; this closes the remaining hole.

## Testing

- `tests/test_providers.py`: 21/21 pass.
- Full suite: 537 pass. The lone `test_progress.py::test_lanes_not_capped_off_a_terminal` failure is pre-existing on `omnibus/v0.8.4` and environment-only (assumes `sys.stderr` isn't a TTY; the bg-job harness gives it a pty, so lane-capping fires) — unrelated to this change, passes in normal CI.

Targets `omnibus/v0.8.4` (part of the v0.8.4 patch), no `SCHEMA_VERSION` bump, no re-ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)