### PR TITLE
guard-main-write.sh: gate git push on refspec destination, not current branch

### DIFF
--- a/.claude/hooks/guard-main-write.sh
+++ b/.claude/hooks/guard-main-write.sh
@@ -16,6 +16,16 @@
 # non-option token, skipping git's global options) is commit or push. So
 # `git log --grep commit` and `echo 'git commit'` are NOT blocked.
 #
+# Push is judged by *where it writes*, not the current branch. A `git push`
+# carrying an explicit positional refspec is gated on that refspec's destination
+# ref — blocked only when it resolves to main/master (`origin main`, `HEAD:main`,
+# `develop:main`, `+main`, `refs/heads/main`, `--delete main` all count). So an
+# explicit non-main push (`push -u origin issue/42-foo`) is allowed even from
+# main — which the ship workflow needs to create an omnibus branch. A push with
+# no positional refspec (bare `git push`, `git push origin`, `--all`, `--mirror`)
+# would resolve through the configured upstream / push.default; we don't parse
+# that, so it falls back to the current-branch check, exactly like commit.
+#
 # Known limitation: a separator (`;` `&` `|`) or a `cd`/git line *inside quotes
 # or a here-doc* is still treated structurally (no real shell parsing), so it can
 # mis-resolve. Rare in practice and overridable by running the command yourself
@@ -61,6 +71,46 @@ git_dir_opt() {
   done
 }
 
+# Destination ref of a `git push` segment's positional refspec, normalized, or
+# empty when the push carries no positional refspec (bare push / remote-only /
+# --all / --mirror — those fall back to the branch check, preserving prior
+# behavior). Only called after git_subcommand matched push, so TOKS[0] is git.
+push_dest_ref() {
+  local -a TOKS; _tokenize "$1"
+  local i=1 n=${#TOKS[@]}
+  # Skip git's global options to reach the `push` subcommand token.
+  while [ "$i" -lt "$n" ]; do
+    case "${TOKS[$i]}" in
+      -C|-c|--git-dir|--work-tree|--namespace|--exec-path) i=$((i + 2)) ;;
+      -*) i=$((i + 1)) ;;
+      *) break ;;
+    esac
+  done
+  i=$((i + 1))   # step past `push`
+  # Walk push args, collecting positionals: #1 is the remote, #2 the refspec.
+  # Skip the push options that consume the following token, lest their value be
+  # mistaken for the remote (`push -o ci.skip origin main`).
+  local pos=0 refspec=""
+  while [ "$i" -lt "$n" ]; do
+    case "${TOKS[$i]}" in
+      -o|--push-option|--repo|--receive-pack|--exec) i=$((i + 2)) ;;
+      -*) i=$((i + 1)) ;;
+      *)
+        pos=$((pos + 1))
+        [ "$pos" -eq 2 ] && { refspec="${TOKS[$i]}"; break; }
+        i=$((i + 1))
+        ;;
+    esac
+  done
+  [ -n "$refspec" ] || return 0
+  # Normalize to the destination ref: drop a leading '+' (force), keep the part
+  # after the last ':' (src:dst → dst), drop a refs/heads/ prefix.
+  refspec="${refspec#+}"
+  refspec="${refspec##*:}"
+  refspec="${refspec#refs/heads/}"
+  printf '%s' "$refspec"
+}
+
 # Absolute path of $2 resolved from base $1, or empty if it doesn't exist.
 resolve_dir() { (cd "$1" 2>/dev/null && cd "$2" 2>/dev/null && pwd) || true; }
 
@@ -79,10 +129,22 @@ for seg in $(printf '%s' "$cmd" | tr ';&|' '\n'); do
     continue
   fi
 
-  case "$(git_subcommand "$seg")" in
+  sub=$(git_subcommand "$seg")
+  case "$sub" in
     commit|push) ;;
     *) continue ;;
   esac
+
+  # An explicit push refspec is judged by its destination ref, not the branch:
+  # block only when it writes main/master. A refspec-less push falls through to
+  # the branch check below, like commit.
+  if [ "$sub" = "push" ]; then
+    dest=$(push_dest_ref "$seg")
+    if [ -n "$dest" ]; then
+      case "$dest" in main|master) blocked=1 ;; esac
+      continue
+    fi
+  fi
 
   check_dir="$eff_cwd"
   dopt=$(git_dir_opt "$seg")

