### PR TITLE
Gate temperature in AnthropicProvider.classify (Opus 4.7+ 400s)

### DIFF
--- a/bartleby/providers/anthropic.py
+++ b/bartleby/providers/anthropic.py
@@ -103,7 +103,7 @@ class AnthropicProvider:
         schema: type[BaseModel],
         temperature: float = 0.0,
     ) -> BaseModel:
-        response = self._client.messages.create(
+        kwargs: dict = dict(
             model=model,
             max_tokens=2048,
             temperature=temperature,
@@ -115,6 +115,13 @@ class AnthropicProvider:
             }],
             tool_choice={"type": "tool", "name": _CLASSIFY_TOOL},
         )
+        # Opus 4.7+ rejects temperature outright (see summarize) — drop it wherever
+        # it would 400. Tag classification reuses the summarizer's model, so a
+        # 4.7+ config would otherwise 400 on every classify call.
+        if _drops_temperature(model):
+            _warn_dropped_temperature(temperature, model)
+            del kwargs["temperature"]
+        response = self._client.messages.create(**kwargs)
         return _extract_tool_input(response, _CLASSIFY_TOOL, schema)
 
     def analyze_image(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -122,6 +122,36 @@ def test_anthropic_minimal_effort_maps_to_low(monkeypatch):
     assert fake.last_call["output_config"] == {"effort": "low"}
 
 
+def _classify_on(monkeypatch, model):
+    class _Schema(BaseModel):
+        ok: bool
+
+    response = _FakeAnthropicResponse([
+        _block("tool_use", name="save_classification", input_={"ok": True}),
+    ])
+    fake = _install_anthropic(monkeypatch, response)
+    from bartleby.providers.anthropic import AnthropicProvider
+    result = AnthropicProvider().classify(
+        "prompt", model=model, schema=_Schema, temperature=0.3,
+    )
+    return fake, result
+
+
+def test_anthropic_classify_drops_temperature_on_47plus(monkeypatch):
+    # Opus 4.7+ 400s on temperature; classify reuses the summarizer's model, so it
+    # must drop temperature too or every tag-classification call fails.
+    fake, result = _classify_on(monkeypatch, "claude-opus-4-8")
+    assert result.ok is True
+    assert fake.last_call["tool_choice"]["name"] == "save_classification"
+    assert "temperature" not in fake.last_call
+
+
+def test_anthropic_classify_keeps_temperature_on_older_model(monkeypatch):
+    # Models that accept temperature still get it — don't over-drop.
+    fake, _ = _classify_on(monkeypatch, "claude-haiku-4-5")
+    assert fake.last_call["temperature"] == 0.3
+
+
 def test_anthropic_analyze_image_validates_tool_input(monkeypatch):
     response = _FakeAnthropicResponse([
         _block("tool_use", name="save_image_description", input_=_VLM_INPUT),


### PR DESCRIPTION
`classify()` sent `temperature` unconditionally, so a config naming `claude-opus-4-7/4-8` — whose summaries already work via #250 — got a hard API 400 from *every* tag-classification call (tag classification reuses the summarizer's model/temperature).

Applies the same `_drops_temperature` / `_warn_dropped_temperature` gate `summarize()` uses, sharing the one-time warning. Adds two tests: `classify` on `claude-opus-4-8` sends no `temperature`; on `claude-haiku-4-5` it's still sent.

No schema bump. Part of #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)