### PR TITLE
tooling: make release.py additive-aware (Part of #363)

### DIFF
--- a/docs/decisions/GH-0361-release-additive-aware-messaging-0001.md
+++ b/docs/decisions/GH-0361-release-additive-aware-messaging-0001.md
@@ -1,0 +1,54 @@
+# Make `release.py` additive-aware in its messaging (issue #361)
+
+> Source: [#361](https://github.com/jswest/bartleby/issues/361)
+
+`release.py` hard-coded "Existing corpora must be re-ingested" on *any* minor
+bump — in the GitHub Release notes (`build_release_notes`), in the dry-run
+summary line (`Schema: N (bumped → re-ingest)`), and in the module docstring's
+claim that the minor "never moves without a re-ingest". That was true while
+every schema bump was breaking, but #212 established the sanctioned exception:
+an *additive* bump moves `SCHEMA_VERSION` while a `_UPGRADES` chain entry covers
+each crossed step, so existing corpora run `bartleby project upgrade <name>`
+instead of re-ingesting. v0.9.0 is exactly such a bump, so the unconditional
+banner would have mis-published a re-ingest order the release didn't need.
+
+This change is **messaging only**. The DDL-drift refusal gate `check_drift`
+(DDL changed but `SCHEMA_VERSION` static) is correct and untouched — it gates a
+*different* failure (a forgotten bump) and never reads the upgrade chain.
+
+The disposition is binary and is read from the same source of truth the runtime
+upgrade path uses, so the two can't disagree: `_UPGRADES` in
+`bartleby/db/upgrades.py`. A new pure helper `upgrade_covers(schema_from,
+schema_to)` returns True only when **every** step `v -> v+1` from the old minor
+up to the new schema has a chain entry (`all(v in _UPGRADES for v in range(from,
+to))`). A single missing step makes the whole bump breaking — matching
+`upgrade()`, which raises on the first gap. A non-forward move
+(`schema_from >= schema_to`) is never additive.
+
+`build_release_notes` and the dry-run summary now branch on `upgrade_covers`:
+
+- **Additive** → "Existing corpora upgrade in place: run `bartleby project
+  upgrade <name>`." / `(bumped → upgrade in place)`.
+- **Breaking** → the original "must be re-ingested." banner / `(bumped →
+  re-ingest)`.
+
+`<name>` is left as a literal placeholder: release notes are corpus-agnostic, so
+they name the command, not a specific project.
+
+### Alternatives weighed
+
+- **Re-derive coverage from the DDL diff** instead of consulting `_UPGRADES`.
+  Rejected: it would re-litigate "is this bump additive?" in a second place and
+  could drift from what `project upgrade` actually does. `_UPGRADES` *is* the
+  registry of additive steps; reading it keeps notes and runtime in lockstep.
+- **Touch `check_drift`.** Explicitly out of scope — it's a different,
+  correct gate.
+
+### Tests
+
+`tests/test_release.py` covers both notes branches (additive → `project upgrade
+<name>`, no "re-ingested"; breaking → "re-ingested", no "project upgrade") by
+monkeypatching `release._UPGRADES`, plus `upgrade_covers` directly for the
+single-step, multi-step-complete, missing-step, empty-chain, and non-forward
+cases. The pre-existing `test_notes_banner_on_schema_bump` (which assumed every
+bump re-ingests) was replaced by these two disposition-specific tests.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -154,17 +154,15 @@ def build_release_notes(
     """
     parts: list[str] = []
     if schema_from is not None and schema_to is not None and schema_from != schema_to:
-        if upgrade_covers(schema_from, schema_to):
-            parts.append(
-                f"⚠️ **This release changes the database schema "
-                f"({schema_from} → {schema_to}). Existing corpora upgrade in place: "
-                f"run `bartleby project upgrade <name>`.**\n"
-            )
-        else:
-            parts.append(
-                f"⚠️ **This release changes the database schema "
-                f"({schema_from} → {schema_to}). Existing corpora must be re-ingested.**\n"
-            )
+        remedy = (
+            "Existing corpora upgrade in place: run `bartleby project upgrade <name>`."
+            if upgrade_covers(schema_from, schema_to)
+            else "Existing corpora must be re-ingested."
+        )
+        parts.append(
+            f"⚠️ **This release changes the database schema "
+            f"({schema_from} → {schema_to}). {remedy}**\n"
+        )
     parts.append("## Changes\n")
     if log_lines:
         parts.extend(f"- {line}" for line in log_lines)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -4,8 +4,12 @@
 Versioning scheme — ``v0.<SCHEMA_VERSION>.<patch>``:
 
 * **MINOR == SCHEMA_VERSION** (read straight from ``bartleby/db/schema.py``). It
-  increments monotonically and never moves without a re-ingest, so the version
-  number self-documents the schema: ``v0.8.3`` means "schema 8, third patch".
+  increments monotonically, so the version number self-documents the schema:
+  ``v0.8.3`` means "schema 8, third patch". A minor bump has two dispositions.
+  *Additive* — every crossed version has a ``_UPGRADES`` chain entry
+  (``bartleby/db/upgrades.py``): existing corpora run
+  ``bartleby project upgrade <name>`` and the notes say so. *Breaking* — some
+  step has no chain entry: the notes order a full re-ingest.
 * **PATCH** increments for every release at the same schema; resets to ``0`` on a
   schema bump.
 * **MAJOR** is a human call (a real 1.0, a ground-up rewrite) — never automated
@@ -34,7 +38,10 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
 SCHEMA_PATH = "bartleby/db/schema.py"
+
+from bartleby.db.upgrades import _UPGRADES  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +104,20 @@ def schema_moved(schema_version: int, last_tag: str | None) -> bool:
     return parse_version_tag(last_tag)[1] != schema_version
 
 
+def upgrade_covers(schema_from: int, schema_to: int) -> bool:
+    """True when the ``_UPGRADES`` chain spans every crossed version.
+
+    An *additive* bump has a chain entry for each step ``v -> v+1`` between the
+    old and new schema, so existing corpora run ``bartleby project upgrade``
+    rather than re-ingesting. A single missing step makes the whole bump
+    breaking (re-ingest). A non-forward move (``schema_from >= schema_to``) is
+    never an additive upgrade.
+    """
+    if schema_from >= schema_to:
+        return False
+    return all(v in _UPGRADES for v in range(schema_from, schema_to))
+
+
 def check_drift(old_source: str, new_source: str) -> str | None:
     """Compare two ``schema.py`` sources; return an error string if they drift.
 
@@ -124,14 +145,26 @@ def build_release_notes(
     schema_from: int | None,
     schema_to: int | None,
 ) -> str:
-    """Assemble GitHub Release notes from the git log, with a re-ingest banner
-    prepended on a schema bump."""
+    """Assemble GitHub Release notes from the git log, with a schema banner
+    prepended on a schema bump.
+
+    An *additive* bump (``_UPGRADES`` covers every crossed version) tells users
+    to run ``bartleby project upgrade <name>``; a *breaking* bump orders a full
+    re-ingest.
+    """
     parts: list[str] = []
     if schema_from is not None and schema_to is not None and schema_from != schema_to:
-        parts.append(
-            f"⚠️ **This release changes the database schema "
-            f"({schema_from} → {schema_to}). Existing corpora must be re-ingested.**\n"
-        )
+        if upgrade_covers(schema_from, schema_to):
+            parts.append(
+                f"⚠️ **This release changes the database schema "
+                f"({schema_from} → {schema_to}). Existing corpora upgrade in place: "
+                f"run `bartleby project upgrade <name>`.**\n"
+            )
+        else:
+            parts.append(
+                f"⚠️ **This release changes the database schema "
+                f"({schema_from} → {schema_to}). Existing corpora must be re-ingested.**\n"
+            )
     parts.append("## Changes\n")
     if log_lines:
         parts.extend(f"- {line}" for line in log_lines)
@@ -228,8 +261,16 @@ def main(argv: list[str] | None = None) -> int:
         commits, schema_from=schema_from, schema_to=schema_version if moved else None,
     )
 
+    if moved:
+        disposition = (
+            "  (bumped → upgrade in place)"
+            if upgrade_covers(schema_from, schema_version)
+            else "  (bumped → re-ingest)"
+        )
+    else:
+        disposition = ""
     print(f"Last tag:     {last_tag or '(none)'}")
-    print(f"Schema:       {schema_version}{'  (bumped → re-ingest)' if moved else ''}")
+    print(f"Schema:       {schema_version}{disposition}")
     print(f"Next release: {new_tag}")
     print()
     print(notes)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -124,12 +124,56 @@ def test_notes_include_commits():
     assert "⚠️" not in notes  # no re-ingest banner when the schema didn't move
 
 
-def test_notes_banner_on_schema_bump():
+def test_notes_reingest_banner_on_breaking_bump(monkeypatch):
+    # No _UPGRADES entry for the 8 -> 9 step: breaking bump, re-ingest.
+    monkeypatch.setattr(release, "_UPGRADES", {})
     notes = release.build_release_notes(
-        ["Big change"], schema_from=7, schema_to=8,
+        ["Big change"], schema_from=8, schema_to=9,
     )
     assert "⚠️" in notes
-    assert "7 → 8" in notes
+    assert "8 → 9" in notes
+    assert "re-ingested" in notes
+    assert "project upgrade" not in notes
+
+
+def test_notes_upgrade_banner_on_additive_bump(monkeypatch):
+    # Every crossed step (8 -> 9) has a chain entry: upgrade in place, no re-ingest.
+    monkeypatch.setattr(release, "_UPGRADES", {8: object()})
+    notes = release.build_release_notes(
+        ["Big change"], schema_from=8, schema_to=9,
+    )
+    assert "⚠️" in notes
+    assert "8 → 9" in notes
+    assert "bartleby project upgrade <name>" in notes
+    assert "re-ingested" not in notes
+
+
+# --- upgrade_covers --------------------------------------------------------
+
+def test_upgrade_covers_single_step_present(monkeypatch):
+    monkeypatch.setattr(release, "_UPGRADES", {7: object()})
+    assert release.upgrade_covers(7, 8) is True
+
+
+def test_upgrade_covers_multi_step_all_present(monkeypatch):
+    monkeypatch.setattr(release, "_UPGRADES", {5: object(), 6: object(), 7: object()})
+    assert release.upgrade_covers(5, 8) is True
+
+
+def test_upgrade_covers_missing_step_is_breaking(monkeypatch):
+    monkeypatch.setattr(release, "_UPGRADES", {5: object(), 7: object()})  # 6 missing
+    assert release.upgrade_covers(5, 8) is False
+
+
+def test_upgrade_covers_no_entry_is_breaking(monkeypatch):
+    monkeypatch.setattr(release, "_UPGRADES", {})
+    assert release.upgrade_covers(8, 9) is False
+
+
+def test_upgrade_covers_non_forward_is_false(monkeypatch):
+    monkeypatch.setattr(release, "_UPGRADES", {8: object()})
+    assert release.upgrade_covers(9, 9) is False
+    assert release.upgrade_covers(9, 8) is False
 
 
 def test_notes_baseline_when_no_commits():


### PR DESCRIPTION
Part of #363.

`release.py` hard-coded "Existing corpora must be re-ingested" on every minor bump — in the GitHub Release notes (`build_release_notes`), the dry-run summary line, and the module docstring. v0.9.0 is an *additive* bump (`SCHEMA_VERSION` moves but a `_UPGRADES` chain entry covers each crossed step), so the unconditional banner would mis-publish a re-ingest order the release doesn't need.

## What changed
- New pure helper `upgrade_covers(schema_from, schema_to)` reads `bartleby/db/upgrades.py`'s `_UPGRADES` — the same registry the runtime upgrade path uses — and is True only when **every** step `v -> v+1` has a chain entry. One gap = breaking.
- `build_release_notes` and the dry-run summary now branch on it: additive → "run `bartleby project upgrade <name>`"; breaking → the original re-ingest banner.
- Module docstring describes both dispositions.

## Out of scope
`check_drift` (the DDL-drift refusal gate) is untouched — a different, correct gate.

## Tests
Both notes branches plus `upgrade_covers` (single-step, multi-step-complete, missing-step, empty-chain, non-forward). Full suite: 746 passed.

Decision doc: `docs/decisions/GH-0361-release-additive-aware-messaging-0001.md`.