### PR TITLE
Dedup byte-identical files in resume bookkeeping (#313)

### DIFF
--- a/bartleby/ingest/classify.py
+++ b/bartleby/ingest/classify.py
@@ -110,18 +110,26 @@ def _classify(
     Hashing + the resume lookups run here on the main process; only the parse
     bucket crosses to workers.
 
-    A fourth bucket, ``duplicates``, catches two byte-identical files *within one
-    run*: ``documents.file_hash`` is UNIQUE, so only the first can persist. The
-    DB lookup can't see the in-run twin (neither is committed yet), so we track
-    hashes queued this run and divert the rest here rather than let the second
-    crash ``persist_parse`` (#225)."""
+    A fourth bucket, ``duplicates``, catches a byte-identical twin seen earlier
+    *within one run* — whatever the first copy did, the twin is redundant. We
+    track every hash classified this run and divert the rest here. This guards
+    two things at once: the never-parsed case, where
+    ``documents.file_hash`` is UNIQUE and the second would crash ``persist_parse``
+    since the DB lookup can't see an uncommitted in-run twin (#225); and the
+    already-parsed resume case, where two copies resolving to the same
+    ``document_id`` would otherwise both land in ``to_resume`` and double-count
+    the one incomplete document (#313)."""
     to_parse: list[parsers.ParseRequest] = []
     to_resume: list[_ResumeItem] = []
     skipped: list[str] = []
     duplicates: list[str] = []
-    queued_hashes: set[str] = set()
+    seen_hashes: set[str] = set()
     for path, ext in sources:
         file_hash = _hash_file(path)
+        if file_hash in seen_hashes:
+            duplicates.append(path.name)
+            continue
+        seen_hashes.add(file_hash)
         document_id = writer.document_id_for(file_hash)
         if document_id is not None:
             if _is_complete(writer, document_id):
@@ -129,15 +137,11 @@ def _classify(
             else:
                 to_resume.append(_ResumeItem(document_id, path.name, file_hash))
             continue
-        if file_hash in queued_hashes:
-            duplicates.append(path.name)
-            continue
         if ext in IMAGE_EXTENSIONS and not vision_enabled:
             console.warn(
                 f"{path.name}: skipping image (no vision provider configured)."
             )
             continue
-        queued_hashes.add(file_hash)
         to_parse.append(
             parsers.ParseRequest(
                 path=path, ext=ext, file_hash=file_hash, file_name=path.name

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -1379,6 +1379,54 @@ def test_is_complete_false_when_image_uncaptioned(isolated_project):
         conn.close()
 
 
+def test_classify_dedupes_byte_identical_incomplete_resume(isolated_project, tmp_path):
+    """Two byte-identical copies of an incomplete, already-parsed file resume the
+    one document once: the first lands in to_resume, the twin is diverted to
+    duplicates. Without the dedup both resolve to the same document_id and both
+    land in to_resume, so the incomplete tally double-counts a phantom unit (#313)."""
+    a = tmp_path / "a.jpg"
+    b = tmp_path / "b.jpg"
+    a.write_bytes(b"identical image bytes")
+    b.write_bytes(b"identical image bytes")
+    file_hash = classify._hash_file(a)
+    assert classify._hash_file(b) == file_hash
+
+    conn = open_db("test_proj")
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO documents "
+            "(file_hash, file_name, file_path, page_count, token_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (file_hash, "a.jpg", str(a), None, 0),
+        )
+        doc_id = conn.last_insert_rowid()
+        # analysis_json IS NULL → uncaptioned → the document is incomplete, so the
+        # first copy resumes rather than skips.
+        cur.execute(
+            "INSERT INTO images (file_hash, file_path, width, height, "
+            "analysis_json, analysis_model) VALUES (?, ?, ?, ?, NULL, NULL)",
+            ("imgblob", str(a), 100, 100),
+        )
+        image_id = conn.last_insert_rowid()
+        cur.execute(
+            "INSERT INTO document_images "
+            "(document_id, image_id, page_number, image_index_on_page) "
+            "VALUES (?, ?, ?, ?)",
+            (doc_id, image_id, None, 0),
+        )
+        writer = scribe.Writer(conn)
+        to_parse, to_resume, skipped, duplicates = classify._classify(
+            writer, [(a, ".jpg"), (b, ".jpg")], vision_enabled=True,
+        )
+        assert to_parse == []
+        assert [r.document_id for r in to_resume] == [doc_id]
+        assert duplicates == ["b.jpg"]
+        assert skipped == []
+    finally:
+        conn.close()
+
+
 def test_documents_needing_summary_filters_summarized_and_empty(isolated_project):
     """The summarize work-list (issue #167) is documents with indexed chunks and
     no summary row; already-summarized docs and zero-chunk docs (nothing


### PR DESCRIPTION
Part of #315.

**Problem.** `_classify`'s `queued_hashes` dedup only guarded the never-parsed bucket. Two byte-identical copies of an already-parsed-but-incomplete file both resolved to the same `document_id` and both landed in `to_resume`; downstream each became a `DocUnit`, so the incomplete-count loop tallied the one document twice — a phantom unit in the "N file(s) ingested but incomplete" message.

**Fix.** Replace `queued_hashes` with a single `seen_hashes` set checked at the top of the `_classify` loop. The first occurrence of a content hash is bucketed normally (skip / resume / parse); any later byte-identical twin is diverted to the existing `duplicates` bucket. This fixes the resume double-count and keeps the #225 persist-crash guard intact (the never-parsed dedup still happens).

Incidental: a vision-disabled image twin now routes to `duplicates` (was a second skip-warn) — quieter and consistent.

**Test.** `test_classify_dedupes_byte_identical_incomplete_resume` — two byte-identical copies of an incomplete already-parsed doc resume the one document once; the twin lands in `duplicates`.

Tests: full `uv run pytest` green (679 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)