### PR TITLE
fix: merge_tags value-collision data-loss + mixed-type guard + read_chunks hint (Part of #363)

### DIFF
--- a/bartleby/skill_scripts/merge_tags.py
+++ b/bartleby/skill_scripts/merge_tags.py
@@ -15,13 +15,23 @@ destination tag. ``already_present`` is the number skipped because the
 destination tag already carried that document (the overlap absorbed by
 ``INSERT OR IGNORE``). Their sum is the source tag's pre-merge assignment count.
 
+**Same-type only.** Both tags must be the same kind — two value-tags or two
+boolean tags. A mixed merge (value-tag into a boolean tag, or vice versa) is
+refused with ``MIXED_TYPE_MERGE`` before anything mutates: a value-tag's
+``value``/``chunk_id`` carried onto a boolean tag (``value_type IS NULL``)
+would be unreachable — every value-read path gates on ``value_type IS NOT
+NULL`` — and the source's ``value_type``/``pattern`` would be lost with it.
+
 **Value collision rule (value-tags).** The merge is value-preserving on the
 target's existing rows: where both tags carry a *value* for the same document,
 the **target's value is kept** and the source's is dropped (reported in
-``value_collisions`` with ``kept``/``dropped``, never silently lost). For a
-document the source carries but the target doesn't, the source's value (and its
-chunk anchor) rides along with the copied assignment. ``value_collisions`` is
-empty for boolean-tag merges.
+``value_collisions`` with ``kept``/``dropped``, never silently lost). Where the
+target carries a *plain* assignment (value NULL — someone assigned the value-tag
+without extracting) and the source holds a value for that document, the source's
+value (and chunk anchor) is **carried onto the target** rather than discarded —
+no silent loss. For a document the source carries but the target doesn't, the
+source's value (and its chunk anchor) rides along with the copied assignment.
+``value_collisions`` is empty for boolean-tag merges.
 """
 
 from __future__ import annotations
@@ -49,6 +59,19 @@ def work(*, conn, args, session_id) -> dict:
     src = require_tag_by_name(conn, args.from_name)
     dst = require_tag_by_name(conn, args.into_name)
 
+    # Same-type only: a value-tag's value/chunk_id is invisible on a boolean
+    # tag (value-read paths gate on value_type IS NOT NULL) and the source's
+    # value_type/pattern would vanish with the deleted source. Refuse before
+    # mutating anything.
+    if src.is_value_tag != dst.is_value_tag:
+        src_kind = "value-tag" if src.is_value_tag else "boolean tag"
+        dst_kind = "value-tag" if dst.is_value_tag else "boolean tag"
+        raise SkillError(
+            "MIXED_TYPE_MERGE",
+            f"Cannot merge {src.name!r} ({src_kind}) into {dst.name!r} "
+            f"({dst_kind}): both tags must be the same kind.",
+        )
+
     cur = conn.cursor()
     moved_before = cur.execute(
         "SELECT COUNT(*) FROM document_tags WHERE tag_id = ?", (src.tag_id,),
@@ -70,6 +93,20 @@ def work(*, conn, args, session_id) -> dict:
             (dst.tag_id, src.tag_id),
         )
     ]
+
+    # Carry the source's value/chunk onto a destination row that is a *plain*
+    # assignment (value NULL) where the source holds a value. Without this the
+    # OR IGNORE below would keep the destination's NULL row and the source value
+    # would be deleted with the source tag — silent data loss. Done before the
+    # INSERT so it only touches pre-existing destination rows.
+    cur.execute(
+        "UPDATE document_tags AS d SET value = s.value, chunk_id = s.chunk_id "
+        "FROM document_tags AS s "
+        "WHERE d.tag_id = ? AND d.value IS NULL "
+        "  AND s.tag_id = ? AND s.value IS NOT NULL "
+        "  AND s.document_id = d.document_id",
+        (dst.tag_id, src.tag_id),
+    )
 
     # Carry value + chunk anchor along when the destination doesn't already
     # carry the document (OR IGNORE keeps the destination's row on overlap).

--- a/bartleby/skill_scripts/read_chunks.py
+++ b/bartleby/skill_scripts/read_chunks.py
@@ -208,13 +208,19 @@ def _read_by_chunk_ids(
     # Cross-namespace hint: a missing chunk_id that exists as a document_id is
     # very likely a --document id passed to --chunks. Surface a per-id hint so a
     # silently-wrong-namespace lookup gets caught before it becomes a citation.
-    # (Memory-walled foreign finding chunks also land in ``missing`` but aren't
-    # document_ids, so they never trigger a hint.)
+    # Memory-walled foreign finding chunks also land in ``missing``, but their
+    # ids ARE chunk ids (chunk and document ids overlap freely), so a walled id
+    # that happens to collide with a live document_id would otherwise mis-fire
+    # this hint. Suppress the hint for any missing id that still exists as a
+    # chunk_id — the id is genuinely a chunk in this corpus, just walled, so the
+    # director's rule (never hint on an id valid in the requested namespace)
+    # holds. The hint fires only for ids that are not chunks here at all.
+    live_chunk_ids = _live_chunk_ids(conn, missing)
     doc_ids = _live_document_ids(conn, missing)
     hints = {
         str(cid): f"{cid} is a document_id — did you mean --document {cid}?"
         for cid in missing
-        if cid in doc_ids
+        if cid in doc_ids and cid not in live_chunk_ids
     }
 
     out = {

--- a/docs/decisions/GH-0363-critic-merge-tags-readchunks-fixes-0001.md
+++ b/docs/decisions/GH-0363-critic-merge-tags-readchunks-fixes-0001.md
@@ -1,0 +1,71 @@
+# Critic-loop fixes: merge_tags value safety + read_chunks walled-chunk hint (omnibus #363)
+
+> Source: [#363](https://github.com/jswest/bartleby/issues/363) (omnibus v0.9.0 critic loop)
+
+Three confirmed 🟡 correctness findings surfaced by the `/ultraship` critic over
+#114's `merge_tags` and #370's `read_chunks`. All patch-level, no schema change,
+no `SCHEMA_VERSION` bump.
+
+## A — merge_tags silently destroyed a source value (data loss)
+
+The value-collision report required *both* sides non-NULL
+(`d.value IS NOT NULL AND s.value IS NOT NULL`). When the **destination** held a
+plain assignment (value NULL — someone `assign_tag`'d the value-tag without
+extracting a value) and the **source** held an extracted value for the same
+document, the `INSERT OR IGNORE` kept the destination's NULL row, then the source
+row was deleted with the source tag — value + chunk anchor permanently lost, and
+*not* reported in `value_collisions`. The docstring promised values are never
+silently lost.
+
+**Fix (carry, don't drop):** before the `INSERT OR IGNORE`, an `UPDATE` carries
+the source's `value`/`chunk_id` onto any destination row that is a plain
+assignment (`value IS NULL`) where the source holds a value. No silent loss; this
+is not a kept/dropped collision (the destination had no competing value), so
+`value_collisions` stays empty for these. The chosen rule — *carry the value* —
+matches the docstring's "never silently lost" promise and is now documented
+there. The collision path (both sides hold a *value*) is unchanged: target's
+value kept, source's reported as `dropped`.
+
+## B — merge_tags allowed a mixed-type merge (values become invisible)
+
+Merging a value-tag into a boolean tag (target `value_type IS NULL`) copied
+`value`/`chunk_id` onto a tag whose value-read paths all gate on
+`value_type IS NOT NULL` (`list_documents._value_tag_values`, `read_tags`
+display), so the carried values were unreachable — and the source's
+`value_type`/`pattern` were deleted with the source tag.
+
+**Fix (refuse before mutating):** `merge_tags` now rejects any mixed-kind merge
+(value-tag → boolean tag *or* boolean tag → value-tag) with
+`{"error", "code": "MIXED_TYPE_MERGE"}` and a non-zero exit, computed from
+`TagRow.is_value_tag` immediately after both tags resolve — before any write.
+Same-kind merges (two value-tags or two boolean tags) are unaffected.
+
+## C — read_chunks cross-namespace hint over-fired on walled finding chunks
+
+The hint "`<id>` is a document_id — did you mean --document `<id>`?" fired for any
+`missing` id that is a live `document_id`. The old comment claimed memory-walled
+foreign finding chunks "aren't document_ids, so they never trigger a hint" — this
+was **false**: a walled finding chunk's id lands in `missing`, and chunk/document
+ids overlap freely, so a walled chunk id colliding with a real document_id
+mis-fired the hint, telling the agent to `--document N` for an id that is really a
+(walled) chunk.
+
+**Fix:** (1) the comment is corrected; (2) the hint is suppressed for any
+`missing` id that still EXISTS as a `chunk_id` (reusing the existing
+`_live_chunk_ids` helper) — the id is genuinely a chunk in this corpus, just
+walled. The hint now fires only when the id is *not* a chunk here at all, which
+preserves the director's binding rule (never hint on an id valid in the requested
+namespace).
+
+## Tests
+
+- `test_merge_value_tags_carries_value_onto_null_destination` — NULL destination
+  absorbs the source value + anchor; no entry in `value_collisions`.
+- `test_merge_value_tag_into_boolean_tag_refused` /
+  `test_merge_boolean_tag_into_value_tag_refused` — `MIXED_TYPE_MERGE`, non-zero
+  exit, nothing mutated.
+- `test_read_chunks_no_hint_for_walled_finding_chunk_colliding_with_document` —
+  a walled finding chunk whose id is forced to equal a live document_id produces
+  NO hint (and still leaks nothing).
+
+Full suite green (821 passed, 0 xfailed, 0 failed).

--- a/tests/test_skill_read_chunks.py
+++ b/tests/test_skill_read_chunks.py
@@ -437,6 +437,45 @@ def test_read_chunks_around_memory_off_foreign_finding_walled(seeded_project, ca
     assert out["code"] == "MEMORY_OFF"
 
 
+def test_read_chunks_no_hint_for_walled_finding_chunk_colliding_with_document(
+    seeded_project, capsys,
+):
+    """A walled finding chunk whose id collides with a live document_id: no hint.
+
+    Regression: the cross-namespace hint fires for a ``missing`` id that is a
+    live document_id. A memory-walled foreign finding chunk lands in ``missing``
+    too, and its chunk_id can collide with a real document_id (the two id spaces
+    overlap freely). The hint must NOT fire there — the id is genuinely a chunk
+    in this corpus, just walled — only when the id is not a chunk here at all.
+    """
+    project = seeded_project["project"]
+    conn = open_db(project)
+    try:
+        author = _other_session(conn)
+        foreign = _seed_finding_chunk(conn, session_id=author, body="walled body")
+        # Force a document_id that equals the walled finding chunk_id, so the
+        # collision the hint keys off of is present.
+        conn.cursor().execute(
+            "INSERT INTO documents "
+            "(document_id, file_hash, file_name, file_path) "
+            "VALUES (?, ?, ?, ?)",
+            (foreign, f"hash-{foreign}", "collider.pdf", "/x/collider.pdf"),
+        )
+    finally:
+        conn.close()
+
+    start_session(project, memory_enabled=False)
+
+    read_chunks.main(["--project", project, "--chunks", str(foreign)])
+    out = json.loads(capsys.readouterr().out)
+    # The walled chunk is missing (no leak)...
+    assert out["missing"] == [foreign]
+    assert out["chunks"] == []
+    # ...and despite the document_id collision, no misleading hint fires.
+    assert "hints" not in out
+    assert "walled body" not in json.dumps(out)
+
+
 def test_read_chunks_around_memory_off_own_finding_allowed(seeded_project, capsys):
     """--around-chunk on the session's own finding chunk still works memory-off."""
     project = seeded_project["project"]

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -1114,6 +1114,102 @@ def test_merge_value_tags_keeps_target_reports_dropped(seeded_project, capsys):
     ) == ("200", None)
 
 
