### PR TITLE
Enforce MAX_INGEST_ATTEMPTS on the parse stage (#307)

### DIFF
--- a/bartleby/ingest/parse.py
+++ b/bartleby/ingest/parse.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from bartleby.ingest import parsers
 from bartleby.ingest import pool
 from bartleby.ingest.progress import ScribeProgress
-from bartleby.ingest.writer import Writer
+from bartleby.ingest.writer import MAX_INGEST_ATTEMPTS, Writer
 from bartleby.lib import console
 
 if TYPE_CHECKING:
@@ -64,8 +64,23 @@ def parse_all(
     ]
     parse_phase = progress.phase("parse")
     parse_phase.start(len(to_parse))
+
+    # Capped files (failed MAX_INGEST_ATTEMPTS× already) are skipped, not retried
+    # — parse is the most expensive stage, so the gate precedes the pool, mirroring
+    # the identical gates in caption.py/summary.py.
+    to_parse_live: list[parsers.ParseRequest] = []
+    for req in to_parse:
+        if writer.is_capped(req.file_hash, "parse"):
+            console.warn(
+                f"{req.file_name}: skipping parse — failed "
+                f"{MAX_INGEST_ATTEMPTS}× already; not retrying."
+            )
+            parse_phase.advance()
+        else:
+            to_parse_live.append(req)
+
     for outcome in pool.parse_stream(
-        to_parse,
+        to_parse_live,
         parse_fn=parsers._parse_request,
         config=parse_config,
         max_workers=max_workers,

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -2450,3 +2450,121 @@ def test_scribe_warns_on_config_drift(
         ).fetchone()[0] == 2
     finally:
         conn.close()
+
+
+def _text_pdf_config():
+    """Image-free pdfplumber ingest — no vision provider, no summary pass, so the
+    only stage that can fail (or be capped) is parse."""
+    return {
+        "summary_depth": "none",
+        "pdf_converter": "pdfplumber", "html_converter": "docling",
+        "sparse_text_threshold": 100, "ocr_min_confidence": 30,
+    }
+
+
+def test_scribe_records_then_clears_a_parse_failure(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """A parse that fails once is recorded in failed_ingests (stage='parse') with
+    nothing persisted; a later clean run lands the document and clears the
+    failure — the record/clear lifecycle caption/summary already have (#307)."""
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.load_config", _text_pdf_config,
+    )
+
+    import bartleby.ingest.pdfplumber as pp
+    real_convert = pp.convert
+    parses = {"n": 0}
+
+    def flaky_convert(*a, **k):
+        parses["n"] += 1
+        if parses["n"] == 1:
+            raise RuntimeError("transient parse error")
+        return real_convert(*a, **k)
+
+    monkeypatch.setattr(
+        "bartleby.ingest.parsers.pdfplumber_pipeline.convert", flaky_convert,
+    )
+
+    pdf = _text_pdf(tmp_path / "doc.pdf", text="Durable body text " * 12)
+
+    # Run 1: the parse fails. Recorded as a parse failure; nothing persisted.
+    scribe.main(project="test_proj", files=str(pdf))
+    assert parses["n"] == 1
+    conn = open_db("test_proj")
+    try:
+        cur = conn.cursor()
+        assert cur.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+        stage, attempts = cur.execute(
+            "SELECT stage, attempts FROM failed_ingests"
+        ).fetchone()
+        assert stage == "parse" and attempts == 1
+    finally:
+        conn.close()
+
+    # Run 2: the parse recovers. The document lands; the failure row clears.
+    scribe.main(project="test_proj", files=str(pdf))
+    assert parses["n"] == 2
+    conn = open_db("test_proj")
+    try:
+        cur = conn.cursor()
+        assert cur.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 1
+        assert cur.execute(
+            "SELECT COUNT(*) FROM failed_ingests"
+        ).fetchone()[0] == 0                                 # failure cleared
+    finally:
+        conn.close()
+
+
+def test_scribe_caps_parse_retries_and_stops_reparsing(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """A deterministically-failing parse is retried up to the cap, recorded, then
+    never re-parsed again — the parse stage now honours MAX_INGEST_ATTEMPTS like
+    caption/summary, so a corrupt file can't loop the most expensive stage
+    forever and can't silently read as done (#307)."""
+    from bartleby.ingest.writer import MAX_INGEST_ATTEMPTS
+
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.load_config", _text_pdf_config,
+    )
+
+    parses = {"n": 0}
+
+    def failing_convert(*a, **k):
+        parses["n"] += 1
+        raise RuntimeError("corrupt PDF")
+
+    monkeypatch.setattr(
+        "bartleby.ingest.parsers.pdfplumber_pipeline.convert", failing_convert,
+    )
+
+    pdf = _text_pdf(tmp_path / "doc.pdf", text="Body text " * 12)
+
+    # Each run makes exactly one more parse attempt until the cap is reached.
+    for _ in range(MAX_INGEST_ATTEMPTS):
+        scribe.main(project="test_proj", files=str(pdf))
+    assert parses["n"] == MAX_INGEST_ATTEMPTS
+
+    conn = open_db("test_proj")
+    try:
+        cur = conn.cursor()
+        stage, attempts = cur.execute(
+            "SELECT stage, attempts FROM failed_ingests"
+        ).fetchone()
+        assert stage == "parse" and attempts == MAX_INGEST_ATTEMPTS
+        # The parse never succeeded — nothing persisted.
+        assert cur.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+    # A further run is a no-op against the converter — the unit is capped.
+    scribe.main(project="test_proj", files=str(pdf))
+    assert parses["n"] == MAX_INGEST_ATTEMPTS                # NOT re-parsed
+    conn = open_db("test_proj")
+    try:
+        assert conn.cursor().execute(
+            "SELECT attempts FROM failed_ingests"
+        ).fetchone()[0] == MAX_INGEST_ATTEMPTS               # not bumped past cap
+    finally:
+        conn.close()


### PR DESCRIPTION
Part of #315.

**Problem.** The parse phase sent every queued file across the worker pool unconditionally. `caption.py` and `summary.py` both gate on `writer.is_capped(file_hash, stage)`, but `parse_all` never did — so a deterministically-failing parse (a corrupt PDF) was re-run forever on the most expensive stage while `attempts` climbed past the cap, and the end-of-run "capped — not retried" line was false for parse rows.

**Fix.** Add the symmetric cap gate to `bartleby/ingest/parse.py`: filter `to_parse` before `pool.parse_stream`, skipping any file capped on the `"parse"` stage with a warning + progress advance, mirroring the identical gates in `caption.py`/`summary.py`. The gate precedes the pool because parse is the costly stage. `is_capped` is already generic over stage, so no `writer.py` change and no schema change. The report line becomes truthful for parse for free.

**Tests** (cloning the caption-cap pair, counting converter calls):
- record/clear lifecycle — a parse that fails once is recorded (`stage='parse'`), then a clean run persists the document and clears the failure.
- the cap — a converter that always raises is retried to the cap then never re-parsed; `attempts` never exceeds `MAX_INGEST_ATTEMPTS`.

Full suite green (680 passed). No `Closes` — sub-issue closes at the #315 → main promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)