### PR TITLE
fix: crash-safe per-step upgrade stamping + widen CLI catch (Part of #363)

### DIFF
--- a/bartleby/commands/project.py
+++ b/bartleby/commands/project.py
@@ -147,8 +147,8 @@ def upgrade(*, name: str) -> None:
 
         try:
             upgrades_mod.upgrade(conn, current)
-        except RuntimeError as e:
-            _console.print(f"[red]{e}[/red]")
+        except (RuntimeError, apsw.Error) as e:
+            _console.print(f"[red]Upgrade failed: {e}[/red]")
             sys.exit(1)
     finally:
         conn.close()

--- a/bartleby/db/upgrades.py
+++ b/bartleby/db/upgrades.py
@@ -177,17 +177,20 @@ def upgrade(conn: apsw.Connection, current_version: int) -> None:
                 f"No additive upgrade from v{v} to v{v + 1}. "
                 f"This is a non-additive bump; re-ingest is required."
             )
+        # Stamp the new version INSIDE the step's transaction: the DDL and the
+        # schema_version bump commit together. A crash between two steps leaves
+        # the DB at the last completed step's version (never a structural-vs-
+        # meta mismatch), so a re-run resumes from there and completes.
         with conn:
             step(conn)
+            conn.cursor().execute(
+                "UPDATE meta SET value = ? WHERE key = 'schema_version'",
+                (str(v + 1),),
+            )
         v += 1
 
     with conn:
-        cur = conn.cursor()
-        cur.execute(
-            "UPDATE meta SET value = ? WHERE key = 'schema_version'",
-            (str(SCHEMA_VERSION),),
-        )
-        cur.execute(
+        conn.cursor().execute(
             "INSERT OR REPLACE INTO meta (key, value) VALUES ('upgraded_at', ?)",
             (datetime.now(timezone.utc).isoformat(),),
         )

--- a/docs/decisions/GH-0353-crash-safe-upgrade-stamping-0001.md
+++ b/docs/decisions/GH-0353-crash-safe-upgrade-stamping-0001.md
@@ -1,0 +1,45 @@
+# Crash-safe per-step upgrade stamping + widen the CLI catch (issue #353)
+
+> Source: [#353](https://github.com/jswest/bartleby/issues/353)
+
+`upgrades.upgrade()` committed each `_upgrade_vN_to_vN+1` step in its own
+`with conn:` but stamped `meta.schema_version` only *after* the whole chain. A
+crash after an earlier step committed left the DB structurally at vN+1 while
+`meta` still said vN. A re-run then replayed that step and died on
+"table already exists" — an `apsw.SQLError`, not a `RuntimeError`. The CLI
+(`commands/project.py`) caught only `RuntimeError`, so the replay surfaced as a
+raw traceback; meanwhile `open_db`'s strict version check rejected the DB, so
+the corpus was permanently wedged with no path back.
+
+**Fix: stamp `schema_version` inside each per-step transaction.** The
+`UPDATE meta SET value = ?` for `schema_version` now lives *inside* each step's
+`with conn:`, set to `v + 1`, so the DDL and the version bump commit atomically
+together. A crash between two steps therefore leaves the DB at the *last
+completed step's* version (never a structural-vs-meta mismatch), and a re-run
+of `bartleby project upgrade` resumes from there — the loop reads the current
+version and walks only the remaining steps, so no committed step is ever
+re-applied. `upgraded_at` stays a single stamp at the end of the chain (its only
+job is recording when the upgrade finished; it carries no resumption semantics).
+
+**CLI catch widened to `(RuntimeError, apsw.Error)`.** A step failure (missing
+step → `RuntimeError`; DDL error → `apsw.Error`) now exits 1 with a readable
+`Upgrade failed: <e>` line in the repo's existing `[red]...[/red]` style, never a
+raw apsw traceback. `apsw.Error` is the base of `apsw.SQLError` et al., so the
+catch covers the whole family.
+
+**Test: `test_upgrade_resumes_after_mid_chain_crash` (`tests/test_project.py`).**
+It strips a fresh DB back to v4 (mirroring the chain-walk test's teardown),
+monkeypatches the v6→v7 step (`_UPGRADES[6]`) to raise `apsw.SQLError` *after*
+v4→v5 and v5→v6 have committed, and asserts the DB comes to rest at
+`schema_version == 6` with the v6 tables present and the v7 columns absent. It
+then restores the real step, re-runs via `project_cmd.upgrade`, and asserts the
+chain resumes from v6 and completes to `SCHEMA_VERSION` — proving both
+resumption and no double-application (re-walking a committed step would raise
+"table already exists").
+
+Not done, deliberately: `SCHEMA_VERSION` is untouched (held at 8), and neither
+the dormant `_upgrade_v8_to_v9` body nor the held-at-8 xfail on the chain-walk
+gate was altered — those belong to the v0.9.0 assembly commit.
+
+touches: `bartleby/db/upgrades.py`, `bartleby/commands/project.py`,
+`tests/test_project.py` (one added test). No schema change.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -341,3 +341,94 @@ def test_upgrade_chain_walks_from_v4_through_current(projects_root):
         assert count == 1
     finally:
         conn.close()
+
+
+def test_upgrade_resumes_after_mid_chain_crash(projects_root, monkeypatch):
+    """A crash mid-chain leaves the DB at the last completed step; a re-run finishes.
+
+    Each `_upgrade_vN_to_vN+1` now stamps `meta.schema_version` inside its own
+    `with conn:`, so a step that raises after earlier steps committed leaves the
+    DB at an intermediate version (not a structural-vs-meta mismatch). A re-run
+    resumes from there and completes to SCHEMA_VERSION with no double-application
+    (re-walking a committed step would raise "table already exists").
+    """
+    import apsw
+
+    from bartleby.commands import project as project_cmd
+    from bartleby.db import upgrades as upgrades_mod
+    from bartleby.db.connection import project_db_path
+
+    bartleby.project.create_project("alpha")
+    # Simulate a v4 DB by undoing every additive step since (mirrors the
+    # chain-walk test's teardown).
+    db_path = project_db_path("alpha")
+    conn = apsw.Connection(str(db_path))
+    try:
+        cur = conn.cursor()
+        for table in ("documents", "summaries", "chunks"):
+            cur.execute(f"ALTER TABLE {table} DROP COLUMN ingest_run_id")
+        cur.execute("DROP TABLE ingests")
+        cur.execute("DROP TABLE failed_ingests")
+        cur.execute("ALTER TABLE sessions DROP COLUMN harness")
+        cur.execute("ALTER TABLE sessions DROP COLUMN model")
+        cur.execute("DROP INDEX idx_document_tags_tag")
+        cur.execute("DROP TABLE document_tags")
+        cur.execute("DROP TABLE tags")
+        cur.execute("ALTER TABLE summaries DROP COLUMN authored_date")
+        cur.execute("UPDATE meta SET value = '4' WHERE key = 'schema_version'")
+    finally:
+        conn.close()
+
+    # Kill the chain at the v6→v7 step: v4→v5 and v5→v6 commit first, then this
+    # raises. The DB must come to rest at v6 (the last completed step), with the
+    # v5/v6 shapes present and the v7 shape absent.
+    real_v6_to_v7 = upgrades_mod._UPGRADES[6]
+    crashed = {"hit": False}
+
+    def boom(_conn):
+        crashed["hit"] = True
+        raise apsw.SQLError("simulated mid-chain crash")
+
+    monkeypatch.setitem(upgrades_mod._UPGRADES, 6, boom)
+
+    with pytest.raises(apsw.Error):
+        upgrades_mod.upgrade(apsw.Connection(str(db_path)), 4)
+    assert crashed["hit"]
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        cur = conn.cursor()
+        meta = dict(cur.execute("SELECT key, value FROM meta"))
+        # Stamped to the last completed step, not the original v4 or the target.
+        assert meta["schema_version"] == "6"
+        names = {
+            row[0] for row in cur.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert "tags" in names and "document_tags" in names  # v6 landed
+        scols = [r[1] for r in cur.execute("PRAGMA table_info(sessions)")]
+        assert "model" not in scols  # v7 did NOT land
+    finally:
+        conn.close()
+
+    # Re-run with the real step restored: it must resume from v6 (never
+    # re-applying v5/v6 — that would raise "table already exists") and complete.
+    monkeypatch.setitem(upgrades_mod._UPGRADES, 6, real_v6_to_v7)
+    project_cmd.upgrade(name="alpha")
+
+    conn = open_db("alpha")
+    try:
+        cur = conn.cursor()
+        meta = dict(cur.execute("SELECT key, value FROM meta"))
+        assert meta["schema_version"] == str(SCHEMA_VERSION)
+        scols = [r[1] for r in cur.execute("PRAGMA table_info(sessions)")]
+        assert "model" in scols and "harness" in scols  # v7 now landed
+        names = {
+            row[0] for row in cur.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert "ingests" in names and "failed_ingests" in names  # v8 landed
+    finally:
+        conn.close()


### PR DESCRIPTION
Part of #363.

`upgrades.upgrade()` stamped `meta.schema_version` only after the whole chain, so a crash after an earlier step committed left the DB structurally at vN+1 while `meta` said vN. A re-run replayed the step and died on "table already exists" (an `apsw.SQLError`), and `commands/project.py` caught only `RuntimeError` — surfacing a raw traceback and wedging the DB.

This PR:
- Moves the `schema_version` UPDATE **inside** each per-step `with conn:` (set to `v+1`), so each step's DDL and version bump commit atomically. A crash between steps leaves the DB at the last completed step's version; a re-run resumes and completes to `SCHEMA_VERSION` with no double-application. `upgraded_at` stays a single end-of-chain stamp.
- Widens the CLI catch to `(RuntimeError, apsw.Error)`, exiting 1 with a readable `Upgrade failed: ...` line.
- Adds `test_upgrade_resumes_after_mid_chain_crash`: monkeypatches the v6→v7 step to raise after v4→v5/v5→v6 commit, asserts the DB rests at v6, then re-runs and asserts completion to `SCHEMA_VERSION`.

`SCHEMA_VERSION` untouched (held at 8); the dormant `_upgrade_v8_to_v9` body and the held-at-8 xfail are unchanged.

Full suite: 799 passed, 1 xfailed (held-at-8 chain-walk gate).