+def test_merge_value_tags_carries_value_onto_null_destination(
+    seeded_project, capsys,
+):
+    """A plain (value-NULL) destination row absorbs the source's value+anchor.
+
+    Regression: the destination had a value-tag assignment with no extracted
+    value while the source held one for the same doc. The old INSERT OR IGNORE
+    kept the NULL destination row and then deleted the source — losing the
+    value silently. The merge must carry the source value onto the destination.
+    """
+    src = _seed_value_tag(
+        seeded_project["project"], name="rev_src", pattern=r"(?P<value>\d+)",
+    )
+    dst = _seed_value_tag(
+        seeded_project["project"], name="rev_dst", pattern=r"(?P<value>\d+)",
+    )
+    conn = open_db(seeded_project["project"])
+    try:
+        cur = conn.cursor()
+        # Destination: a plain assignment (value NULL, no chunk anchor).
+        cur.execute(
+            "INSERT INTO document_tags (document_id, tag_id, value) VALUES (?, ?, ?)",
+            (seeded_project["doc_a"], dst, None),
+        )
+        # Source: holds an extracted value + chunk anchor for the same doc.
+        cur.execute(
+            "INSERT INTO document_tags (document_id, tag_id, value, chunk_id) "
+            "VALUES (?, ?, ?, ?)",
+            (seeded_project["doc_a"], src, "777", 1),
+        )
+    finally:
+        conn.close()
+
+    merge_tags.main([
+        "--project", seeded_project["project"],
+        "--from", "rev_src", "--into", "rev_dst",
+    ])
+    out = json.loads(capsys.readouterr().out)
+
+    # Not a kept/dropped collision — the destination had no competing value.
+    assert out["value_collisions"] == []
+    # The source's value + anchor were carried onto the destination, not lost.
+    assert _doc_value(
+        seeded_project["project"], seeded_project["doc_a"], dst,
+    ) == ("777", 1)
+
+
+def test_merge_value_tag_into_boolean_tag_refused(seeded_project, capsys):
+    """value-tag → boolean tag is refused before any mutation (MIXED_TYPE_MERGE)."""
+    src = _seed_value_tag(
+        seeded_project["project"], name="rev_src", pattern=r"(?P<value>\d+)",
+    )
+    _seed_tag(seeded_project["project"], name="boolcat", description="a category")
+    conn = open_db(seeded_project["project"])
+    try:
+        conn.cursor().execute(
+            "INSERT INTO document_tags (document_id, tag_id, value, chunk_id) "
+            "VALUES (?, ?, ?, ?)",
+            (seeded_project["doc_a"], src, "500", 1),
+        )
+    finally:
+        conn.close()
+
+    with pytest.raises(SystemExit):
+        merge_tags.main([
+            "--project", seeded_project["project"],
+            "--from", "rev_src", "--into", "boolcat",
+        ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "MIXED_TYPE_MERGE"
+    # Nothing mutated: source tag and its value row both survive.
+    assert _doc_value(
+        seeded_project["project"], seeded_project["doc_a"], src,
+    ) == ("500", 1)
+    conn = open_db(seeded_project["project"])
+    try:
+        assert tags_helpers.get_tag_by_name(conn, "rev_src") is not None
+    finally:
+        conn.close()
+
+
+def test_merge_boolean_tag_into_value_tag_refused(seeded_project, capsys):
+    """boolean tag → value-tag is refused too (MIXED_TYPE_MERGE)."""
+    _seed_tag(seeded_project["project"], name="boolcat", description="a category")
+    _seed_value_tag(
+        seeded_project["project"], name="rev_dst", pattern=r"(?P<value>\d+)",
+    )
+    with pytest.raises(SystemExit):
+        merge_tags.main([
+            "--project", seeded_project["project"],
+            "--from", "boolcat", "--into", "rev_dst",
+        ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "MIXED_TYPE_MERGE"
+
+
 def test_list_documents_surfaces_value_chip(seeded_project, capsys):
     tag_id = _seed_value_tag(seeded_project["project"])
     conn = open_db(seeded_project["project"])


### PR DESCRIPTION
Part of #363. Critic-loop fixes over #114's `merge_tags` and #370's `read_chunks`. Patch-level, no schema change.

**A — merge_tags silently destroyed a source value (data loss).** When the destination held a plain assignment (`value` NULL) and the source held a value for the same document, `INSERT OR IGNORE` kept the NULL row and the source value was deleted with the source tag — unreported. Now an `UPDATE ... FROM` carries the source value/chunk onto the destination before the insert.

**B — merge_tags allowed a mixed-type merge.** value-tag <-> boolean tag merges placed values where every value-read path (gating on `value_type IS NOT NULL`) can't see them. Now refused with `MIXED_TYPE_MERGE` before any mutation.

**C — read_chunks cross-namespace hint over-fired on walled finding chunks.** A memory-walled foreign finding chunk lands in `missing`; when its id collides with a live `document_id` the hint mis-fired. Comment corrected; hint suppressed for any `missing` id that still exists as a `chunk_id`.

Decision doc: `docs/decisions/GH-0363-critic-merge-tags-readchunks-fixes-0001.md`. Regression tests added; full suite 821 passed (0 xfailed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)