### PR TITLE
Render post-truncation input token count in benchmark tables

### DIFF
--- a/benchmarks/examine.py
+++ b/benchmarks/examine.py
@@ -54,6 +54,22 @@ def _config(records: list[dict]) -> dict:
     return next((r for r in records if r.get("kind") == "config"), {})
 
 
+def _input_tokens_label(cfg: dict) -> str:
+    """Token count the models actually saw, annotating truncation.
+
+    A truncated run was fed exactly `--max-tokens`, so spell out the elision
+    ("50,000 of 80,000 input tokens") rather than the full source count — which
+    the original title overstated. Derived from the existing record fields, so
+    pre-fix benchmark JSONL renders correctly too.
+    """
+    full = cfg.get("source_token_count")
+    if full is None:
+        return "? input tokens"
+    if cfg.get("source_truncated"):
+        return f"{cfg['max_tokens']:,} of {full:,} input tokens"
+    return f"{full:,} input tokens"
+
+
 def _runs_by_model(records: list[dict]) -> dict[str, list[dict]]:
     by_model: dict[str, list[dict]] = defaultdict(list)
     for r in records:
@@ -158,7 +174,7 @@ def cmd_timings(args) -> int:
         rows.append([(s["model"], None), schema, inf, tps, ev])
 
     title = (f"Timings · {cfg.get('pdf_name', '?')} · "
-             f"{cfg.get('source_token_count', '?')} input tokens · "
+             f"{_input_tokens_label(cfg)} · "
              f"temp {cfg.get('temperature', '?')}")
     emit_table(title, columns, rows)
     note("Inference (s) = wall − load_duration (cold-start excluded); Tok/s from "
@@ -296,7 +312,7 @@ def cmd_leaderboard(args) -> int:
     survivors.sort(key=lambda s: (-(s["quality"] or -1), -s["tps"]))
 
     title = (f"Summarizer leaderboard · {cfg.get('pdf_name', '?')} · "
-             f"{cfg.get('source_token_count', '?')} input tokens · "
+             f"{_input_tokens_label(cfg)} · "
              f"temp {cfg.get('temperature', '?')}")
     columns = [("Model", "left"), ("Schema-valid %", "right"), ("Tok/s", "right"),
                ("Inference (s)", "right"), ("Mean quality (/5)", "right"), ("Frontier", "center")]


### PR DESCRIPTION
`examine.py`'s timings/leaderboard titles rendered `source_token_count` — the *pre*-truncation count — overstating what models saw for any source over `--max-tokens`, while the recorded `source_truncated` flag went unsurfaced.

Adds `_input_tokens_label(cfg)`: renders the count models were actually fed, spelling out truncation as **"50,000 of 80,000 input tokens"** (vs **"80,000 input tokens"** when untruncated, now comma-formatted). Derived from the existing `source_token_count`/`source_truncated`/`max_tokens` record fields — a truncated run was fed exactly `max_tokens` — so **no new persisted state** and pre-fix benchmark JSONL renders correctly too.

*(Deviation from the issue's suggested fix: rather than store `input_token_count` in the config record, it's computed consumer-side — simpler, no schema-ish field, and fixes old records. Same rendered output.)*

Tests: `uv run pytest` — 538 passed.

Part of #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)