### PR TITLE
Point NO_PROVIDER error at `bartleby config`

### DIFF
--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -427,7 +427,7 @@ def resolve_classifier() -> tuple[Provider, str, float]:
     if not name or not model:
         raise SkillError(
             "NO_PROVIDER",
-            "No LLM provider configured. Run `bartleby ready` first.",
+            "No LLM provider configured. Run `bartleby config` first.",
         )
     ensure_provider_env(name, config)
     provider = get_provider(name, ollama_base_url=config.get("ollama_base_url"))

--- a/docs/decisions/GH-0329-no-provider-names-bartleby-config-0001.md
+++ b/docs/decisions/GH-0329-no-provider-names-bartleby-config-0001.md
@@ -1,0 +1,32 @@
+# `NO_PROVIDER` error names `bartleby config`, not stale `bartleby ready`
+
+**Issue:** #329 (part of the v0.8.11 omnibus, #331)
+
+## Context
+
+`resolve_classifier()` in `bartleby/skill_scripts/_tags.py` raises a
+`SkillError("NO_PROVIDER", ...)` when the summarizer config has no provider or
+model. Its message told the user to run `bartleby ready` — but PR #137 split the
+two surfaces apart: `bartleby ready` now only *installs the skill* into
+`~/.claude/skills/`, while the provider-config wizard moved to `bartleby config`.
+So the remedy the error named no longer fixes the error.
+
+## Decision
+
+Change the one message string to point at the correct command:
+
+```
+"No LLM provider configured. Run `bartleby config` first.",
+```
+
+A focused test (`test_resolve_classifier_no_provider_names_config_command` in
+`tests/test_skill_tags.py`) monkeypatches `load_config` to an empty dict and
+asserts the raised `SkillError` has code `NO_PROVIDER`, contains `bartleby
+config`, and does *not* contain `bartleby ready` — so the fix can't silently
+regress to the stale command.
+
+## Scope
+
+Deliberately just this one message. Auditing other stale `bartleby ready`
+references elsewhere in the tree is a separate sweep item and was left untouched
+here.

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -20,6 +20,7 @@ from bartleby.skill_scripts import (
     tag as tag_script,
     unassign_tag,
 )
+from bartleby.skill_runner import SkillError
 from bartleby.skill_scripts import _tags as tags_helpers
 from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
 
@@ -436,6 +437,18 @@ def test_tag_retries_transient_failure_once(seeded_project, capsys, monkeypatch)
     assert calls["n"] == 2          # one failure, then a successful retry
     assert out["failed"] == []
     assert out["classified"][0]["applies"] is True
+
+
+def test_resolve_classifier_no_provider_names_config_command(monkeypatch):
+    """The NO_PROVIDER error points at `bartleby config`, not the stale
+    `bartleby ready` (issue #329)."""
+    monkeypatch.setattr(tags_helpers, "load_config", lambda: {})
+    with pytest.raises(SkillError) as exc_info:
+        tags_helpers.resolve_classifier()
+    err = exc_info.value
+    assert err.code == "NO_PROVIDER"
+    assert "bartleby config" in err.message
+    assert "bartleby ready" not in err.message
 
 
 def test_tag_rejects_when_no_vocabulary(seeded_project, capsys):


### PR DESCRIPTION
Part of #329 — omnibus #331

The tag classifier's `NO_PROVIDER` error (`bartleby/skill_scripts/_tags.py`) told users to run `bartleby ready`. Since PR #137 split the commands, `bartleby ready` only installs the skill, while the provider-config wizard is `bartleby config`. This points the message at the command that actually fixes the error.

- One-line message edit.
- Focused test asserting the message contains `bartleby config` and not `bartleby ready`.
- Decision doc `docs/decisions/GH-0329-no-provider-names-bartleby-config-0001.md`.

Full suite: 724 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)