### PR TITLE
Test ingest failure surfacing + project-info failed-units row (#312)

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -99,6 +99,71 @@ def test_project_info_reports_v1_stats(projects_root):
     }
 
 
+def _seed_failed_ingests(name: str, rows: list[tuple[str, str, str, str, int]]) -> None:
+    """Insert (file_hash, file_name, stage, error, attempts) rows into failed_ingests."""
+    conn = open_db(name)
+    try:
+        conn.cursor().executemany(
+            "INSERT INTO failed_ingests "
+            "(file_hash, file_name, stage, error, attempts, last_attempt) "
+            "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            rows,
+        )
+    finally:
+        conn.close()
+
+
+def test_project_info_reports_failed_ingests(projects_root):
+    """get_project_info counts every failed unit and, separately, the capped ones."""
+    from bartleby.ingest.writer import MAX_INGEST_ATTEMPTS
+
+    bartleby.project.create_project("alpha")
+    # No failures yet → both counters sit at zero.
+    assert bartleby.project.get_project_info("alpha")["failed_ingests"] == {
+        "total": 0, "capped": 0,
+    }
+
+    _seed_failed_ingests("alpha", [
+        ("h1", "capped.pdf", "parse", "boom", MAX_INGEST_ATTEMPTS),
+        ("h2", "over.pdf", "caption", "boom", MAX_INGEST_ATTEMPTS + 2),
+        ("h3", "retry.pdf", "summary", "boom", 1),
+    ])
+
+    failed = bartleby.project.get_project_info("alpha")["failed_ingests"]
+    assert failed == {"total": 3, "capped": 2}
+
+
+def test_project_info_command_renders_failed_units_row(projects_root, monkeypatch):
+    """`bartleby project info` renders the Failed units row only when units failed."""
+    import io
+
+    from rich.console import Console
+
+    from bartleby.commands import project as project_cmd
+    from bartleby.ingest.writer import MAX_INGEST_ATTEMPTS
+
+    bartleby.project.create_project("alpha")
+
+    def _render() -> str:
+        buf = io.StringIO()
+        monkeypatch.setattr(project_cmd, "_console", Console(file=buf, width=200))
+        project_cmd.info(name="alpha")
+        return buf.getvalue()
+
+    # No failures → no row.
+    assert "Failed units" not in _render()
+
+    _seed_failed_ingests("alpha", [
+        ("h1", "capped.pdf", "parse", "boom", MAX_INGEST_ATTEMPTS),
+        ("h2", "retry.pdf", "summary", "boom", 1),
+    ])
+
+    out = _render()
+    assert "Failed units" in out
+    assert "2 incomplete" in out
+    assert "1 capped, not retried" in out
+
+
 def test_delete_project_removes_dir_and_clears_active(projects_root):
     bartleby.project.create_project("alpha")
     bartleby.project.delete_project("alpha")

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -2266,6 +2266,61 @@ def test_writer_failure_helpers_record_bump_and_clear(isolated_project):
         conn.close()
 
 
+def test_report_failures_silent_when_no_failures(isolated_project, monkeypatch):
+    """The end-of-run block emits nothing when every unit completed."""
+    from bartleby.ingest.writer import Writer
+
+    warnings: list[str] = []
+    monkeypatch.setattr(scribe.console, "warn", lambda m: warnings.append(m))
+
+    conn = open_db("test_proj")
+    try:
+        scribe._report_failures(Writer(conn))
+    finally:
+        conn.close()
+    assert warnings == []
+
+
+def test_report_failures_warns_with_caps_and_display_limit(
+    isolated_project, monkeypatch
+):
+    """The end-of-run warn block headlines the count + capped wording, flags each
+    unit as capped vs will-retry, and truncates the listing at 10 with a pointer."""
+    from bartleby.ingest.writer import MAX_INGEST_ATTEMPTS, Writer
+
+    warnings: list[str] = []
+    monkeypatch.setattr(scribe.console, "warn", lambda m: warnings.append(m))
+
+    conn = open_db("test_proj")
+    try:
+        writer = Writer(conn)
+        # Two capped units (driven to the cap) + eleven that will retry → 13 total,
+        # past the 10-line display limit.
+        for _ in range(MAX_INGEST_ATTEMPTS):
+            writer.record_failure("capped0", "capped0.pdf", "parse", "boom")
+            writer.record_failure("capped1", "capped1.pdf", "caption", "boom")
+        for i in range(11):
+            writer.record_failure(f"retry{i}", f"retry{i}.pdf", "summary", "later")
+
+        scribe._report_failures(writer)
+    finally:
+        conn.close()
+
+    blob = "\n".join(warnings)
+    # Header: total count, capped subtotal + attempt wording, retry tail.
+    assert "13 ingest unit(s) did not complete" in blob
+    assert f"2 capped after {MAX_INGEST_ATTEMPTS} attempts" in blob
+    assert "the rest will retry on the next run" in blob
+    # Per-unit flags, both branches.
+    assert "capped — not retried" in blob
+    assert f"will retry (attempt 1/{MAX_INGEST_ATTEMPTS})" in blob
+    # Display cap: only 10 unit lines, then the "… and N more" pointer.
+    unit_lines = [w for w in warnings if w.startswith("  [")]
+    assert len(unit_lines) == 10
+    assert "… and 3 more" in blob
+    assert "bartleby project info" in blob
+
+
 def test_scribe_timings_emits_aggregate_json(
     isolated_project, tmp_path, mock_embed, capsys
 ):


### PR DESCRIPTION
Adds coverage for the previously-untested ingest failure-surfacing path.

**`tests/test_project.py`**
- `test_project_info_reports_failed_ingests` — seeds `failed_ingests` with capped and not-yet-capped rows; asserts `get_project_info` reports the right `{total, capped}` (and stays `{0, 0}` with no failures).
- `test_project_info_command_renders_failed_units_row` — asserts the `bartleby project info` command renders the "Failed units" row only when units failed.

**`tests/test_scribe.py`**
- `test_report_failures_silent_when_no_failures` — no failures → no output.
- `test_report_failures_warns_with_caps_and_display_limit` — asserts the end-of-run warn block: count + capped wording header, per-unit capped/will-retry flags, and the 10-item display cap with "… and N more".

No source changes — tests only. Closes the coverage gap flagged by the 2026-06-09 sweep.

Part of #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)