### PR TITLE
Assert chunks/chunks_fts/chunks_vec stay in sync across mutation tests

### DIFF
--- a/docs/decisions/GH-0344-triple-table-sync-assertions.md
+++ b/docs/decisions/GH-0344-triple-table-sync-assertions.md
@@ -1,0 +1,75 @@
+# Mutation tests assert chunks / chunks_fts / chunks_vec stay in sync — checked per-leg (issue #344)
+
+> Source: [#344](https://github.com/jswest/bartleby/issues/344)
+
+The skill mutation paths (`edit_finding`, `merge_findings`, `save_summary`
+replace, `delete_finding`) rewrite the polymorphic `chunks` table and its two
+mirrors — the `chunks_fts` external-content FTS5 index and the `chunks_vec`
+`vec0` table — through the typed `bartleby.db.chunks` helpers. The tests asserted
+the `chunks` row deltas but only spot-checked the mirrors, and where they touched
+`chunks_fts` they did so **vacuously**. This issue adds one shared assertion and
+closes the specific gaps. It is **tests-only**: no production code path changed,
+no `SCHEMA_VERSION` bump.
+
+**The two mirrors must be checked DIFFERENTLY — that asymmetry is the point.**
+`assert_chunk_tables_consistent(conn)` lives in `tests/_skill_fixtures.py` (where
+the suite already shares fixtures/helpers) and verifies each leg with the only
+check that is *non-vacuous* for that leg:
+
+- **FTS leg → FTS5's own `'integrity-check'`.** `chunks_fts` is declared
+  `content='chunks'` (`schema.py` ~158-164), so it stores no row text of its own
+  — any rowid lookup or `COUNT` over it is satisfied by reading *through* `chunks`
+  and therefore can never observe index/content drift. The pre-existing
+  `SELECT … FROM chunks_fts WHERE rowid = ?` assertions in `delete_finding` and
+  `edit_finding` were exactly this vacuous shape. The only thing that catches a
+  drifted external-content index is `INSERT INTO chunks_fts(chunks_fts)
+  VALUES('integrity-check')`, which raises if the FTS index disagrees with its
+  content table.
+- **Vector leg → direct rowid-set comparison.** `chunks_vec` is a real `vec0`
+  table with its own row storage, so `{rowid FROM chunks_vec}` must equal
+  `{chunk_id FROM chunks}` exactly, and a mismatch is a true observation.
+
+The helper is called at the END of the `edit_finding` body-rebuild,
+`merge_findings` happy-path, `save_summary` replace, and `delete_finding`
+mutation tests. The vacuous per-rowid `chunks_fts` checks in `delete_finding`
+(and the FTS-only mirror check in `edit_finding`) are replaced by the
+integrity-check call; the vec leg keeps explicit per-id presence/absence
+assertions because the objective asks each mutation to name the specific chunks
+that should land in / leave `chunks_vec`.
+
+**`chunk_id` (and `summary_id`) rowid reuse forced identity-by-content, not
+by-id.** SQLite reuses freed `INTEGER PRIMARY KEY` rowids, so after a
+delete-old/insert-new dance the *replacement* chunks frequently re-own the freed
+ids. Naive "the old id is gone" assertions therefore pass vacuously (or fail
+spuriously). The gap-closers account for this:
+
+- **`save_summary` replace.** The fixture's prior summary for doc A was seeded
+  with **zero** chunks, so the replace's delete-old/insert-new was unobserved.
+  The seed now inserts two prior summary chunks (`_skill_fixtures.py`), and the
+  test identifies the old summary by its **distinctive chunk text** (not its
+  `summary_id`, which the replacement re-owns) and asserts those texts are gone
+  from `chunks`, that the surviving summary's chunks reflect the new body, and
+  that all three tables agree. A new seed chunk count broke one unrelated test
+  (`test_skill_search.py::test_search_with_summaries_source_kind` seeded its own
+  summary chunk at `chunk_index=0`, now colliding on the
+  `(source_kind, source_id, chunk_index)` UNIQUE) — bumped its `chunk_index` to
+  2; that is the only edit outside the four mutation-test files and the fixtures.
+- **`edit_finding` body rebuild.** Captures the finding's body-chunk ids before
+  the edit, then asserts the new ids are present in `chunks_vec` and any old id
+  **not reused** by the new body is absent (today the test checked FTS but never
+  vec).
+- **`merge_findings` happy path.** Captures the source findings' body-chunk ids
+  before the merge, then asserts each source chunk not re-owned by the rebuilt
+  target body is absent from both mirrors and the target's new chunks are present
+  in both.
+
+**The assertions pass on current HEAD — no production bug surfaced.** Per the
+issue, in the happy path these operations *should* keep the three tables
+consistent because they go through the typed helpers; a failure would have been a
+real write-path bug to PARK and report, not fix here. None failed.
+
+touches: `tests/_skill_fixtures.py`, `tests/test_skill_edit_finding.py`,
+`tests/test_skill_merge_findings.py`, `tests/test_skill_save_summary.py`,
+`tests/test_skill_delete_finding.py`, and `tests/test_skill_search.py` (the
+one-line collision fix forced by the richer seed). No product code, no schema
+change (`SCHEMA_VERSION` unchanged).

--- a/tests/_skill_fixtures.py
+++ b/tests/_skill_fixtures.py
@@ -11,6 +11,7 @@ from bartleby.db.chunks import (
     ChunkInput,
     insert_document_chunks,
     insert_image_chunks,
+    insert_summary_chunks,
 )
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
@@ -18,6 +19,33 @@ from bartleby.db.schema import EMBEDDING_DIM
 
 def _emb(seed: float = 0.0) -> list[float]:
     return [seed + 0.001 * j for j in range(EMBEDDING_DIM)]
+
+
+def assert_chunk_tables_consistent(conn) -> None:
+    """Assert ``chunks``, ``chunks_fts``, and ``chunks_vec`` agree.
+
+    The two mirror tables are checked DIFFERENTLY because they are different
+    kinds of virtual table:
+
+    - ``chunks_fts`` is an external-content FTS5 table (``content='chunks'``),
+      so any non-MATCH read (rowid lookup, ``COUNT``) is satisfied THROUGH
+      ``chunks`` and would be vacuous. The only way to catch drift between the
+      FTS index and its content table is FTS5's own ``'integrity-check'``
+      command, which raises if they disagree.
+    - ``chunks_vec`` is a real ``vec0`` table with its own row storage, so its
+      ``rowid`` set can be compared against ``chunks`` directly.
+    """
+    cur = conn.cursor()
+    # FTS leg: external-content integrity check (raises on drift).
+    cur.execute("INSERT INTO chunks_fts(chunks_fts) VALUES('integrity-check')")
+    # Vector leg: rowid sets must match exactly.
+    chunk_ids = {r[0] for r in cur.execute("SELECT chunk_id FROM chunks")}
+    vec_ids = {r[0] for r in cur.execute("SELECT rowid FROM chunks_vec")}
+    assert vec_ids == chunk_ids, (
+        f"chunks_vec rowids drifted from chunks: "
+        f"only in vec={sorted(vec_ids - chunk_ids)}, "
+        f"only in chunks={sorted(chunk_ids - vec_ids)}"
+    )
 
 
 @pytest.fixture
@@ -73,17 +101,32 @@ def seeded_project(project_env):
                        chunk_index=1),
         ])
 
