### PR TITLE
Chmod ~/.bartleby/config.yaml to 0600 in save_config

### DIFF
--- a/bartleby/config.py
+++ b/bartleby/config.py
@@ -88,6 +88,10 @@ def save_config(config: dict) -> None:
         yaml.safe_dump(config, default_flow_style=False, sort_keys=False),
         encoding="utf-8",
     )
+    # The config holds provider API keys; keep it owner-only. ``write_text``
+    # leaves an existing file's mode untouched and a fresh file at the umask
+    # default (typically 0644), so set the bits explicitly on every save.
+    CONFIG_PATH.chmod(0o600)
 
 
 def save_config_field(key: str, value: Any) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ import pytest
 
 import bartleby.config
 import bartleby.commands.config as config
-from bartleby.config import config_drift, redact_config
+from bartleby.config import config_drift, redact_config, save_config
 
 
 @pytest.fixture
@@ -317,6 +317,24 @@ def test_redact_config_matches_token_secret_password_credential():
         "gcp_credential": "c",
     }
     assert redact_config(cfg) == {"keep": 1}
+
+
+# -------------------- config file permissions --------------------
+
+
+def test_save_config_writes_owner_only_mode(isolated_config):
+    # The config holds provider API keys; it must not be world-readable.
+    save_config({"anthropic_api_key": "sk-secret"})
+    assert isolated_config.stat().st_mode & 0o777 == 0o600
+
+
+def test_save_config_tightens_preexisting_loose_mode(isolated_config):
+    # write_text leaves an existing file's mode untouched, so an already-0644
+    # config must still get clamped back to 0600 on the next save.
+    isolated_config.write_text("anthropic_api_key: old\n", encoding="utf-8")
+    isolated_config.chmod(0o644)
+    save_config({"anthropic_api_key": "sk-new"})
+    assert isolated_config.stat().st_mode & 0o777 == 0o600
 
 
 def test_config_drift_none_prior_is_silent():


### PR DESCRIPTION
Part of #255.

**Problem.** `save_config` persisted `~/.bartleby/config.yaml` with a bare `write_text` — fresh files land at the umask default (typically 0644) and `write_text` leaves an existing file's mode untouched. That file holds the provider API keys (ANTHROPIC/OPENAI/Gemini), left world-readable.

**Fix.** `CONFIG_PATH.chmod(0o600)` after the write, set explicitly on every save, mirroring the chmod-is-load-bearing pattern already used for the scratch dir (`ensure_scratch_dir`, config.py:27-37).

**Tests.** Two cases pin the mode: a fresh-file write and the load-bearing preexisting-0644 → 0600 clamp.

**Acceptance criteria** (from #257): after `bartleby config`, `~/.bartleby/config.yaml` has mode 0600. ✅ — No schema bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)