### PR TITLE
test: upgrade-chain refusal path leaves DB unchanged (Part of #363)

### DIFF
--- a/docs/decisions/GH-0356-upgrade-chain-refusal-leaves-db-unchanged-0001.md
+++ b/docs/decisions/GH-0356-upgrade-chain-refusal-leaves-db-unchanged-0001.md
@@ -1,0 +1,52 @@
+# Pin the upgrade-chain refusal path: a DB below the first step is refused, DB unchanged (issue #356)
+
+> Source: [#356](https://github.com/jswest/bartleby/issues/356)
+
+Part of the v0.9.0 additive schema-bump omnibus ([#363](https://github.com/jswest/bartleby/issues/363)).
+
+## Problem
+
+`upgrade()` walks `_UPGRADES` from the DB's stamped version up to `SCHEMA_VERSION`,
+raising a `RuntimeError` ("non-additive bump; re-ingest is required") the moment it
+hits a version with no chain step (`upgrades.py` `_UPGRADES.get(v) is None`). The CLI
+wrapper (`commands/project.py`) catches that and `sys.exit(1)`s. Neither path had a
+test: the refusal `RuntimeError` and the CLI `exit(1)` were both uncovered, and the
+load-bearing **"a refused upgrade leaves the DB unchanged"** property was unpinned.
+
+That property matters specifically because the chain now stamps `meta.schema_version`
+*inside each step's own transaction* (the per-step-commit structure from #353/#354's
+mid-chain-crash work). A future mid-chain hole would persist the earlier steps' DDL
+while leaving the stamp old — so we want an explicit guarantee that a *refused* walk
+(one with no step to begin from) writes nothing at all.
+
+## What the test does
+
+`test_upgrade_refuses_below_chain_first_step_without_mutation` (in
+`tests/test_project.py`):
+
+- Creates a fresh project, then stamps `meta.schema_version` to
+  `min(_UPGRADES) - 1` (currently v3 — one below the chain's first entry, v4). No
+  production code branches on schema version, so the stale stamp alone reproduces
+  the "below the chain, nothing to walk from" condition without hand-mutating DDL.
+- Snapshots the full `sqlite_master` (type, name, tbl_name, sql) **and** the
+  `schema_version` stamp before the call.
+- Invokes the CLI `project_cmd.upgrade(name=...)`, asserts it raises `SystemExit`
+  with code 1 and that the rendered output contains the re-ingest guidance.
+- Re-snapshots and asserts the snapshot is **byte-identical** before/after — both
+  the full DDL and the version stamp — so the refusal provably mutated nothing.
+
+## Why v3, not "newer than code"
+
+`test_upgrade_refuses_db_newer_than_code` already covers `current_version >
+SCHEMA_VERSION` (the tail `upgraded_at` write that would rewrite a newer stamp down).
+This test covers the *other* refusal branch — `current_version < SCHEMA_VERSION` with
+a hole at the bottom of the chain — which is the path the issue calls out as
+uncovered. Stamping below `min(_UPGRADES)` (computed, not hard-coded to 3) keeps the
+test honest if the chain's floor ever moves.
+
+## Scope
+
+Test-only. No production change, no `SCHEMA_VERSION` bump, and the held-at-8 xfail on
+`test_upgrade_chain_walks_from_v4_through_current` is untouched. Full suite stays at
+green + 1 xfailed. The refusal path was verified to genuinely leave the DB unchanged
+(no real mutation bug found).

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -434,6 +434,77 @@ def test_upgrade_resumes_after_mid_chain_crash(projects_root, monkeypatch):
         conn.close()
 
 
+def test_upgrade_refuses_below_chain_first_step_without_mutation(
+    projects_root, monkeypatch
+):
+    """A DB below the chain's first entry is refused, leaving the DB unchanged.
+
+    The chain's first step is keyed at v4 (`_upgrade_v4_to_v5`), so a DB stamped
+    at v3 has no step to walk from: `upgrade()`'s loop hits `_UPGRADES.get(3) is
+    None` and raises ("non-additive bump; re-ingest is required"), and the CLI
+    wrapper surfaces that as exit 1. This pins the refusal property the
+    per-step-commit structure makes load-bearing — a refused upgrade must not
+    persist any DDL or move the version stamp. We assert both the full
+    `sqlite_master` DDL and the `schema_version` stamp are byte-identical
+    before and after.
+    """
+    import apsw
+
+    from bartleby.commands import project as project_cmd
+    from bartleby.db import upgrades as upgrades_mod
+    from bartleby.db.connection import project_db_path
+
+    bartleby.project.create_project("alpha")
+    db_path = project_db_path("alpha")
+
+    # Stamp the DB at v3 — one below the chain's first entry (v4). No code
+    # branches on schema version, so the stale stamp alone reproduces the
+    # "below the chain" condition; the structural DDL stays at the fresh shape.
+    below_first = min(upgrades_mod._UPGRADES) - 1
+    conn = apsw.Connection(str(db_path))
+    try:
+        conn.cursor().execute(
+            "UPDATE meta SET value = ? WHERE key = 'schema_version'",
+            (str(below_first),),
+        )
+    finally:
+        conn.close()
+
+    def _snapshot():
+        conn = apsw.Connection(str(db_path))
+        try:
+            cur = conn.cursor()
+            master = cur.execute(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master "
+                "ORDER BY type, name"
+            ).fetchall()
+            stamp = cur.execute(
+                "SELECT value FROM meta WHERE key = 'schema_version'"
+            ).fetchone()[0]
+            return master, stamp
+        finally:
+            conn.close()
+
+    before = _snapshot()
+    assert before[1] == str(below_first)
+
+    # CLI: refuses with exit 1 and the re-ingest guidance.
+    import io
+
+    from rich.console import Console
+
+    buf = io.StringIO()
+    monkeypatch.setattr(project_cmd, "_console", Console(file=buf, width=200))
+    with pytest.raises(SystemExit) as exc:
+        project_cmd.upgrade(name="alpha")
+    assert exc.value.code == 1
+    assert "re-ingest" in buf.getvalue().lower()
+
+    # The refusal mutated nothing: full DDL and the version stamp are identical.
+    after = _snapshot()
+    assert after == before
+
+
 def test_upgrade_refuses_db_newer_than_code(projects_root):
     """A DB stamped newer than the code is refused without mutation.
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -448,7 +448,10 @@ def test_upgrade_refuses_below_chain_first_step_without_mutation(
     `sqlite_master` DDL and the `schema_version` stamp are byte-identical
     before and after.
     """
+    import io
+
     import apsw
+    from rich.console import Console
 
     from bartleby.commands import project as project_cmd
     from bartleby.db import upgrades as upgrades_mod
@@ -489,10 +492,6 @@ def test_upgrade_refuses_below_chain_first_step_without_mutation(
     assert before[1] == str(below_first)
 
     # CLI: refuses with exit 1 and the re-ingest guidance.
-    import io
-
-    from rich.console import Console
-
     buf = io.StringIO()
     monkeypatch.setattr(project_cmd, "_console", Console(file=buf, width=200))
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
Part of #363.

Pins the upgrade-chain refusal path that was previously untested. A test stamps a DB at `min(_UPGRADES) - 1` (currently v3, one below the chain's first entry v4) and asserts that `bartleby project upgrade`:

- exits non-zero (SystemExit code 1) with the re-ingest guidance message, and
- leaves both the full `sqlite_master` DDL **and** the `meta.schema_version` stamp byte-identical before/after.

This covers the previously-uncovered refusal `RuntimeError` (`upgrades.py`) and CLI `exit(1)` (`commands/project.py`), and locks in the 'a refused upgrade mutates nothing' property the per-step-commit structure (#353/#354) makes load-bearing.

Test-only: no production change, no `SCHEMA_VERSION` bump, the held-at-8 xfail on the chain-walk gate is untouched. Full suite: 813 passed, 1 xfailed. The refusal path was verified to genuinely leave the DB unchanged (no real mutation bug found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)