-        # Summary for doc A
+        # Summary for doc A — seeded WITH chunks so a later replace has prior
+        # chunks to delete from all three tables (the save_summary replace test
+        # asserts they are gone afterward).
         cur.execute(
             "INSERT INTO summaries (document_id, title, description, text, model) "
             "VALUES (?, ?, ?, ?, ?)",
             (doc_a, "Alpha", "Test summary of alpha document.",
              "A summary of alpha.", "test"),
         )
+        summary_a = conn.last_insert_rowid()
+        summary_a_chunk_ids = insert_summary_chunks(conn, summary_a, [
+            ChunkInput(text="alpha summary chunk zero", embedding=_emb(3.0),
+                       chunk_index=0),
+            ChunkInput(text="alpha summary chunk one", embedding=_emb(3.1),
+                       chunk_index=1),
+        ])
     finally:
         conn.close()
 
-    return {"project": project_env, "doc_a": doc_a, "doc_b": doc_b}
+    return {
+        "project": project_env,
+        "doc_a": doc_a,
+        "doc_b": doc_b,
+        "summary_a": summary_a,
+        "summary_a_chunk_ids": summary_a_chunk_ids,
+    }
 
 
 def seed_image(conn, document_id: int, *, file_hash: str, file_path: str,

--- a/tests/test_skill_delete_finding.py
+++ b/tests/test_skill_delete_finding.py
@@ -11,7 +11,11 @@ from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.session import start_session
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
+from tests._skill_fixtures import (  # noqa: F401
+    assert_chunk_tables_consistent,
+    project_env,
+    seeded_project,
+)
 
 
 def _seed_finding_as(conn, session_id, title="Foreign draft") -> int:
@@ -126,16 +130,16 @@ def test_delete_finding_removes_row_chunks_and_citations(
             "SELECT COUNT(*) FROM finding_citations WHERE finding_id = ?",
             (finding_id,),
         ).fetchone()[0] == 0
-        # The finding's body chunks are gone from chunks + the fts/vec mirrors.
+        # The finding's body chunks are gone from chunks + the vec mirror.
+        # (chunks_fts is external-content, so a per-rowid COUNT reads THROUGH
+        # chunks and is vacuous — the FTS leg is verified by the integrity
+        # check in assert_chunk_tables_consistent below instead.)
         assert cur.execute(
             "SELECT COUNT(*) FROM chunks WHERE source_kind='finding' "
             "AND source_id = ?",
             (finding_id,),
         ).fetchone()[0] == 0
         for cid in body_chunk_ids:
-            assert cur.execute(
-                "SELECT COUNT(*) FROM chunks_fts WHERE rowid = ?", (cid,)
-            ).fetchone()[0] == 0
             assert cur.execute(
                 "SELECT COUNT(*) FROM chunks_vec WHERE rowid = ?", (cid,)
             ).fetchone()[0] == 0
@@ -144,6 +148,8 @@ def test_delete_finding_removes_row_chunks_and_citations(
             assert cur.execute(
                 "SELECT COUNT(*) FROM chunks WHERE chunk_id = ?", (cid,)
             ).fetchone()[0] == 1
+
+        assert_chunk_tables_consistent(conn)
     finally:
         conn.close()
 

--- a/tests/test_skill_edit_finding.py
+++ b/tests/test_skill_edit_finding.py
@@ -9,7 +9,11 @@ import pytest
 from bartleby.skill_scripts import edit_finding, save_finding
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
+from tests._skill_fixtures import (  # noqa: F401
+    assert_chunk_tables_consistent,
+    project_env,
+    seeded_project,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -63,16 +67,26 @@ def test_edit_finding_body_rebuilds_citations_and_chunks(
     finding_id = saved["finding_id"]
     a, b = saved["_chunks"]
 
-    # Fetch a third chunk to verify swapping citations works.
+    # Fetch a third chunk to verify swapping citations works, and capture the
+    # finding's current body-chunk ids before the edit replaces them.
     conn = open_db(seeded_project["project"])
     try:
-        c = conn.cursor().execute(
+        cur = conn.cursor()
+        c = cur.execute(
             "SELECT chunk_id FROM chunks WHERE source_kind='document' "
             "AND source_id = ? AND chunk_index = 2",
             (seeded_project["doc_a"],),
         ).fetchone()[0]
+        old_finding_chunk_ids = {
+            row[0] for row in cur.execute(
+                "SELECT chunk_id FROM chunks WHERE source_kind='finding' "
+                "AND source_id = ?",
+                (finding_id,),
+            )
+        }
     finally:
         conn.close()
+    assert old_finding_chunk_ids  # sanity: the finding had body chunks
 
     new_body = f"# Fixed\n\nOnly claim now[^{c}]."
     new_body_file = tmp_path / "edited.md"
@@ -132,6 +146,21 @@ def test_edit_finding_body_rebuilds_citations_and_chunks(
                 "SELECT text FROM chunks_fts WHERE rowid = ?", (cid,)
             ).fetchone()
             assert fts_text == (new_body,)
+        # The chunks_vec mirror tracks the rebuild: the new body chunks are
+        # present in vec, and any old chunk id NOT reused by the new body is
+        # gone. (SQLite reuses chunk_id values, so disjointness can't be
+        # assumed — only the ids that fell out of the finding must be absent.)
+        new_finding_chunk_ids = set(finding_chunk_ids)
+        for cid in new_finding_chunk_ids:
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks_vec WHERE rowid = ?", (cid,),
+            ).fetchone()[0] == 1
+        for cid in old_finding_chunk_ids - new_finding_chunk_ids:
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks_vec WHERE rowid = ?", (cid,),
+            ).fetchone()[0] == 0
+
+        assert_chunk_tables_consistent(conn)
     finally:
         conn.close()
 

--- a/tests/test_skill_merge_findings.py
+++ b/tests/test_skill_merge_findings.py
@@ -11,7 +11,11 @@ from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.session import start_session
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
+from tests._skill_fixtures import (  # noqa: F401
+    assert_chunk_tables_consistent,
+    project_env,
+    seeded_project,
+)
 
 
 def _seed_finding_as(conn, session_id, title="Foreign draft") -> int:
@@ -59,6 +63,20 @@ def _doc_chunk_ids(project, doc_id) -> list[int]:
         conn.close()
 
 
+def _finding_chunk_ids(project, finding_id) -> list[int]:
+    conn = open_db(project)
+    try:
+        return [
+            r[0] for r in conn.cursor().execute(
+                "SELECT chunk_id FROM chunks WHERE source_kind='finding' "
+                "AND source_id = ? ORDER BY chunk_index",
+                (finding_id,),
+            )
+        ]
+    finally:
+        conn.close()
+
+
 def _save(project, tmp_path, capsys, *, name, title, cite) -> int:
     body_file = tmp_path / f"{name}.md"
     body_file.write_text(f"# {title}\n\nClaim[^{cite}].", encoding="utf-8")
@@ -80,6 +98,11 @@ def test_merge_folds_sources_into_target(seeded_project, tmp_path, capsys):
     target = _save(project, tmp_path, capsys, name="t", title="Keep me", cite=c0)
     src1 = _save(project, tmp_path, capsys, name="s1", title="Dup one", cite=c1)
     src2 = _save(project, tmp_path, capsys, name="s2", title="Dup two", cite=c2)
+
+    # Capture the source findings' body-chunk ids before the merge consumes
+    # them, so we can assert they leave all three chunk tables.
+    src_chunk_ids = _finding_chunk_ids(project, src1) + _finding_chunk_ids(project, src2)
+    assert src_chunk_ids  # sanity: the sources had body chunks
 
     merged_body = f"# Consolidated\n\nAll together[^{c0}][^{c1}][^{c2}]."
     merged_file = tmp_path / "merged.md"
@@ -133,6 +156,35 @@ def test_merge_folds_sources_into_target(seeded_project, tmp_path, capsys):
                 "SELECT COUNT(*) FROM finding_citations WHERE finding_id = ?",
                 (src,),
             ).fetchone()[0] == 0
+
+        # The source body chunks left BOTH mirrors, and the target's NEW body
+        # chunks are present in both. The merged body re-chunks the target, so
+        # its chunk ids are whatever the finding now owns.
+        target_chunk_ids = [
+            r[0] for r in cur.execute(
+                "SELECT chunk_id FROM chunks WHERE source_kind='finding' "
+                "AND source_id = ?", (target,),
+            )
+        ]
+        assert target_chunk_ids  # sanity: the merged target has body chunks
+        for cid in src_chunk_ids:
+            if cid in target_chunk_ids:
+                continue  # chunk_id reused by the rebuilt target body
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks_fts WHERE rowid = ?", (cid,),
+            ).fetchone()[0] == 0
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks_vec WHERE rowid = ?", (cid,),
+            ).fetchone()[0] == 0
+        for cid in target_chunk_ids:
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks_fts WHERE rowid = ?", (cid,),
+            ).fetchone()[0] == 1
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks_vec WHERE rowid = ?", (cid,),
+            ).fetchone()[0] == 1
+
+        assert_chunk_tables_consistent(conn)
     finally:
         conn.close()
 

