### PR TITLE
v0.8.6 — independent hardening & polish

### DIFF
--- a/bartleby/commands/logs.py
+++ b/bartleby/commands/logs.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from bartleby.db.connection import open_db, resolve_project_name
+from bartleby.session import read_active_session_id
 
 
 _ARGS_TRUNCATE = 80
@@ -30,7 +31,7 @@ def _format_duration(ms: int | None) -> str:
     return f"{ms / 1000:.2f}s"
 
 
-def _resolve_session(conn, session: str | None):
+def _resolve_session(conn, session: str | None, project_name: str):
     cur = conn.cursor()
     if session:
         row = cur.execute(
@@ -40,6 +41,13 @@ def _resolve_session(conn, session: str | None):
             _console.print(f"[red]No session named '{session}'.[/red]")
             sys.exit(1)
         return row
+    active_id = read_active_session_id(project_name)
+    if active_id is not None:
+        row = cur.execute(
+            "SELECT session_id, name FROM sessions WHERE session_id = ?", (active_id,)
+        ).fetchone()
+        if row is not None:
+            return row
     return cur.execute(
         "SELECT session_id, name FROM sessions ORDER BY session_id DESC LIMIT 1"
     ).fetchone()
@@ -54,7 +62,7 @@ def main(*, session: str | None = None, limit: int = 50, project: str | None = N
 
     conn = open_db(project_name)
     try:
-        resolved = _resolve_session(conn, session)
+        resolved = _resolve_session(conn, session, project_name)
         if resolved is None:
             _console.print("No sessions yet.")
             return

--- a/bartleby/config.py
+++ b/bartleby/config.py
@@ -88,6 +88,10 @@ def save_config(config: dict) -> None:
         yaml.safe_dump(config, default_flow_style=False, sort_keys=False),
         encoding="utf-8",
     )
+    # The config holds provider API keys; keep it owner-only. ``write_text``
+    # leaves an existing file's mode untouched and a fresh file at the umask
+    # default (typically 0644), so set the bits explicitly on every save.
+    CONFIG_PATH.chmod(0o600)
 
 
 def save_config_field(key: str, value: Any) -> None:

--- a/bartleby/providers/anthropic.py
+++ b/bartleby/providers/anthropic.py
@@ -103,7 +103,7 @@ class AnthropicProvider:
         schema: type[BaseModel],
         temperature: float = 0.0,
     ) -> BaseModel:
-        response = self._client.messages.create(
+        kwargs: dict = dict(
             model=model,
             max_tokens=2048,
             temperature=temperature,
@@ -115,6 +115,13 @@ class AnthropicProvider:
             }],
             tool_choice={"type": "tool", "name": _CLASSIFY_TOOL},
         )
