### PR TITLE
test: strengthen upgrade-chain equivalence gate to full DDL (Part of #363)

### DIFF
--- a/docs/decisions/GH-0355-strengthen-chain-gate-full-ddl-0001.md
+++ b/docs/decisions/GH-0355-strengthen-chain-gate-full-ddl-0001.md
@@ -1,0 +1,66 @@
+# Strengthen the upgrade-chain equivalence gate to full DDL
+
+`test_upgrade_chain_walks_from_v4_through_current` is the regression gate that
+keeps the hand-built upgrade chain (`bartleby/db/upgrades.py`) in lockstep with
+the canonical schema (`bartleby/db/schema.py`). Its `_schema()` helper compared
+only table names plus *sorted column names per table* — so dropped indexes,
+column type drift, `NOT NULL` / `DEFAULT` / `CHECK` constraint drift, and FK
+clause drift were all invisible to it (exactly the drift the gate exists to
+catch).
+
+## Decision
+
+`_schema()` now compares the whitespace-normalized `sqlite_master.sql` of every
+`type IN ('table', 'index')` row between the chain-upgraded DB and a
+freshly-created one. Normalization, in order:
+
+1. **Strip `--` line comments.** `schema.py` annotates columns (e.g. the `#254`
+   anchor-splitting note); the chain's hand-built `CREATE` strings don't. A
+   comment is layout, not structure.
+2. **Collapse all whitespace** to single spaces, then uppercase — so multi-line
+   `CREATE`s vs single-line hand-built strings don't false-positive.
+3. **For `CREATE TABLE`, split the body on top-level (paren-depth-0) commas and
+   sort the resulting column/constraint defs.** This makes the comparison
+   order-independent. It must be: the chain reaches v8 via `ALTER TABLE ADD
+   COLUMN`, which *appends*, so a chain-built table lists the same columns in a
+   different physical order than `schema.py` declares them — an equivalent
+   schema we must not flag. Splitting only at depth 0 keeps a
+   `CHECK (x IN ('a','b'))` or a multi-column `PRIMARY KEY (a, b)` intact.
+4. **Indexes (and any non-plain-table `CREATE`) compare whole.** A dropped index
+   becomes a missing dict key; an altered one becomes a changed value.
+
+Verified directly: this catches column type drift, `NOT NULL`/constraint drift,
+FK-clause drift, `CHECK`-value drift, and dropped indexes, while reconciling all
+pure-layout differences (column reordering from `ALTER`, the `#254` comment,
+trailing-paren whitespace) that the old check never saw and that a naive
+whitespace-only normalization *would* have false-positived on.
+
+## Why not naive whitespace-only normalization
+
+The issue's acceptance criterion says "compare whitespace-normalized
+`sqlite_master.sql`," but it also warns to "normalize aggressively … so the gate
+doesn't false-positive on layout differences." Whitespace-only is insufficient:
+the chain's `ALTER`-appended column order and `schema.py`'s embedded SQL comments
+differ structurally-irrelevantly. Without comment-stripping and order-independent
+column comparison, the gate would go *red* (not merely xfail) the moment the
+v0.9.0 assembly commit removes the xfail — even on a correct schema. The
+order-independent + comment-stripped form is the smallest normalization that
+catches the target drift without that false-positive.
+
+## xfail left in place (deliberate)
+
+The test stays `@pytest.mark.xfail(reason="held at 8 …")`. `SCHEMA_VERSION` is
+held at 8 while `schema.py` and a dormant `_upgrade_v8_to_v9` step already carry
+the v9 (`#114` value-tags, `#254` anchor-splitting) columns. The chain walks
+`v < 8` only, so the v8→v9 step never fires: the chain-upgraded `tags` /
+`document_tags` lack their v9 columns while a fresh DB has them. The strengthened
+gate correctly surfaces *only* that genuine, expected held-at-8 difference (no
+spurious layout diffs remain), so the test still xfails — confirming the gate is
+not vacuously satisfied. The v0.9.0 assembly commit (not this change) bumps
+`SCHEMA_VERSION` to 9, removes the xfail, and extends the chain-strip steps; the
+strengthened comparison then proves the full chain end-to-end.
+
+## Scope
+
+Test-only change in `tests/test_project.py` (and a `re` import). No production
+code, no schema change, `SCHEMA_VERSION` untouched, xfail marker untouched.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 import bartleby.config
@@ -255,22 +257,68 @@ def test_upgrade_chain_walks_from_v4_through_current(projects_root):
     finally:
         conn.close()
 
-    # The upgraded DB must be schema-equivalent to a freshly-created v8: same
-    # tables, same columns per table. This is the regression gate that keeps
-    # the upgrade chain in lockstep with db/schema.py.
+    # The upgraded DB must be schema-equivalent to a freshly-created DB down to
+    # the full DDL: same tables AND indexes, with identical column types,
+    # NOT NULL / DEFAULT / CHECK constraints, and FK clauses. This is the
+    # regression gate that keeps the upgrade chain in lockstep with
+    # db/schema.py — comparing only table+column names (the old check) let
+    # dropped indexes, type drift, and constraint/FK drift slip through.
     bartleby.project.create_project("beta")
 
+    def _top_level_defs(body: str) -> tuple[str, ...]:
+        """Split a CREATE TABLE body on its top-level commas, normalized + sorted.
+
+        Each piece is one column or table-constraint definition (carrying its
+        type, ``NOT NULL`` / ``DEFAULT`` / ``CHECK``, and ``REFERENCES`` FK
+        clause). Splitting only at paren-depth 0 keeps a ``CHECK (... IN (...))``
+        or a multi-column ``PRIMARY KEY (a, b)`` intact. Sorting makes the set
+        order-independent: the chain's ``ALTER TABLE ADD COLUMN`` appends, so a
+        chain-built table lists the same columns in a different order than
+        schema.py — equivalent schemas we must not flag.
+        """
+        parts, depth, current = [], 0, ""
+        for ch in body:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            if ch == "," and depth == 0:
+                parts.append(current)
+                current = ""
+            else:
+                current += ch
+        parts.append(current)
+        return tuple(sorted(" ".join(p.split()) for p in parts if p.strip()))
+
+    def _normalize(sql: str):
+        # Strip `--` line comments (schema.py annotates columns; the chain's
+        # hand-built CREATEs don't — pure layout, not structural drift) and
+        # collapse whitespace, so only real DDL differences survive.
+        sql = re.sub(r"--[^\n]*", "", sql)
+        sql = " ".join(sql.split())
+        if sql.upper().startswith("CREATE TABLE"):
+            open_paren, close_paren = sql.find("("), sql.rfind(")")
+            head = sql[:open_paren].strip().upper()
+            return (head, _top_level_defs(sql[open_paren + 1 : close_paren]))
+        # Indexes (and any non-plain-table CREATE) compare whole: a dropped or
+        # altered index changes this normalized string outright.
+        return (sql.upper(),)
+
     def _schema(conn):
-        tables = [
-            row[0] for row in conn.cursor().execute(
-                "SELECT name FROM sqlite_master WHERE type = 'table'"
-            )
-        ]
+        # Compare the full DDL of every table and index — column types,
+        # NOT NULL / DEFAULT / CHECK constraints, FK clauses, and index
+        # definitions — between the chain-upgraded DB and a fresh one, after
+        # normalizing away whitespace, comments, and (within a table) column
+        # order so pure formatting never false-positives. Rows with NULL sql
+        # (autoindexes, the FTS5 / vec0 shadow internals) carry no
+        # author-written DDL to diff and are skipped; both DBs build those
+        # identically from the same CREATEs.
         return {
-            t: sorted(
-                r[1] for r in conn.cursor().execute(f"PRAGMA table_info({t})")
+            (kind, name): _normalize(sql)
+            for kind, name, sql in conn.cursor().execute(
+                "SELECT type, name, sql FROM sqlite_master "
+                "WHERE type IN ('table', 'index') AND sql IS NOT NULL"
             )
-            for t in tables
         }
 
     upgraded, fresh = open_db("alpha"), open_db("beta")


### PR DESCRIPTION
Part of #363.

Strengthens `test_upgrade_chain_walks_from_v4_through_current`'s equivalence gate (issue #355). The old `_schema()` helper compared only table names plus sorted column names, so dropped indexes, column type drift, and `NOT NULL` / `DEFAULT` / `CHECK` / FK constraint drift were invisible to it — exactly the drift the gate exists to catch.

## What changed

`_schema()` now compares the whitespace-normalized `sqlite_master.sql` of every `type IN ('table','index')` row between the chain-upgraded DB and a fresh one:
- strip `--` line comments (schema.py annotates columns; the chain doesn't),
- collapse whitespace + uppercase,
- for `CREATE TABLE`, split the body on top-level (paren-depth-0) commas and sort the column/constraint defs, so the chain's `ALTER TABLE ADD COLUMN` append order doesn't false-positive while `CHECK (... IN (...))` and multi-column `PRIMARY KEY (a, b)` stay intact,
- indexes (and any non-plain-table CREATE) compare whole, so a dropped index is caught.

Verified the normalization catches type/NOT NULL/FK/CHECK-value drift and dropped indexes, while reconciling all pure-layout differences (column reordering, the `#254` comment, trailing-paren whitespace).

## xfail left in place

The `@pytest.mark.xfail(reason="held at 8 …")` marker is **intentionally untouched**. While `SCHEMA_VERSION` is held at 8, the chain walks `v < 8` only, so the v8→v9 step never fires and the chain-upgraded `tags` / `document_tags` legitimately lack their v9 columns vs a fresh DB. The strengthened gate surfaces exactly that expected difference (and nothing spurious), so the test still xfails — confirming the gate is not vacuously satisfied. The v0.9.0 assembly commit (not this PR) bumps `SCHEMA_VERSION` to 9, extends the chain-strip steps, and removes the xfail; the strengthened comparison then proves the full chain.

Test-only change; no production code, no schema change, `SCHEMA_VERSION` untouched. Full suite: 790 passed, 1 xfailed.

Decision doc: `docs/decisions/GH-0355-strengthen-chain-gate-full-ddl-0001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)