--- a/tests/test_skill_save_summary.py
+++ b/tests/test_skill_save_summary.py
@@ -9,7 +9,11 @@ import pytest
 from bartleby.skill_scripts import save_summary
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
+from tests._skill_fixtures import (  # noqa: F401
+    assert_chunk_tables_consistent,
+    project_env,
+    seeded_project,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -55,7 +59,29 @@ def test_save_summary_creates_new_summary(seeded_project, capsys):
 
 
 def test_save_summary_replaces_existing(seeded_project, capsys):
-    # alpha already has an ingest-time summary; replace it.
+    # alpha already has an ingest-time summary, seeded WITH chunks; replace it
+    # and verify the prior summary's chunks are purged from all three tables.
+    # SQLite reuses both summary_id and chunk_id rowids, so the prior summary
+    # is identified by its distinctive chunk TEXT, not by id (an id check would
+    # pass vacuously when the replacement re-owns the freed rowids).
+    prior_chunk_ids = seeded_project["summary_a_chunk_ids"]
+    assert prior_chunk_ids  # sanity: the prior summary actually had chunks
+
+    conn = open_db(seeded_project["project"])
+    try:
+        prior_chunk_texts = [
+            r[0] for r in conn.cursor().execute(
+                "SELECT text FROM chunks WHERE source_kind='summary' "
+                "AND chunk_id IN ({})".format(
+                    ",".join("?" * len(prior_chunk_ids))
+                ),
+                tuple(prior_chunk_ids),
+            )
+        ]
+    finally:
+        conn.close()
+    assert len(prior_chunk_texts) == len(prior_chunk_ids)
+
     save_summary.main([
         "--project", seeded_project["project"],
         "--document", str(seeded_project["doc_a"]),
@@ -67,12 +93,37 @@ def test_save_summary_replaces_existing(seeded_project, capsys):
 
     conn = open_db(seeded_project["project"])
     try:
-        rows = conn.cursor().execute(
+        cur = conn.cursor()
+        rows = cur.execute(
             "SELECT title, text FROM summaries WHERE document_id = ?",
             (seeded_project["doc_a"],),
         ).fetchall()
         assert len(rows) == 1
         assert rows[0] == ("Alpha v2", "Replacement summary for alpha.")
+
+        # The prior summary's chunk texts are gone from chunks entirely: the
+        # replace deleted the old chunks before inserting the new body. (If the
+        # old chunks lingered, these distinctive texts would still be present.)
+        for text in prior_chunk_texts:
+            assert cur.execute(
+                "SELECT COUNT(*) FROM chunks WHERE text = ?", (text,),
+            ).fetchone()[0] == 0
+
+        # The surviving summary's chunks reflect the NEW body, not the old one.
+        new_summary_chunk_texts = [
+            r[0] for r in cur.execute(
+                "SELECT c.text FROM chunks c "
+                "JOIN summaries s ON s.summary_id = c.source_id "
+                "WHERE c.source_kind='summary' AND s.document_id = ?",
+                (seeded_project["doc_a"],),
+            )
+        ]
+        assert new_summary_chunk_texts == ["Replacement summary for alpha."]
+
+        # And all three tables agree: the FTS integrity check would fail if a
+        # stale prior-chunk entry survived in the index, and the vec rowid set
+        # must equal the chunks rowid set.
+        assert_chunk_tables_consistent(conn)
     finally:
         conn.close()
 

--- a/tests/test_skill_search.py
+++ b/tests/test_skill_search.py
@@ -272,8 +272,10 @@ def test_search_with_summaries_source_kind(seeded_project, capsys):
             (seeded_project["doc_a"],),
         ).fetchone()[0]
         emb = [0.1 * i for i in range(EMBEDDING_DIM)]
+        # The seeded summary already owns chunk_index 0 and 1, so append at 2
+        # to avoid the (source_kind, source_id, chunk_index) UNIQUE collision.
         insert_summary_chunks(conn, summary_id, [
-            ChunkInput(text="this is a summary-keyword chunk", embedding=emb, chunk_index=0),
+            ChunkInput(text="this is a summary-keyword chunk", embedding=emb, chunk_index=2),
         ])
     finally:
         conn.close()


### PR DESCRIPTION
Part of #344.

Adds a shared test helper asserting the three chunk tables agree, and calls it across the skill mutation tests. Tests-only — no production code path changed, no `SCHEMA_VERSION` bump. All assertions pass on current HEAD (no production bug surfaced).

## What changed

- **`assert_chunk_tables_consistent(conn)`** in `tests/_skill_fixtures.py`, checking the two mirror legs DIFFERENTLY:
  - **FTS leg:** `INSERT INTO chunks_fts(chunks_fts) VALUES('integrity-check')` — `chunks_fts` is external-content (`content='chunks'`), so any rowid/COUNT read is vacuous; the integrity-check is the only thing that catches index/content drift.
  - **Vector leg:** `chunks_vec` is a real `vec0` table, so its rowid set is compared against `chunks` directly.
- Helper called at the end of the `edit_finding` body-rebuild, `merge_findings` happy-path, `save_summary` replace, and `delete_finding` mutation tests.

## Gaps closed

- **`edit_finding`** (body change): assert new chunk ids exist in `chunks_vec` and non-reused old ones are gone (previously only FTS was checked).
- **`merge_findings`** (happy path): assert source chunks are absent from both fts and vec, and the target's new chunks are present in both.
- **`save_summary`** replace + its seed: the prior summary is now seeded WITH chunks; the test asserts they are purged from all three tables. SQLite reuses both `summary_id` and `chunk_id` rowids, so the prior summary is identified by its distinctive chunk TEXT, not by id.
- **`delete_finding`**: the vacuous per-rowid `chunks_fts` COUNT is replaced by the `integrity-check` helper call.

## Note

The richer seed (prior summary now has 2 chunks) forced a one-line `chunk_index` bump in `test_skill_search.py` to avoid a `(source_kind, source_id, chunk_index)` UNIQUE collision — the only edit outside the four mutation-test files and the fixtures.

Decision note: `docs/decisions/GH-0344-triple-table-sync-assertions.md`.

`uv run pytest`: 725 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>