--- a/tests/test_guard_main_write.py
+++ b/tests/test_guard_main_write.py
@@ -1,0 +1,100 @@
+"""Behavioral tests for the /ship guard hook (`.claude/hooks/guard-main-write.sh`).
+
+The hook reads a PreToolUse(Bash) event as JSON on stdin and exits 2 to block or
+0 to allow. We drive it as a subprocess against a throwaway git repo so the
+current-branch fallback (bare push, commit) has a real HEAD to read.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[1] / ".claude" / "hooks" / "guard-main-write.sh"
+
+BLOCK = 2
+ALLOW = 0
+
+
+def _run(command: str, cwd: Path) -> int:
+    payload = json.dumps({"tool_input": {"command": command}, "cwd": str(cwd)})
+    proc = subprocess.run(
+        ["bash", str(HOOK)], input=payload, capture_output=True, text=True
+    )
+    return proc.returncode
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo_on_main(tmp_path: Path) -> Path:
+    """A repo with one commit, a `feature` branch, currently checked out on main."""
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@t.t")
+    _git(tmp_path, "config", "user.name", "t")
+    _git(tmp_path, "commit", "--allow-empty", "-m", "init")
+    _git(tmp_path, "branch", "feature")
+    return tmp_path
+
+
+# (command, expected) evaluated with HEAD on `main`.
+ON_MAIN = [
+    # Explicit non-main refspec → allowed even though HEAD is main (the point).
+    ("git push -u origin omnibus/v0.8.7", ALLOW),
+    ("git push origin issue/248-foo", ALLOW),
+    ("git push origin HEAD:issue/248-foo", ALLOW),
+    ("git push -o ci.skip origin feature", ALLOW),  # option-value not read as remote
+    ("git push origin --delete feature", ALLOW),
+    # Refspec-less push → upstream-resolving → branch fallback → blocked on main.
+    ("git push", BLOCK),
+    ("git push origin", BLOCK),
+    ("git push --all origin", BLOCK),
+    ("git push --mirror origin", BLOCK),
+    # Explicit main destination, in every spelling → blocked.
+    ("git push origin main", BLOCK),
+    ("git push origin HEAD:main", BLOCK),
+    ("git push origin +main", BLOCK),
+    ("git push origin refs/heads/main", BLOCK),
+    ("git push origin develop:main", BLOCK),
+    ("git push origin --delete main", BLOCK),
+    ("git push -o ci.skip origin main", BLOCK),
+    # commit stays current-branch-gated.
+    ("git commit -m wip", BLOCK),
+    ("git -C . commit -m wip", BLOCK),
+    # Not a gated git write.
+    ("echo git push origin main", ALLOW),
+    ("git log --grep commit", ALLOW),
+    ("git pull --ff-only origin main", ALLOW),
+]
+
+
+@pytest.mark.parametrize("command, expected", ON_MAIN)
+def test_on_main(repo_on_main: Path, command: str, expected: int) -> None:
+    assert _run(command, repo_on_main) == expected
+
+
+# (command, expected) evaluated with HEAD on `feature`.
+ON_FEATURE = [
+    ("git push", ALLOW),  # fallback: not on main
+    ("git push origin feature", ALLOW),
+    ("git commit -m wip", ALLOW),
+    # An explicit main push is blocked regardless of which branch is checked out.
+    ("git push origin main", BLOCK),
+    ("git push origin HEAD:main", BLOCK),
+]
+
+
+@pytest.mark.parametrize("command, expected", ON_FEATURE)
+def test_on_feature(repo_on_main: Path, command: str, expected: int) -> None:
+    _git(repo_on_main, "checkout", "feature")
+    assert _run(command, repo_on_main) == expected
+
+
+def test_cd_into_worktree_then_push_main_is_blocked(repo_on_main: Path) -> None:
+    """A leading `cd` moves the effective dir; an explicit main push still blocks."""
+    assert _run(f"cd {repo_on_main} && git push origin main", repo_on_main.parent) == BLOCK


### PR DESCRIPTION
## What

The `/ship` guard hook blocked *any* `git push` whenever HEAD was on main, regardless of what the push actually wrote. That refused legitimate explicit non-main pushes from the main checkout — notably the ship skill's own omnibus-branch creation (`git push -u origin omnibus/vX.Y.Z`), which is exactly how this issue surfaced.

## Change

A `git push` carrying an **explicit positional refspec** is now judged by that refspec's **destination ref** — blocked only when it resolves to `main`/`master`. Normalization handles every spelling: `origin main`, `HEAD:main`, `develop:main`, `+main`, `refs/heads/main`, `--delete main`. Option-values (`-o ci.skip`) are skipped so they aren't mistaken for the remote.

A **refspec-less** push (bare `git push`, `git push origin`, `--all`, `--mirror`) would resolve through the configured upstream / `push.default`, which the hook deliberately does not parse — it falls back to the existing current-branch check, **identical to prior behavior**. `commit` gating is unchanged.

**Net effect is purely additive:** explicit non-main pushes are now allowed from main; every other case keeps its current behavior bit-for-bit. Out of scope (unchanged): upstream/`push.default` resolution for bare pushes.

## Tests

New `tests/test_guard_main_write.py` — the hook had none. Drives the hook as a subprocess against a temp git repo, covering the full destination truth table, the bare-push/`--all`/`--mirror` fallback, `commit` still gated, branch-independence of explicit-main blocks, and the existing negatives. 27 cases; full suite 592 passed.

Part of #276

> Note: #283 is unrelated to the v0.8.7 memory-off bundle — it's an opportunistic rider on this omnibus (a `/ship onto` shakeout the bundle happened to expose). Tracked in #276's checklist only so promotion auto-closes it.
