### PR TITLE
Default `bartleby logs` to the active session, not the newest row

### DIFF
--- a/bartleby/commands/logs.py
+++ b/bartleby/commands/logs.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from bartleby.db.connection import open_db, resolve_project_name
+from bartleby.session import read_active_session_id
 
 
 _ARGS_TRUNCATE = 80
@@ -30,7 +31,7 @@ def _format_duration(ms: int | None) -> str:
     return f"{ms / 1000:.2f}s"
 
 
-def _resolve_session(conn, session: str | None):
+def _resolve_session(conn, session: str | None, project_name: str):
     cur = conn.cursor()
     if session:
         row = cur.execute(
@@ -40,6 +41,13 @@ def _resolve_session(conn, session: str | None):
             _console.print(f"[red]No session named '{session}'.[/red]")
             sys.exit(1)
         return row
+    active_id = read_active_session_id(project_name)
+    if active_id is not None:
+        row = cur.execute(
+            "SELECT session_id, name FROM sessions WHERE session_id = ?", (active_id,)
+        ).fetchone()
+        if row is not None:
+            return row
     return cur.execute(
         "SELECT session_id, name FROM sessions ORDER BY session_id DESC LIMIT 1"
     ).fetchone()
@@ -54,7 +62,7 @@ def main(*, session: str | None = None, limit: int = 50, project: str | None = N
 
     conn = open_db(project_name)
     try:
-        resolved = _resolve_session(conn, session)
+        resolved = _resolve_session(conn, session, project_name)
         if resolved is None:
             _console.print("No sessions yet.")
             return

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -10,6 +10,7 @@ import bartleby.project
 from bartleby.commands import logs as logs_cmd
 from bartleby.db.audit import log_call
 from bartleby.db.connection import open_db
+from bartleby.session import write_active_session_id
 
 
 @pytest.fixture
@@ -59,6 +60,34 @@ def test_logs_defaults_to_most_recent_session(project, capsys):
     newer = _add_session(project, "newer-sess")
     _add_log(project, session_id=older, tool_name="search_old")
     _add_log(project, session_id=newer, tool_name="search_new")
+
+    logs_cmd.main(session=None, limit=50, project=project)
+    out = capsys.readouterr().out
+    assert "newer-sess" in out
+    assert "search_new" in out
+    assert "search_old" not in out
+
+
+def test_logs_prefers_active_session_over_newest(project, capsys):
+    older = _add_session(project, "older-sess")
+    newer = _add_session(project, "newer-sess")
+    _add_log(project, session_id=older, tool_name="search_old")
+    _add_log(project, session_id=newer, tool_name="search_new")
+    write_active_session_id(project, older)
+
+    logs_cmd.main(session=None, limit=50, project=project)
+    out = capsys.readouterr().out
+    assert "older-sess" in out
+    assert "search_old" in out
+    assert "search_new" not in out
+
+
+def test_logs_falls_back_to_newest_when_active_id_stale(project, capsys):
+    older = _add_session(project, "older-sess")
+    newer = _add_session(project, "newer-sess")
+    _add_log(project, session_id=older, tool_name="search_old")
+    _add_log(project, session_id=newer, tool_name="search_new")
+    write_active_session_id(project, 9999)  # no such session row
 
     logs_cmd.main(session=None, limit=50, project=project)
     out = capsys.readouterr().out


### PR DESCRIPTION
_Part of #255._

**Problem.** With no `--session`, `_resolve_session` picked `ORDER BY session_id DESC LIMIT 1` — the most recently *created* session. The web UI and skill auto-creation can mint sessions after the one the user is in, so the default silently showed a different session than `bartleby session current`.

**Fix.** Prefer `read_active_session_id(project)`, falling back to the newest row when no session is active or the active id has no matching row. No schema bump.

**Tests.** Added two cases — active session preferred over newest; stale active id falls back to newest. Full suite: 540 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)