### PR TITLE
docs: resolve stale held-at-8 schema comment + v8->v9 authoring rule (Part of #363)

### DIFF
--- a/bartleby/db/schema.py
+++ b/bartleby/db/schema.py
@@ -5,12 +5,18 @@ The DDL string here is the canonical schema; run it via ``init_db`` in
 invariant and the rest of the project's load-bearing rules.
 """
 
-# Held at 8 across the #169 concurrent-ingestion omnibus. The `ingests` table
-# and the `ingest_run_id` columns below are additive work landing under that
-# omnibus (issue #171); the single v8→v9 bump + a consolidated
-# `_upgrade_v8_to_v9` ships once when #169 releases, rather than each sub-issue
-# bumping in turn. Until then fresh DBs carry these structures at v8 and an
-# existing v8 corpus must re-ingest to gain them.
+# v8 == the with-`ingests` shape: the `ingests` table and the `ingest_run_id`
+# columns below are part of v8, not deferred to a later bump. The #169
+# concurrent-ingestion omnibus shipped (released as v0.8.x) *staying at* v8 —
+# the once-promised consolidated `_upgrade_v8_to_v9` never materialized; instead
+# `_upgrade_v7_to_v8` was completed to create `ingests`/`ingest_run_id`
+# additively (issue #212), so a v7 corpus reaches the full v8 shape via
+# `project upgrade`, no re-ingest. Caveat — the #164–#171 window cohort: a DB
+# created from `main` between #164 (stamped v8 with only `failed_ingests`) and
+# #171 (folded `ingests`/`ingest_run_id` into v8, still v8) carries v8 in `meta`
+# without those structures. That cohort is RE-INGEST-ONLY — it shares a version
+# number with released v8 but not its DDL, so no upgrade step can repair it in
+# place. Released v0.8.x DBs are unaffected; they already have the full v8 shape.
 SCHEMA_VERSION = 8
 
 EMBEDDING_DIM = 768

--- a/bartleby/db/upgrades.py
+++ b/bartleby/db/upgrades.py
@@ -13,6 +13,15 @@ Note: the DDL here intentionally duplicates `db/schema.py` — fresh DBs run
 the latter, existing DBs walk the former. The regression gate that keeps
 them in sync is `tests/test_project.py::test_upgrade_chain_walks_*`, which
 strips and re-applies the chain end-to-end.
+
+Authoring rule for `_upgrade_v8_to_v9`: it is written against **released
+v0.8.x DBs**, which already carry the full v8 shape — the `ingests` table and
+the `ingest_run_id` columns (`_upgrade_v7_to_v8` creates them; see #212). So a
+v8→v9 step must NOT re-create those, and must be **additive-only** (new tables,
+indexes, or nullable columns with NULL truthful on pre-upgrade rows). The
+#164–#171 window cohort (v8 in `meta` but missing `ingests`/`ingest_run_id`,
+see `db/schema.py`) is out of scope — it is re-ingest-only and never a target
+of this step.
 """
 
 from __future__ import annotations

--- a/docs/decisions/GH-0352-stale-held-at-8-schema-comment-0001.md
+++ b/docs/decisions/GH-0352-stale-held-at-8-schema-comment-0001.md
@@ -1,0 +1,55 @@
+# Resolve the stale "held at 8" schema comment + the v8→v9 authoring rule (issue #352)
+
+> Source: [#352](https://github.com/jswest/bartleby/issues/352)
+
+The header comment on `SCHEMA_VERSION` in `bartleby/db/schema.py` still described a
+plan that never happened. It promised that "a consolidated `_upgrade_v8_to_v9`
+ships once when #169 releases" and told existing v8 corpora to **re-ingest** to gain
+the `ingests` table / `ingest_run_id` columns. Both halves were wrong by the time
+v0.8.x shipped:
+
+- #169 is **closed** (released as v0.8.x), and the omnibus shipped *staying at* v8 —
+  no v8→v9 bump, no consolidated `_upgrade_v8_to_v9`.
+- `_upgrade_v7_to_v8` was completed (issue
+  [#212](https://github.com/jswest/bartleby/issues/212),
+  [GH-0212](GH-0212-complete-v7-to-v8-additive-upgrade-0001.md)) to create
+  `ingests`/`ingest_run_id` **additively**, so a v7 corpus reaches the full v8 shape
+  via `bartleby project upgrade` — not re-ingest.
+
+Two live hazards motivated writing this down rather than just deleting the stale
+text:
+
+1. **Forward trap.** A naive `_upgrade_v8_to_v9` that re-shipped the `ingests` DDL
+   would crash every released v0.8.x DB with "table ingests already exists",
+   because v7→v8 already creates it.
+2. **Window cohort.** A DB created from `main` between #164 (stamped v8 with only
+   `failed_ingests`) and #171 (folded `ingests`/`ingest_run_id` into v8, still v8)
+   carries `v8` in `meta` without those structures. `open_db` accepts the version
+   number, then the first write crashes raw on the missing column. There is no
+   upgrade step that can repair it — it shares a version number with released v8 but
+   not its DDL.
+
+## Decision
+
+Comment/doc only — no behavior, schema, or `SCHEMA_VERSION` change.
+
+- **`schema.py` header** now declares: **v8 == the with-`ingests` shape** (the
+  `ingests` table + `ingest_run_id` columns are *part of* v8, not deferred); the
+  #169 omnibus shipped staying at v8 and the promised consolidation never
+  materialized; and the **#164–#171 window cohort is re-ingest-only**. Released
+  v0.8.x DBs already carry the full v8 shape and are unaffected.
+
+- **`upgrades.py` module docstring** records the authoring rule for any
+  `_upgrade_v8_to_v9`: it is written against **released v0.8.x DBs** (which already
+  contain `ingests`/`ingest_run_id`), so it must NOT re-create those and must be
+  **additive-only**. The window cohort is explicitly out of scope (re-ingest-only).
+
+This entry is consistent with the now-written versioning policy
+([GH-0362](GH-0362-schema-change-versioning-policy-0001.md)): additive-or-breaking
+is binary, and an additive bump ships a chain entry. It documents the *durable*
+versioning truth and the authoring rule for the eventual v8→v9, independent of the
+transient "held at 8" state of the v0.9.0 omnibus (where the v9 columns are present
+in `schema.py` and the `_upgrade_v8_to_v9` step is dormant until the assembly commit
+bumps `SCHEMA_VERSION` to 9 and removes the held-at-8 xfail on the chain-walk test).
+The dormant `_upgrade_v8_to_v9` function body and the v9 columns are left untouched
+by this change.


### PR DESCRIPTION
Part of #363.

Resolves the stale `SCHEMA_VERSION` header in `bartleby/db/schema.py` (#352). It promised a consolidated `_upgrade_v8_to_v9` "ships once when #169 releases" and told v8 corpora to re-ingest — both stale: #169 shipped (v0.8.x) staying at v8, and `_upgrade_v7_to_v8` was completed (#212) to create `ingests`/`ingest_run_id` additively.

- schema.py header now declares **v8 == the with-`ingests` shape** and the **#164–#171 window cohort as re-ingest-only**.
- upgrades.py module docstring records the authoring rule: any `_upgrade_v8_to_v9` is written against released v0.8.x DBs (ingests/ingest_run_id already present) and is additive-only.

Comment/doc only — no behavior, schema, or `SCHEMA_VERSION` change; SCHEMA_VERSION stays held at 8 and the dormant `_upgrade_v8_to_v9` body + v9 columns are untouched. Consistent with the GH-0362 versioning policy. Decision doc `docs/decisions/GH-0352-stale-held-at-8-schema-comment-0001.md` added.

Gate: `uv run pytest` → 790 passed, 1 xfailed (held-at-8 chain-walk xfail; unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)