### PR TITLE
Fix leading-dash web search/scan queries (#258)

### DIFF
--- a/bartleby/web/src/lib/server/skill.js
+++ b/bartleby/web/src/lib/server/skill.js
@@ -48,7 +48,9 @@ export function toSkillError(e) {
  */
 export function runSkill(name, args = []) {
   const { project } = getDb();
-  const argv = ['skill', name, ...args.map(String), '--project', project];
+  // --project leads the user args so a trailing `--` sentinel (search/scan use
+  // one to fence a leading-dash query) keeps everything after it positional.
+  const argv = ['skill', name, '--project', project, ...args.map(String)];
 
   return new Promise((resolve, reject) => {
     const child = spawn(BARTLEBY_BIN, argv, {

--- a/bartleby/web/src/routes/search/+page.server.js
+++ b/bartleby/web/src/routes/search/+page.server.js
@@ -26,7 +26,10 @@ export async function load({ url }) {
   if (!q) return { params, available, result: null, error: null };
 
   try {
-    const args = [q, '--limit', limit];
+    // Build options first; the query is appended last after a `--` sentinel so
+    // a leading-dash term (`-foo`, `-LRB-`) reaches argparse as the positional
+    // rather than an unknown option (which 500s the page as BAD_OUTPUT).
+    const args = ['--limit', limit];
     if (docs) args.push('--in-documents', docs);
     for (const t of tags) args.push('--tag', t);
 
@@ -34,6 +37,7 @@ export async function load({ url }) {
     if (mode === 'scan') {
       if (matchTerms) args.push('--match-terms');
       if (offset) args.push('--offset', offset);
+      args.push('--', q);
       result = await runSkill('scan', args);
       // Add summary title/description + a source link to each match.
       result.matches = enrichScanMatches(result.matches);
@@ -43,6 +47,7 @@ export async function load({ url }) {
       const effective = kinds.length ? kinds : DEFAULT_KINDS;
       for (const k of effective) args.push(`--${k}`);
       if (context) args.push('--add-context', context);
+      args.push('--', q);
       result = await runSkill('search', args);
       result.results = enrichHits(result.results);
     }


### PR DESCRIPTION
_Part of #255._

**Problem.** A web search/scan whose query starts with a non-numeric dash (`-foo`, `-LRB-`) was passed as the first argv token, so Python argparse treated it as an unknown option → `SystemExit(2)`, non-JSON stdout, and the page rendered a `BAD_OUTPUT` "Search failed" instead of results.

**Fix.** Build the CLI options first and append the query last after a `--` end-of-options sentinel; move `--project` ahead of the user args in `runSkill` so everything after the sentinel stays positional. Final argv: `bartleby skill search --project X --limit 20 -- -foo` → `query='-foo'`. No schema bump.

**Tests.** `uv run pytest` — 538 passed. (Diff is JS-only; no `.py`/`pyproject.toml` touched, but `skip-tests` was not requested so the full suite ran.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)