### PR TITLE
fix: guard upgrade() against a DB newer than the code (Part of #363)

### DIFF
--- a/bartleby/db/upgrades.py
+++ b/bartleby/db/upgrades.py
@@ -167,8 +167,17 @@ def upgrade(conn: apsw.Connection, current_version: int) -> None:
     """Walk the chain from ``current_version`` up to ``SCHEMA_VERSION``.
 
     Raises if a step is missing — non-additive bumps have no entry and force
-    re-ingest.
+    re-ingest. Also raises, without stamping or mutating anything, if the DB is
+    newer than this code: the loop would never run and the unconditional
+    `upgraded_at` write below would otherwise rewrite a newer DB this code can't
+    reason about. Keep the wording in lockstep with the CLI guard in
+    `commands/project.py`.
     """
+    if current_version > SCHEMA_VERSION:
+        raise RuntimeError(
+            f"DB schema v{current_version} is newer than this code "
+            f"(v{SCHEMA_VERSION}). Update the code, not the DB."
+        )
     v = current_version
     while v < SCHEMA_VERSION:
         step = _UPGRADES.get(v)

--- a/docs/decisions/GH-0354-guard-newer-db-0001.md
+++ b/docs/decisions/GH-0354-guard-newer-db-0001.md
@@ -1,0 +1,44 @@
+# Guard `upgrade()` against a DB newer than the code (issue #354)
+
+> Source: [#354](https://github.com/jswest/bartleby/issues/354)
+
+`upgrades.upgrade()` walked the chain from `current_version` up to
+`SCHEMA_VERSION` but never guarded the case where `current_version >
+SCHEMA_VERSION`. The `while v < SCHEMA_VERSION` loop simply never ran, fell
+through to the unconditional trailing `with conn:` block, and stamped
+`upgraded_at` on a DB this code can't reason about. Worse, the contract was that
+the library was the only place callers reached — yet only the CLI wrapper
+(`commands/project.py`) caught a newer DB (and refused with exit 1). The
+library itself had the hole, and that CLI guard was untested.
+
+**Fix: refuse a newer DB at the top of `upgrade()`, before any mutation.** A
+single early guard raises a `RuntimeError` when `current_version >
+SCHEMA_VERSION`:
+
+```
+DB schema vN is newer than this code (vM). Update the code, not the DB.
+```
+
+The wording matches the existing CLI guard in `commands/project.py`
+("Update the code, not the DB.") so the two surfaces speak the same language.
+The guard runs before the chain walk and before the trailing `upgraded_at`
+write, so nothing is stamped or mutated. The CLI catch (#353 widened it to
+`(RuntimeError, apsw.Error)`) surfaces it as a readable `Upgrade failed: <e>`
+exit-1 line for any caller that reaches the library directly; the CLI's own
+pre-check still short-circuits the common path with its dedicated message.
+
+**Test: `test_upgrade_refuses_db_newer_than_code` (`tests/test_project.py`).**
+It creates a fresh project, stamps `meta.schema_version` to `SCHEMA_VERSION + 1`,
+then asserts (a) the library `upgrade()` raises `RuntimeError` matching
+"newer than this code", (b) `meta` is byte-for-byte unchanged afterward —
+`schema_version` is *not* rewritten down and no `upgraded_at` key appears — and
+(c) the CLI wrapper `project_cmd.upgrade` refuses with `SystemExit(1)`. The
+no-mutation assertion is the load-bearing one: it pins the exact corruption the
+issue describes (a newer DB silently downgraded).
+
+Not done, deliberately: `SCHEMA_VERSION` is untouched (held at 8), and neither
+the dormant `_upgrade_v8_to_v9` body nor the held-at-8 xfail on the chain-walk
+gate was altered — those belong to the v0.9.0 assembly commit.
+
+touches: `bartleby/db/upgrades.py`, `tests/test_project.py` (one added test).
+No schema change.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -432,3 +432,51 @@ def test_upgrade_resumes_after_mid_chain_crash(projects_root, monkeypatch):
         assert "ingests" in names and "failed_ingests" in names  # v8 landed
     finally:
         conn.close()
+
+
+def test_upgrade_refuses_db_newer_than_code(projects_root):
+    """A DB stamped newer than the code is refused without mutation.
+
+    With `current_version > SCHEMA_VERSION` the chain loop never runs, so the
+    unconditional `upgraded_at` write at the tail used to rewrite a newer DB's
+    `schema_version` *down* to the code's — silently corrupting the version
+    contract. `upgrade()` must raise before touching anything, and the CLI
+    wrapper must surface that as exit 1 ("Update the code, not the DB").
+    """
+    import apsw
+
+    from bartleby.commands import project as project_cmd
+    from bartleby.db import upgrades as upgrades_mod
+    from bartleby.db.connection import project_db_path
+
+    bartleby.project.create_project("alpha")
+    db_path = project_db_path("alpha")
+
+    # Stamp the DB one version ahead of the code.
+    newer = SCHEMA_VERSION + 1
+    conn = apsw.Connection(str(db_path))
+    try:
+        conn.cursor().execute(
+            "UPDATE meta SET value = ? WHERE key = 'schema_version'", (str(newer),)
+        )
+        before = dict(conn.cursor().execute("SELECT key, value FROM meta"))
+    finally:
+        conn.close()
+
+    # Library: raises, and stamps/mutates nothing.
+    with pytest.raises(RuntimeError, match="newer than this code"):
+        upgrades_mod.upgrade(apsw.Connection(str(db_path)), newer)
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        after = dict(conn.cursor().execute("SELECT key, value FROM meta"))
+        assert after["schema_version"] == str(newer)  # not rewritten down
+        assert "upgraded_at" not in after  # tail write never ran
+        assert after == before  # nothing mutated at all
+    finally:
+        conn.close()
+
+    # CLI: refuses with exit 1.
+    with pytest.raises(SystemExit) as exc:
+        project_cmd.upgrade(name="alpha")
+    assert exc.value.code == 1


### PR DESCRIPTION
Part of #363.

`upgrades.upgrade()` never guarded `current_version > SCHEMA_VERSION`: the chain loop fell through to the unconditional trailing `with conn:` and stamped `upgraded_at`, silently rewriting a newer DB's `schema_version` *down* to the code's. Only the CLI wrapper guarded this, and that guard was untested.

**Fix.** Add an early raise at the top of `upgrade()` — before the chain walk and before any mutation — when `current_version > SCHEMA_VERSION`, with wording in lockstep with the CLI guard ("Update the code, not the DB."). The #353-widened CLI catch `(RuntimeError, apsw.Error)` surfaces it as exit 1.

**Test.** `test_upgrade_refuses_db_newer_than_code` stamps `SCHEMA_VERSION + 1`, asserts the library raises, `meta` is byte-for-byte unchanged (no downgrade, no `upgraded_at`), and the CLI refuses with `SystemExit(1)`.

`SCHEMA_VERSION` held at 8; dormant `_upgrade_v8_to_v9` and the held-at-8 xfail untouched. Full suite: 803 passed, 1 xfailed (held-at-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)