### PR TITLE
test: persist_parse atomicity rollback (Part of #363)

### DIFF
--- a/docs/decisions/GH-0358-persist-parse-rollback-atomicity-0001.md
+++ b/docs/decisions/GH-0358-persist-parse-rollback-atomicity-0001.md
@@ -1,0 +1,43 @@
+# Test pins persist_parse's mid-unit rollback (the "atomic parse" invariant) (issue #358)
+
+> Source: [#358](https://github.com/jswest/bartleby/issues/358)
+
+The "atomic parse" invariant — a `documents` row implies a *finished* parse, so
+resume logic only re-runs units that left no row — rides entirely on
+`Writer.persist_parse`'s single `with self.conn` transaction (`writer.py`). The
+suite had no test that forced a failure *after* the `documents` INSERT and
+asserted the row rolled back, so a refactor that split that one transaction (or
+moved the chunk write outside it) would pass the whole suite while silently
+committing a partial parse that reads as complete. This becomes more load-bearing
+under #254, which persists N+1 `documents` rows per file — a partially-split file
+must not commit a subset.
+
+**This is tests-only — `persist_parse` is already atomic and the test passes on
+current HEAD.** Per the issue's TEST-ONLY constraint, the test asserts the
+existing guarantee; no production code changed and `SCHEMA_VERSION` is untouched.
+Had the assertion failed it would have been a real write-path bug to PARK and
+report, not to patch here. It did not fail.
+
+**The failure is injected at the natural validation chokepoint, after the
+`documents` row is already in.** `persist_parse` does, in order, inside one
+`with self.conn`: clear the prior failure, INSERT the `documents` row, then call
+`insert_document_chunks(...)`. That helper's `_validate` pass (`db/chunks.py`)
+runs *before* it opens its own inner `with conn`, and rejects an embedding whose
+length is not `EMBEDDING_DIM`, raising `ValueError("embedding has N dims, ...")`.
+The test's second document chunk carries an embedding of length `EMBEDDING_DIM +
+1`, so:
+
+- the `documents` INSERT has already executed (the row exists *within* the
+  transaction),
+- the first chunk is well-formed, so this is a genuine mid-unit failure,
+- the `ValueError` propagates out of the outer `with self.conn`, which rolls the
+  whole unit back (APSW commits/rolls back the outermost context on exit).
+
+The test then asserts `COUNT(*) == 0` in `documents`, `chunks`, and `images` —
+the three tables `persist_parse` writes — proving nothing partial committed. It
+reuses the established `tests/test_scribe.py` fixtures/builders (`isolated_project`,
+`open_db`, `Writer`, `ParsedDocument`/`ParsedImage`/`ChunkInput`, `_emb`,
+`EMBEDDING_DIM`) and mirrors the shape of `test_writer_persist_parse_dedupes_shared_image`.
+
+touches: `tests/test_scribe.py` (one added test). No product code, no schema
+change (`SCHEMA_VERSION` unchanged).

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -2736,3 +2736,49 @@ def test_scribe_caps_parse_retries_and_stops_reparsing(
         ).fetchone()[0] == MAX_INGEST_ATTEMPTS               # not bumped past cap
     finally:
         conn.close()
+
+
+def test_persist_parse_rolls_back_on_mid_unit_failure(isolated_project, tmp_path):
+    """persist_parse is one transaction: a failure *after* the documents INSERT
+    leaves no trace in documents/chunks/images.
+
+    The "atomic parse" invariant — a documents row implies a finished parse, so
+    resume only re-runs missing units — rides entirely on persist_parse's single
+    ``with self.conn`` (writer.py). This test forces a failure mid-unit (a
+    wrong-sized embedding on the second document chunk, which _validate rejects
+    after the documents row is already inserted) and asserts the whole unit
+    rolled back. A refactor that split that transaction would pass the rest of
+    the suite while silently committing a partial parse that reads as complete
+    (load-bearing under #254, which writes N+1 documents rows per file).
+    """
+    from bartleby.db.chunks import ChunkInput
+    from bartleby.ingest.writer import ParsedDocument, ParsedImage, Writer
+
+    good, bad = _emb(0.0, 1)[0], [0.1] * (EMBEDDING_DIM + 1)
+    parsed = ParsedDocument(
+        file_hash="atomic", file_name="atomic.pdf",
+        archive_path=tmp_path / "atomic.pdf", page_count=1, token_count=2,
+        document_chunks=[
+            ChunkInput(text="First chunk lands fine.", embedding=good, chunk_index=0),
+            # Second chunk's embedding is one dim too long: insert_document_chunks
+            # validates the batch and raises *after* the documents INSERT.
+            ChunkInput(text="Second chunk is poison.", embedding=bad, chunk_index=1),
+        ],
+        images=[ParsedImage(
+            hash="atomic-img", archive_path=tmp_path / "i.jpg",
+            width=10, height=10, page_number=1, image_index_on_page=1,
+        )],
+    )
+
+    conn = open_db("test_proj")
+    try:
+        writer = Writer(conn)
+        with pytest.raises(ValueError, match="dims"):
+            writer.persist_parse(parsed)
+
+        cur = conn.cursor()
+        assert cur.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+        assert cur.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 0
+        assert cur.execute("SELECT COUNT(*) FROM images").fetchone()[0] == 0
+    finally:
+        conn.close()


### PR DESCRIPTION
Part of #363.

Adds a Writer-level test pinning the "atomic parse" invariant: a `documents` row implies a finished parse. The test injects a failure *after* the `documents` INSERT (a wrong-sized embedding, len `EMBEDDING_DIM + 1`, on the second document chunk — rejected by `chunks._validate` before any chunk lands) and asserts zero rows survive in `documents`, `chunks`, and `images` once `persist_parse`'s single `with self.conn` transaction rolls back.

A refactor that split that transaction would pass the rest of the suite while silently committing a partial parse that reads as complete — load-bearing under #254, which writes N+1 `documents` rows per file.

Tests-only: `persist_parse` is already atomic and the test passes on HEAD. No production code change, no `SCHEMA_VERSION` bump. Reuses the established `tests/test_scribe.py` fixtures (`isolated_project`, `open_db`, `Writer`, `ParsedDocument`/`ParsedImage`/`ChunkInput`, `_emb`, `EMBEDDING_DIM`).

Decision doc: `docs/decisions/GH-0358-persist-parse-rollback-atomicity-0001.md`.