+        # Opus 4.7+ rejects temperature outright (see summarize) — drop it wherever
+        # it would 400. Tag classification reuses the summarizer's model, so a
+        # 4.7+ config would otherwise 400 on every classify call.
+        if _drops_temperature(model):
+            _warn_dropped_temperature(temperature, model)
+            del kwargs["temperature"]
+        response = self._client.messages.create(**kwargs)
         return _extract_tool_input(response, _CLASSIFY_TOOL, schema)
 
     def analyze_image(

--- a/bartleby/web/src/lib/server/skill.js
+++ b/bartleby/web/src/lib/server/skill.js
@@ -48,7 +48,9 @@ export function toSkillError(e) {
  */
 export function runSkill(name, args = []) {
   const { project } = getDb();
-  const argv = ['skill', name, ...args.map(String), '--project', project];
+  // --project leads the user args so a trailing `--` sentinel (search/scan use
+  // one to fence a leading-dash query) keeps everything after it positional.
+  const argv = ['skill', name, '--project', project, ...args.map(String)];
 
   return new Promise((resolve, reject) => {
     const child = spawn(BARTLEBY_BIN, argv, {

--- a/bartleby/web/src/routes/search/+page.server.js
+++ b/bartleby/web/src/routes/search/+page.server.js
@@ -26,7 +26,10 @@ export async function load({ url }) {
   if (!q) return { params, available, result: null, error: null };
 
   try {
-    const args = [q, '--limit', limit];
+    // Build options first; the query is appended last after a `--` sentinel so
+    // a leading-dash term (`-foo`, `-LRB-`) reaches argparse as the positional
+    // rather than an unknown option (which 500s the page as BAD_OUTPUT).
+    const args = ['--limit', limit];
     if (docs) args.push('--in-documents', docs);
     for (const t of tags) args.push('--tag', t);
 
@@ -34,6 +37,7 @@ export async function load({ url }) {
     if (mode === 'scan') {
       if (matchTerms) args.push('--match-terms');
       if (offset) args.push('--offset', offset);
+      args.push('--', q);
       result = await runSkill('scan', args);
       // Add summary title/description + a source link to each match.
       result.matches = enrichScanMatches(result.matches);
@@ -43,6 +47,7 @@ export async function load({ url }) {
       const effective = kinds.length ? kinds : DEFAULT_KINDS;
       for (const k of effective) args.push(`--${k}`);
       if (context) args.push('--add-context', context);
+      args.push('--', q);
       result = await runSkill('search', args);
       result.results = enrichHits(result.results);
     }

--- a/benchmarks/examine.py
+++ b/benchmarks/examine.py
@@ -54,6 +54,22 @@ def _config(records: list[dict]) -> dict:
     return next((r for r in records if r.get("kind") == "config"), {})
 
 
+def _input_tokens_label(cfg: dict) -> str:
+    """Token count the models actually saw, annotating truncation.
+
+    A truncated run was fed exactly `--max-tokens`, so spell out the elision
+    ("50,000 of 80,000 input tokens") rather than the full source count — which
+    the original title overstated. Derived from the existing record fields, so
+    pre-fix benchmark JSONL renders correctly too.
+    """
+    full = cfg.get("source_token_count")
+    if full is None:
+        return "? input tokens"
+    if cfg.get("source_truncated"):
+        return f"{cfg['max_tokens']:,} of {full:,} input tokens"
+    return f"{full:,} input tokens"
+
+
 def _runs_by_model(records: list[dict]) -> dict[str, list[dict]]:
     by_model: dict[str, list[dict]] = defaultdict(list)
     for r in records:
@@ -158,7 +174,7 @@ def cmd_timings(args) -> int:
         rows.append([(s["model"], None), schema, inf, tps, ev])
 
     title = (f"Timings · {cfg.get('pdf_name', '?')} · "
-             f"{cfg.get('source_token_count', '?')} input tokens · "
+             f"{_input_tokens_label(cfg)} · "
              f"temp {cfg.get('temperature', '?')}")
     emit_table(title, columns, rows)
     note("Inference (s) = wall − load_duration (cold-start excluded); Tok/s from "
@@ -296,7 +312,7 @@ def cmd_leaderboard(args) -> int:
     survivors.sort(key=lambda s: (-(s["quality"] or -1), -s["tps"]))
 
     title = (f"Summarizer leaderboard · {cfg.get('pdf_name', '?')} · "
-             f"{cfg.get('source_token_count', '?')} input tokens · "
+             f"{_input_tokens_label(cfg)} · "
              f"temp {cfg.get('temperature', '?')}")
     columns = [("Model", "left"), ("Schema-valid %", "right"), ("Tok/s", "right"),
                ("Inference (s)", "right"), ("Mean quality (/5)", "right"), ("Frontier", "center")]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ import pytest
 
 import bartleby.config
 import bartleby.commands.config as config
-from bartleby.config import config_drift, redact_config
+from bartleby.config import config_drift, redact_config, save_config
 
 
 @pytest.fixture
@@ -317,6 +317,24 @@ def test_redact_config_matches_token_secret_password_credential():
         "gcp_credential": "c",
     }
     assert redact_config(cfg) == {"keep": 1}
+
+
+# -------------------- config file permissions --------------------
+
+
+def test_save_config_writes_owner_only_mode(isolated_config):
+    # The config holds provider API keys; it must not be world-readable.
+    save_config({"anthropic_api_key": "sk-secret"})
+    assert isolated_config.stat().st_mode & 0o777 == 0o600
+
+
+def test_save_config_tightens_preexisting_loose_mode(isolated_config):
+    # write_text leaves an existing file's mode untouched, so an already-0644
+    # config must still get clamped back to 0600 on the next save.
+    isolated_config.write_text("anthropic_api_key: old\n", encoding="utf-8")
+    isolated_config.chmod(0o644)
+    save_config({"anthropic_api_key": "sk-new"})
+    assert isolated_config.stat().st_mode & 0o777 == 0o600
 
 
 def test_config_drift_none_prior_is_silent():

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -10,6 +10,7 @@ import bartleby.project
 from bartleby.commands import logs as logs_cmd
 from bartleby.db.audit import log_call
 from bartleby.db.connection import open_db
+from bartleby.session import write_active_session_id
 
 
 @pytest.fixture
@@ -59,6 +60,34 @@ def test_logs_defaults_to_most_recent_session(project, capsys):
     newer = _add_session(project, "newer-sess")
     _add_log(project, session_id=older, tool_name="search_old")
     _add_log(project, session_id=newer, tool_name="search_new")
+
+    logs_cmd.main(session=None, limit=50, project=project)
+    out = capsys.readouterr().out
+    assert "newer-sess" in out
+    assert "search_new" in out
+    assert "search_old" not in out
+
+
+def test_logs_prefers_active_session_over_newest(project, capsys):
+    older = _add_session(project, "older-sess")
+    newer = _add_session(project, "newer-sess")
+    _add_log(project, session_id=older, tool_name="search_old")
+    _add_log(project, session_id=newer, tool_name="search_new")
+    write_active_session_id(project, older)
+
+    logs_cmd.main(session=None, limit=50, project=project)
+    out = capsys.readouterr().out
+    assert "older-sess" in out
+    assert "search_old" in out
+    assert "search_new" not in out
+
+
+def test_logs_falls_back_to_newest_when_active_id_stale(project, capsys):
+    older = _add_session(project, "older-sess")
+    newer = _add_session(project, "newer-sess")
+    _add_log(project, session_id=older, tool_name="search_old")
+    _add_log(project, session_id=newer, tool_name="search_new")
+    write_active_session_id(project, 9999)  # no such session row
 
     logs_cmd.main(session=None, limit=50, project=project)
     out = capsys.readouterr().out

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -122,6 +122,36 @@ def test_anthropic_minimal_effort_maps_to_low(monkeypatch):
     assert fake.last_call["output_config"] == {"effort": "low"}
 
 
+def _classify_on(monkeypatch, model):
+    class _Schema(BaseModel):
+        ok: bool
+
+    response = _FakeAnthropicResponse([
+        _block("tool_use", name="save_classification", input_={"ok": True}),
+    ])
+    fake = _install_anthropic(monkeypatch, response)
+    from bartleby.providers.anthropic import AnthropicProvider
+    result = AnthropicProvider().classify(
+        "prompt", model=model, schema=_Schema, temperature=0.3,
+    )
+    return fake, result
+
+
+def test_anthropic_classify_drops_temperature_on_47plus(monkeypatch):
+    # Opus 4.7+ 400s on temperature; classify reuses the summarizer's model, so it
+    # must drop temperature too or every tag-classification call fails.
+    fake, result = _classify_on(monkeypatch, "claude-opus-4-8")
+    assert result.ok is True
+    assert fake.last_call["tool_choice"]["name"] == "save_classification"
+    assert "temperature" not in fake.last_call
+
+
+def test_anthropic_classify_keeps_temperature_on_older_model(monkeypatch):
+    # Models that accept temperature still get it — don't over-drop.
+    fake, _ = _classify_on(monkeypatch, "claude-haiku-4-5")
+    assert fake.last_call["temperature"] == 0.3
+
+
 def test_anthropic_analyze_image_validates_tool_input(monkeypatch):
     response = _FakeAnthropicResponse([
         _block("tool_use", name="save_image_description", input_=_VLM_INPUT),


### PR DESCRIPTION
Promotes the `v0.8.6` bundle: five file-disjoint correctness/hardening fixes, no schema bump, no re-ingest (`SCHEMA_VERSION` 8).

- #256 — gate `temperature` in `AnthropicProvider.classify` (Opus 4.7+ 400s)
- #257 — `chmod 0600` on `~/.bartleby/config.yaml` (was world-readable)
- #258 — fix leading-dash web search/scan queries (argparse `--`)
- #259 — `bartleby logs` defaults to the active session, not newest row
- #260 — render post-truncation input token count in benchmark tables

Closes #255
Closes #256
Closes #257
Closes #258
Closes #259
Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)