### PR TITLE
test: fix schema-mismatch test direction (Part of #363)

### DIFF
--- a/docs/decisions/GH-0357-schema-mismatch-test-direction-0001.md
+++ b/docs/decisions/GH-0357-schema-mismatch-test-direction-0001.md
@@ -1,0 +1,29 @@
+# GH-0357: Fix schema-mismatch test direction
+
+## Decision
+
+`test_schema_mismatch_points_at_upgrade_first` now stamps `SCHEMA_VERSION - 1`
+(an **older** DB) before reopening, instead of `SCHEMA_VERSION + 1` (a newer DB).
+
+## Why
+
+`open_db` raises on any `db_version != SCHEMA_VERSION` and always emits the same
+remedy: "run `bartleby project upgrade`, and if that reports a non-additive bump,
+re-ingest." That advice only makes sense for an **older** on-disk DB — the
+in-place upgrade chain (`bartleby/db/upgrades.py`) walks `vN → vN+1` forward, so
+it can only bring an older corpus up to the code's expectation.
+
+The old test stamped `SCHEMA_VERSION + 1`, simulating a DB *newer* than the code.
+That direction is semantically the opposite: you cannot "upgrade" a database that
+is already ahead of the code — the correct remedy there is "update the code, not
+the DB." Asserting the upgrade-first message against a newer DB tested the message
+in a direction where it does not actually apply. Stamping `SCHEMA_VERSION - 1`
+exercises the older-DB direction the upgrade-first remedy is written for.
+
+The newer-DB "update the code, not the DB" path (CLI `upgrade()` guard) is covered
+by a separate issue and intentionally not duplicated here.
+
+## Scope
+
+Test-only change in `tests/test_db.py`. No production code, no schema change,
+`SCHEMA_VERSION` untouched.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -115,7 +115,7 @@ def test_schema_mismatch_points_at_upgrade_first(tmp_path, monkeypatch):
     c = open_db("proj")
     c.cursor().execute(
         "UPDATE meta SET value = ? WHERE key = 'schema_version'",
-        (str(SCHEMA_VERSION + 1),),
+        (str(SCHEMA_VERSION - 1),),
     )
     c.close()
 


### PR DESCRIPTION
Part of #363.

`test_schema_mismatch_points_at_upgrade_first` stamped `SCHEMA_VERSION + 1` (a *newer* DB) yet asserted the `bartleby project upgrade` remedy, which only applies to an *older* DB — the in-place upgrade chain walks vN→vN+1 forward and cannot bring a newer corpus back. Now stamps `SCHEMA_VERSION - 1` so the upgrade-first message is asserted in the direction it actually applies to.

Test-only change in `tests/test_db.py`; `SCHEMA_VERSION` untouched. Full suite passes (740).