### PR TITLE
docs: fix document_images replay comment (Part of #363)

### DIFF
--- a/bartleby/ingest/writer.py
+++ b/bartleby/ingest/writer.py
@@ -357,8 +357,15 @@ class Writer:
                         (img.hash, str(img.archive_path), img.width, img.height),
                     )
                     image_id = self.conn.last_insert_rowid()
-                # OR IGNORE: the same (doc, image, page, index) tuple can replay
-                # across runs; a no-op is fine rather than a constraint crash.
+                # Replay is actually prevented by the document-exists early
+                # return above (a re-run of the same file returns the existing
+                # document_id before reaching here). OR IGNORE is only a
+                # secondary guard, and it covers solely *non-NULL*
+                # (doc, image, page, index) tuples: page_number is nullable in
+                # the composite PK and SQLite treats NULLs as distinct, so
+                # docling/HTML/standalone images (page_number = None) are not
+                # deduped by it. A no-op on the rows it does cover is fine
+                # rather than a constraint crash.
                 cur.execute(
                     "INSERT OR IGNORE INTO document_images "
                     "(document_id, image_id, page_number, image_index_on_page) "

--- a/docs/decisions/GH-0359-document-images-replay-comment-0001.md
+++ b/docs/decisions/GH-0359-document-images-replay-comment-0001.md
@@ -1,0 +1,7 @@
+# GH-0359 — `document_images` replay comment correctly names the guard
+
+The old `INSERT OR IGNORE INTO document_images` comment in `bartleby/ingest/writer.py` claimed the `OR IGNORE` dedupes replays of the `(doc, image, page, index)` tuple across runs. That is false in general: `document_images`' composite primary key includes the nullable `page_number` (`schema.py`), and SQLite treats NULLs as distinct in a unique/PK index. docling/HTML/standalone images carry `page_number = None` (`parsers.py`), so for those rows the `OR IGNORE` dedup is inert — it never fires.
+
+The actual replay guard is the document-exists early return (`writer.py`, `document_id_for(file_hash)` → return existing `document_id`): a re-run of a byte-identical file returns before reaching the image loop. The `OR IGNORE` is only a secondary belt-and-braces guard, and it covers solely non-NULL `(doc, image, page, index)` tuples.
+
+Comment-only change; no behavior, SQL, or schema change. The corrected comment now states the early return is the load-bearing replay guard and scopes `OR IGNORE` to non-NULL tuples. Part of the v0.9.0 additive schema-bump omnibus (#363).


### PR DESCRIPTION
Part of #363.

Corrects the misleading `INSERT OR IGNORE INTO document_images` comment in `bartleby/ingest/writer.py`. The old comment claimed `OR IGNORE` dedupes replays of the `(doc, image, page, index)` tuple. That's inert for `page_number = None` rows (docling/HTML/standalone images) because the composite PK includes the nullable `page_number` and SQLite treats NULLs as distinct.

The actual replay guard is the document-exists early return (`document_id_for(file_hash)` → return existing `document_id`). The comment now says so and scopes `OR IGNORE` to non-NULL tuples.

Comment-only: no behavior, SQL, or schema change. Verified against schema.py (nullable `page_number` in PK) and parsers.py (`page_number = None` for docling/HTML/standalone). Full `uv run pytest` passes (740).