### PR TITLE
test: chunks-chokepoint guard (Part of #363)

### DIFF
--- a/docs/decisions/GH-0360-chunks-chokepoint-guard-test-0001.md
+++ b/docs/decisions/GH-0360-chunks-chokepoint-guard-test-0001.md
@@ -1,0 +1,12 @@
+# chunks-chokepoint guard test
+
+The polymorphic-chunks invariant (all writes to `chunks`/`chunks_fts`/`chunks_vec`
+go through `bartleby/db/chunks.py`) was enforced only by code review. `tests/test_chunks_chokepoint.py`
+now statically walks `bartleby/**/*.py` and fails on any `INSERT INTO` targeting
+those tables outside the allowlisted helper module.
+
+Static text scan (not AST): the helper's INSERTs live inside SQL string literals,
+so stripping strings would hide the very statements we allow. The matcher uses a
+`(?![\w.])` right boundary so `chunks` can't false-match a prefix of
+`chunks_archive`/`chunks_fts`/`chunks_vec`, and only fires on `INSERT INTO`
+(not SELECT/DELETE or prose mentions). Allowlist is `bartleby/db/chunks.py` alone.

--- a/tests/test_chunks_chokepoint.py
+++ b/tests/test_chunks_chokepoint.py
@@ -1,0 +1,80 @@
+"""Static guard for the polymorphic-chunks chokepoint invariant.
+
+All writes to the polymorphic ``chunks`` table (and its parallel ``chunks_fts``
+/ ``chunks_vec`` virtual tables) must flow through the typed helpers in
+``bartleby/db/chunks.py`` -- see that module's docstring and ARCHITECTURE.md.
+A raw ``INSERT INTO chunks`` anywhere else would let the three tables drift out
+of sync without code review noticing.
+
+This test walks every ``bartleby/**/*.py`` source file and fails if any module
+other than the allowlisted helper contains an ``INSERT INTO`` targeting one of
+those tables. It scans raw text on purpose: the helper writes its SQL as string
+literals, so we cannot strip strings before matching.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "bartleby"
+
+# The one module sanctioned to issue raw INSERTs against the chunks tables.
+ALLOWLIST = {PACKAGE_ROOT / "db" / "chunks.py"}
+
+# Match ``INSERT INTO <table>`` where <table> is exactly one of the chunks
+# tables. ``\s+`` between INTO and the table tolerates the newline-split SQL in
+# chunks.py. The trailing ``(?![\w.])`` is a precise right boundary: it rejects
+# longer identifiers (e.g. ``chunks_archive``) so ``chunks`` does not falsely
+# match a prefix of ``chunks_fts``/``chunks_vec`` or any other table, while
+# still allowing ``chunks(`` / ``chunks `` / end-of-string.
+CHUNKS_INSERT = re.compile(
+    r"INSERT\s+INTO\s+(?:chunks_fts|chunks_vec|chunks)(?![\w.])",
+    re.IGNORECASE,
+)
+
+
+def _python_sources() -> list[Path]:
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def test_chunks_inserts_only_in_helper() -> None:
+    violations: list[str] = []
+    for path in _python_sources():
+        if path in ALLOWLIST:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in CHUNKS_INSERT.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            rel = path.relative_to(PACKAGE_ROOT.parent)
+            violations.append(f"{rel}:{line}: {match.group(0)!r}")
+
+    assert not violations, (
+        "Raw INSERT INTO chunks/chunks_fts/chunks_vec found outside "
+        "bartleby/db/chunks.py. All chunk writes must go through the typed "
+        "helpers in that module:\n  " + "\n  ".join(violations)
+    )
+
+
+def test_guard_detects_a_planted_violation() -> None:
+    """The matcher fires on a real INSERT and ignores near-misses."""
+    assert CHUNKS_INSERT.search("INSERT INTO chunks (source_kind) VALUES (?)")
+    assert CHUNKS_INSERT.search("insert into chunks_fts(rowid, text) VALUES (?, ?)")
+    assert CHUNKS_INSERT.search("INSERT  INTO\n    chunks_vec(rowid) VALUES (?)")
+
+    # Near-misses that must NOT trip the guard.
+    assert not CHUNKS_INSERT.search("SELECT * FROM chunks")
+    assert not CHUNKS_INSERT.search("DELETE FROM chunks_fts WHERE rowid = ?")
+    assert not CHUNKS_INSERT.search("INSERT INTO chunks_archive VALUES (?)")
+    assert not CHUNKS_INSERT.search("# we never INSERT INTO chunkside tables")
+    assert not CHUNKS_INSERT.search("INSERT INTO documents VALUES (?)")
+
+
+def test_helper_module_is_present_and_does_insert() -> None:
+    """Sanity: the allowlisted helper exists and actually owns the INSERTs."""
+    (helper,) = ALLOWLIST
+    assert helper.exists(), f"missing chunks helper at {helper}"
+    assert CHUNKS_INSERT.search(helper.read_text(encoding="utf-8")), (
+        "chunks.py no longer contains an INSERT INTO chunks -- the chokepoint "
+        "may have moved; update this guard."
+    )


### PR DESCRIPTION
Part of #363.

Adds `tests/test_chunks_chokepoint.py`, a static guard that walks `bartleby/**/*.py` and fails on any `INSERT INTO chunks`/`chunks_fts`/`chunks_vec` outside the allowlisted helper `bartleby/db/chunks.py`. This enforces the polymorphic-chunks invariant (all chunk writes go through the typed helpers) that was previously only code-review-enforced.

The matcher is a precise regex with a `(?![\w.])` right boundary so `chunks` cannot false-match `chunks_archive`/`chunks_fts`/`chunks_vec` prefixes, and only fires on `INSERT INTO` (not SELECT/DELETE or prose). Verified against the current tree: the invariant holds (only `chunks.py` inserts). Full suite green (743 passed).