### PR TITLE
fix: #254 anchor-splitting — preamble content + out-of-order/over-harvested anchors (Part of #363)

### DIFF
--- a/bartleby/ingest/sec2md.py
+++ b/bartleby/ingest/sec2md.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 
 SEC2MD_MAX_TOKENS = 400  # headroom under embedder's 512-token cap (matches docling)
@@ -38,6 +39,15 @@ class Sec2mdResult:
     full_text: str
     page_count: int | None
     chunks: list[Sec2mdChunk]
+
+
+# A synthetic anchor id for the front-matter section that precedes the first TOC
+# target (#254 rework). EDGAR cover pages carry the registrant name, CIK, period,
+# ticker and shares-outstanding — real content that must land in a section rather
+# than be dropped. The leading/trailing underscores keep it from colliding with a
+# genuine HTML id a filing might use as a TOC target.
+_PREAMBLE_ANCHOR_ID = "__preamble__"
+_PREAMBLE_TITLE = "Preamble"
 
 
 @dataclass
@@ -153,18 +163,38 @@ def _convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
         soup = BeautifulSoup(html, "html.parser")
 
     body = soup.body or soup
-    targets = _resolve_toc_targets(soup, body)
+    targets, toc_link_els = _resolve_toc_targets(soup, body)
     if len(targets) < _MIN_SECTIONS_TO_SPLIT:
         return []
 
+    # Slice boundaries are the top-level ancestors of each target, IN DOCUMENT
+    # ORDER (targets are already so ordered). Each slice ends at the next
+    # target's boundary; only the genuine last target runs to end-of-body. A
+    # synthetic "preamble" section captures any body content before the first
+    # target (an EDGAR cover page: registrant name, CIK, period, ticker), which
+    # would otherwise land in no section and vanish from FTS/embeddings.
+    boundaries = [
+        (anchor_id, title, _top_level_ancestor(target_el, body))
+        for anchor_id, title, target_el in targets
+    ]
+    first_start = boundaries[0][2]
+    # The TOC nav block(s) sit before the first target but are navigation, not
+    # content — exclude their top-level ancestors so the preamble is the cover
+    # page, not a re-render of the link list.
+    toc_blocks = {id(_top_level_ancestor(el, body)) for el in toc_link_els}
+    preamble_fragment = _slice_between(
+        _first_body_child(body), first_start, skip=toc_blocks,
+    )
+    slices: list[tuple[str, str | None, str]] = []
+    if preamble_fragment.strip():
+        slices.append((_PREAMBLE_ANCHOR_ID, _PREAMBLE_TITLE, preamble_fragment))
+    for i, (anchor_id, title, start) in enumerate(boundaries):
+        next_start = boundaries[i + 1][2] if i + 1 < len(boundaries) else None
+        slices.append((anchor_id, title or None, _slice_between(start, next_start)))
+
     sections: list[Sec2mdSection] = []
-    for order, (anchor_id, title, target_el) in enumerate(targets):
-        start = _top_level_ancestor(target_el, body)
-        next_start = (
-            _top_level_ancestor(targets[order + 1][2], body)
-            if order + 1 < len(targets) else None
-        )
-        fragment = _slice_between(start, next_start)
+    order = 0
+    for anchor_id, title, fragment in slices:
         if not fragment.strip():
             continue
         section_html = f"<html><body>{fragment}</body></html>".encode("utf-8")
@@ -174,8 +204,9 @@ def _convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
             # index — skip it rather than persist a content-free section row.
             continue
         sections.append(Sec2mdSection(
-            anchor_id=anchor_id, title=title or None, order=order, result=result,
+            anchor_id=anchor_id, title=title, order=order, result=result,
         ))
+        order += 1
 
     # If the slices collapsed to a single (or no) real section, splitting buys
     # nothing — let the caller ingest the file whole.
@@ -184,17 +215,46 @@ def _convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
     return sections
 
 
-def _resolve_toc_targets(soup, body) -> list[tuple[str, str, object]]:
-    """The TOC's internal anchors that resolve to in-document targets, in order.
+def _first_body_child(body):
+    """The first top-level node in ``body`` (the start of the preamble slice)."""
+    for node in body.children:
+        if getattr(node, "name", None) is not None:
+            return node
+    return None
 
-    Each entry is ``(anchor_id, link_text, target_element)``. Only the first
-    link to a given id is kept (a TOC that lists a section twice still yields one
-    section), and only ids that actually exist as a target within the body
-    count — a dangling ``#ref`` is no section boundary.
+
+def _resolve_toc_targets(soup, body):
+    """The filing's real TOC anchors, resolved to in-document targets, in
+    DOCUMENT order.
+
+    Returns ``(targets, toc_link_els)`` where each ``targets`` entry is
+    ``(anchor_id, link_text, target_element)`` and ``toc_link_els`` are the TOC's
+    own ``<a>`` elements (so the caller can excise the nav block from the
+    preamble). The hard part is telling a genuine table of contents from the many
+    other ``<a href="#id">`` links a filing carries — in-text cross-references
+    ("see Item 1A"), footnote markers, and "back to top" links would each
+    otherwise spawn a spurious (and out-of-order) section.
+
+    The rule: a real TOC is a contiguous cluster of *forward* links — each link
+    sits earlier in the document than the section it points at, and the cluster
+    is uninterrupted in link order. We walk every internal link in link order,
+    resolve it to a body target, and keep only forward links to ids not already
+    listed (first link to an id wins). A "back to top" / footnote-return link
+    points backward and is dropped; an in-text cross-reference to an
+    already-listed section is a duplicate and is dropped; a cross-reference to an
+    *un*-listed section is forward, but it sits in the body interrupted from the
+    TOC by other (now-dropped) links, so it falls outside the longest contiguous
+    run. We take that longest run — the TOC — then **sort it by document
+    position** before returning. Sorting is what makes link order irrelevant: a
+    TOC that lists sections out of document order no longer produces a slice
+    whose next boundary lies earlier in the document (which would run to
+    end-of-body and duplicate content).
     """
+    pos = {id(el): i for i, el in enumerate(body.descendants)}
+
     seen: set[str] = set()
-    targets: list[tuple[str, str, object]] = []
-    for a in soup.find_all("a"):
+    links: list[_TocLink] = []
+    for link_idx, a in enumerate(soup.find_all("a")):
         href = a.get("href") or ""
         if not href.startswith("#") or len(href) < 2:
             continue
@@ -202,11 +262,64 @@ def _resolve_toc_targets(soup, body) -> list[tuple[str, str, object]]:
         if anchor_id in seen:
             continue
         target = body.find(id=anchor_id)
-        if target is None:
+        if target is None or id(target) not in pos:
+            continue
+        link_pos = pos.get(id(a))
+        target_pos = pos[id(target)]
+        # Forward links only: a TOC entry sits before the content it indexes; a
+        # "back to top" or footnote-return link points the other way.
+        if link_pos is None or link_pos >= target_pos:
             continue
         seen.add(anchor_id)
-        targets.append((anchor_id, a.get_text(strip=True), target))
-    return targets
+        links.append(_TocLink(
+            target_pos, anchor_id, a.get_text(strip=True), target, a, link_idx,
+        ))
+
+    run = _longest_contiguous_run(links)
+    run.sort(key=lambda link: link.target_pos)
+    targets = [(link.anchor_id, link.text, link.target) for link in run]
+    toc_link_els = [link.el for link in run]
+    return targets, toc_link_els
+
+
+class _TocLink(NamedTuple):
+    """One resolved, forward internal link, used while isolating the TOC cluster.
+
+    ``target_pos`` is the link target's document position (the sort key);
+    ``link_idx`` is the link's index among all ``<a>`` in the document, which
+    tells the run finder where a dropped link breaks contiguity.
+    """
+    target_pos: int
+    anchor_id: str
+    text: str
+    target: object
+    el: object
+    link_idx: int
+
+
+def _longest_contiguous_run(links: list[_TocLink]) -> list[_TocLink]:
+    """The longest cluster of links that is uninterrupted in link order — the TOC.
+
+    ``links`` is the forward, deduped internal links in link order. A gap in
+    their ``link_idx`` means a non-TOC link (a dropped back-to-top, or a forward
+    cross-reference whose target *was* already in the TOC) sat between two kept
+    links, so the run breaks there. The longest run wins; ties keep the earliest
+    (the TOC sits at the top, ahead of any in-body link cluster).
+    """
+    if not links:
+        return []
+    best: list[_TocLink] = []
+    current = [links[0]]
+    for prev, cur in zip(links, links[1:]):
+        if cur.link_idx == prev.link_idx + 1:
+            current.append(cur)
+        else:
+            if len(current) > len(best):
+                best = current
+            current = [cur]
+    if len(current) > len(best):
+        best = current
+    return best
 
 
 def _top_level_ancestor(el, body):
@@ -216,12 +329,18 @@ def _top_level_ancestor(el, body):
     return el
 
 
-def _slice_between(start, end) -> str:
-    """Serialize every top-level sibling from ``start`` up to (not incl) ``end``."""
+def _slice_between(start, end, *, skip: set[int] | None = None) -> str:
+    """Serialize every top-level sibling from ``start`` up to (not incl) ``end``.
+
+    Top-level blocks whose ``id()`` is in ``skip`` are omitted — used to drop the
+    TOC nav block(s) from the preamble slice so navigation isn't re-indexed as
+    front-matter content.
+    """
     parts: list[str] = []
     node = start
     while node is not None and node is not end:
         if getattr(node, "name", None) is not None:
-            parts.append(str(node))
+            if skip is None or id(node) not in skip:
+                parts.append(str(node))
         node = node.find_next_sibling()
     return "".join(parts)

--- a/bartleby/skill_scripts/describe_corpus.py
+++ b/bartleby/skill_scripts/describe_corpus.py
@@ -243,13 +243,17 @@ def work(*, conn, args, session_id) -> dict:
     # are the provenance anchor for their section children, not a summarizable
     # unit. Excluding them from the unsummarized tally keeps a fully-summarized
     # split filing from reading as forever-incomplete. A container is any row
-    # another row points at via parent_document_id.
+    # another row points at via parent_document_id. Only count containers that
+    # have NO summary row, though: ``summarized`` already counts any container an
+    # agent happened to summarize, and double-subtracting it here would undercount
+    # the unsummarized tally (possibly negative).
     w, wp = doc_where("document_id")
     container_count = cur.execute(
         f"SELECT COUNT(*) FROM documents{w}"
         f"{' AND' if w else ' WHERE'} document_id IN "
         f"(SELECT parent_document_id FROM documents "
-        f"WHERE parent_document_id IS NOT NULL)",
+        f"WHERE parent_document_id IS NOT NULL) "
+        f"AND document_id NOT IN (SELECT document_id FROM summaries)",
         wp,
     ).fetchone()[0]
 

--- a/docs/decisions/GH-0254-anchor-splitting-rework-0001.md
+++ b/docs/decisions/GH-0254-anchor-splitting-rework-0001.md
@@ -1,0 +1,98 @@
+# Anchor-splitting rework: preamble section + document-order, TOC-only boundaries (issue #254)
+
+> Source: [#254](https://github.com/jswest/bartleby/issues/254) (critic-loop rework under omnibus [#363](https://github.com/jswest/bartleby/issues/363))
+
+The original #254 split (see
+[`GH-0254-html-anchor-splitting-0001.md`](./GH-0254-html-anchor-splitting-0001.md))
+shipped three confirmed production bugs in `bartleby/ingest/sec2md.py`. Its own
+stated invariant — "every byte of content lands in exactly one section, nothing
+dropped" — did not hold. This rework restores it.
+
+## Bug 1 — pre-TOC content was silently dropped
+
+Slicing started at the first anchor target's top-level ancestor, so everything in
+`<body>` *before* it — the EDGAR cover page (registrant name, CIK, period,
+ticker, shares outstanding) — landed in no section. The zero-chunk container owns
+no chunks, so that content vanished from FTS and embeddings entirely.
+
+**Fix.** `_convert_sections_bytes` now emits a synthetic **preamble** section for
+body content preceding the first TOC target, when that content is non-empty:
+
+- `anchor_id = "__preamble__"` (`_PREAMBLE_ANCHOR_ID`), `section_title =
+  "Preamble"`, `section_order = 0`. The leading/trailing underscores keep the id
+  from colliding with a genuine HTML id a filing uses as a TOC target; the
+  derived `file_hash = sha256(file_bytes + "__preamble__")` is UNIQUE and
+  re-ingest-stable like any section.
+- It is an ordinary section: its own chunks, its own summary, indexed in FTS and
+  sqlite-vec. Cover-page facts are searchable again.
+- The TOC nav block itself is **not** re-indexed as preamble. The TOC's `<a>`
+  elements' top-level ancestors are excised from the preamble slice
+  (`_slice_between(..., skip=toc_blocks)`), so navigation links don't masquerade
+  as front matter.
+- When there is no real pre-TOC content (the first target is the first body
+  block), no preamble section is emitted — the prior shape is preserved.
+
+The remaining sections renumber after the preamble (`order` is assigned in
+emission order), so `section_order` stays a dense 0..N sequence.
+
+## Bug 2 — out-of-order anchors duplicated content; harvesting over-collected
+
+Targets were ordered by **link** occurrence, not **document** position, and
+`_resolve_toc_targets` accepted **every** `<a href="#…">` in the filing.
+
+- **Out-of-order duplication.** If TOC link order ≠ document order, a slice whose
+  next boundary lay *earlier* in the document ran to end-of-body, so the same
+  paragraphs were chunked/embedded/indexed in two sections.
+- **Over-harvesting.** In-text cross-references ("see Item 1A"), footnote-return
+  markers, and "back to top" links were all treated as TOC entries, producing
+  spurious and non-monotone sections.
+
+**Fix — the boundary/harvesting rule.** `_resolve_toc_targets` now:
+
+1. Computes each element's document position from `body.descendants` (a single
+   pass).
+2. Walks `<a href="#id">` links **in link order**, resolving each to a body
+   target. Keeps only **forward** links — the link sits earlier in the document
+   than its target (`link_pos < target_pos`). A "back to top" / footnote-return
+   link points backward and is dropped. Deduplicates by `anchor_id`, first link
+   wins — so an in-text cross-reference to an *already-listed* section is dropped
+   as a duplicate.
+3. Takes the **longest contiguous run** of the surviving links (contiguity in
+   original `<a>` index). A dropped link between two survivors breaks the run, so
+   an in-text cross-reference to an *un*-listed section — which sits in the body,
+   separated from the TOC by other links — falls outside the run. The longest run
+   is the table of contents; ties keep the earliest (the TOC sits at the top of
+   the filing).
+4. **Sorts the run by document position** before returning.
+
+Sorting by document position is what makes link order irrelevant: every slice now
+ends at the next target **in document order**, and only the genuinely last target
+runs to end-of-body. Content can no longer be duplicated, and only the contiguous
+TOC cluster creates sections.
+
+`_slice_between` gained a `skip` set (top-level blocks to omit) so the preamble
+can exclude the TOC nav block; everything else is unchanged.
+
+## Bug 3 — `describe_corpus` container double-subtract
+
+`describe_corpus.py` computed `unsummarized = document_count - summarized -
+container_count`, where `container_count` was *every* container. If a container
+ever acquired a summary row (an agent runs `save_summary` on one), it was counted
+in **both** `summarized` and `container_count`, undercounting `unsummarized`
+(possibly negative).
+
+**Fix.** `container_count` now counts only containers **without** a summary row
+(`AND document_id NOT IN (SELECT document_id FROM summaries)`). A summarized
+container is already accounted for by `summarized`; an unsummarized container is
+subtracted exactly once. The tally can no longer go negative.
+
+## Unchanged invariants
+
+- Container persists **last** in one `persist_parse` transaction; section→parent
+  links wired only after the container row exists. Atomicity / resume keyed on
+  the container's `file_hash` is intact — the preamble is just one more section
+  row in that same unit.
+- All chunk writes go through `bartleby.db.chunks` typed helpers.
+- EDGAR/sec2md only; docling is untouched.
+- No schema change — held at SCHEMA_VERSION 9, no new columns. The preamble reuses
+  the existing `anchor_id` / `section_title` / `section_order` columns.

--- a/docs/decisions/GH-0254-html-anchor-splitting-0001.md
+++ b/docs/decisions/GH-0254-html-anchor-splitting-0001.md
@@ -82,3 +82,10 @@ that API does not cover, and the design is explicitly *anchor/TOC*-driven. Slici
 the raw HTML at TOC-anchor targets is filing-type-agnostic, uses the link text for
 free section titles, and reuses `convert_bytes` unchanged per slice — so every
 byte of content lands in exactly one section with nothing duplicated or dropped.
+
+> **Superseded in part.** The "nothing duplicated or dropped" invariant did not
+> hold as first shipped: pre-TOC content was dropped, out-of-order anchors
+> duplicated content, and harvesting over-collected non-TOC links. The boundary
+> and harvesting rule (document-order slicing, TOC-cluster-only targets) and the
+> synthetic preamble section that restore it are recorded in
+> [`GH-0254-anchor-splitting-rework-0001.md`](./GH-0254-anchor-splitting-rework-0001.md).

--- a/tests/test_ingest_edgar.py
+++ b/tests/test_ingest_edgar.py
@@ -191,6 +191,67 @@ _UNANCHORED_FILING = b"""<?xml version="1.0"?>
 </html>
 """
 
+# A filing whose cover page (registrant name, CIK, period) precedes the TOC —
+# the pre-TOC body content that the #254 rework must capture as a preamble
+# section rather than silently drop (BUG 1).
+_PREAMBLE_FILING = b"""<?xml version="1.0"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+<body>
+<p>Registrant name STARLIGHT AEROSPACE INCORPORATED, Central Index Key 0001999888.</p>
+<p>Annual report for the fiscal period ended December 31, 2025, ticker STAR outstanding.</p>
+<div>
+<a href="#sec_business">Business</a>
+<a href="#sec_risk">Risk Factors</a>
+</div>
+<h2 id="sec_business">Business</h2>
+<p>We build rockets and launch them into orbit for customers worldwide today.</p>
+<h2 id="sec_risk">Risk Factors</h2>
+<p>Rockets are dangerous and may explode on the launch pad without any warning.</p>
+</body>
+</html>
+"""
+
+# A TOC whose links are listed in the WRONG document order: the link to the
+# later section comes first. Slicing by link order would run the first slice to
+# end-of-body and duplicate the later section's content (BUG 2a).
+_OUT_OF_ORDER_FILING = b"""<?xml version="1.0"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+<body>
+<div>
+<a href="#sec_risk">Risk Factors</a>
+<a href="#sec_business">Business</a>
+</div>
+<h2 id="sec_business">Business</h2>
+<p>We build rockets and launch them into orbit for customers worldwide today.</p>
+<h2 id="sec_risk">Risk Factors</h2>
+<p>Rockets are dangerous and may explode on the launch pad without any warning.</p>
+</body>
+</html>
+"""
+
+# A real TOC plus in-text cross-reference links ("see Item 1A") and a "back to
+# top" link sprinkled through the body. Only the TOC cluster may create sections
+# (BUG 2b) — the stray links must not spawn spurious / out-of-order sections.
+_CROSSREF_FILING = b"""<?xml version="1.0"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+<body>
+<div id="top">
+<a href="#sec_business">Business</a>
+<a href="#sec_risk">Risk Factors</a>
+<a href="#sec_glossary">Glossary of Terms</a>
+</div>
+<h2 id="sec_business">Business</h2>
+<p>We build rockets and launch them into orbit for customers worldwide today.</p>
+<p>For competitive pressures, <a href="#sec_risk">see Risk Factors</a> below please.</p>
+<h2 id="sec_risk">Risk Factors</h2>
+<p>Rockets are dangerous and may explode on the launch pad without any warning.</p>
+<p>As noted in <a href="#sec_business">Business</a>, <a href="#top">back to top</a>.</p>
+<h2 id="sec_glossary">Glossary of Terms</h2>
+<p>Apogee is the highest point in an orbit reached by a spacecraft during flight.</p>
+</body>
+</html>
+"""
+
 
 @pytest.fixture
 def edgar_project(tmp_path, monkeypatch):
@@ -248,6 +309,91 @@ def test_convert_sections_ignores_dangling_anchors():
 <p>This is the only anchor that actually resolves to a target in the body here.</p>
 </body></html>"""
     assert sec2md._convert_sections_bytes(html) == []
+
+
+def test_convert_sections_emits_preamble_for_pre_toc_content():
+    """Body content before the first TOC target (the EDGAR cover page) lands in a
+    synthetic order-0 preamble section rather than being silently dropped (BUG 1).
+    The TOC nav block itself is not re-indexed as preamble."""
+    sections = sec2md._convert_sections_bytes(_PREAMBLE_FILING)
+    assert sections[0].anchor_id == sec2md._PREAMBLE_ANCHOR_ID
+    assert sections[0].order == 0
+    # The cover-page facts are searchable in the preamble section's chunks.
+    preamble_text = " ".join(c.text for c in sections[0].result.chunks)
+    assert "STARLIGHT AEROSPACE" in preamble_text
+    assert "0001999888" in preamble_text
+    # The real sections follow, renumbered after the preamble.
+    assert [s.anchor_id for s in sections[1:]] == ["sec_business", "sec_risk"]
+    assert [s.order for s in sections[1:]] == [1, 2]
+    # The TOC link list is navigation, not content — it is not re-emitted.
+    assert "Risk Factors\nBusiness" not in preamble_text
+
+
+def test_convert_sections_does_not_duplicate_out_of_document_order_anchors():
+    """A TOC that lists anchors out of document order is sliced in DOCUMENT order,
+    so no section's slice runs to end-of-body and duplicates a later section's
+    content (BUG 2a)."""
+    sections = sec2md._convert_sections_bytes(_OUT_OF_ORDER_FILING)
+    # Sliced in document order regardless of TOC link order.
+    assert [s.anchor_id for s in sections] == ["sec_business", "sec_risk"]
+    # The risk paragraph ("explode") appears in exactly one section, once.
+    occurrences = sum(
+        c.text.lower().count("explode")
+        for s in sections for c in s.result.chunks
+    )
+    assert occurrences == 1
+    # And it belongs to the risk section, not bled into business.
+    business_text = " ".join(c.text.lower() for c in sections[0].result.chunks)
+    assert "explode" not in business_text
+
+
+def test_convert_sections_ignores_in_text_cross_reference_links():
+    """In-text cross-references ("see Risk Factors") and "back to top" links do
+    not create spurious sections — only the contiguous TOC link cluster does
+    (BUG 2b)."""
+    sections = sec2md._convert_sections_bytes(_CROSSREF_FILING)
+    assert [s.anchor_id for s in sections] == [
+        "sec_business", "sec_risk", "sec_glossary",
+    ]
+    # No content duplicated by the stray forward/backward cross-reference links.
+    occurrences = sum(
+        c.text.lower().count("apogee")
+        for s in sections for c in s.result.chunks
+    )
+    assert occurrences == 1
+
+
+def test_persist_parse_preamble_section_is_searchable(edgar_project, tmp_path):
+    """The preamble section persists as a real, FTS-indexed section row, so the
+    cover-page content is searchable rather than lost with the zero-chunk
+    container (BUG 1, end to end)."""
+    src = _write(tmp_path, "filing.htm", _PREAMBLE_FILING)
+    parsed = parsers._parse_html_sec2md(
+        src, file_hash="preamble-container", file_name="filing.htm",
+    )
+    # The container carries a preamble section child with the synthetic anchor.
+    assert parsed.sections[0].anchor_id == sec2md._PREAMBLE_ANCHOR_ID
+    conn = open_db(edgar_project)
+    try:
+        writer = Writer(conn)
+        container_id = writer.persist_parse(parsed)
+        cur = conn.cursor()
+        preamble = cur.execute(
+            "SELECT document_id FROM documents "
+            "WHERE anchor_id = ? AND parent_document_id = ?",
+            (sec2md._PREAMBLE_ANCHOR_ID, container_id),
+        ).fetchone()
+        assert preamble is not None
+        # Its chunks are indexed in FTS — the cover-page facts are findable.
+        hit = cur.execute(
+            "SELECT COUNT(*) FROM chunks c JOIN chunks_fts f ON f.rowid = c.chunk_id "
+            "WHERE c.source_kind = 'document' AND c.source_id = ? "
+            "AND chunks_fts MATCH 'STARLIGHT'",
+            (preamble[0],),
+        ).fetchone()[0]
+        assert hit >= 1
+    finally:
+        conn.close()
 
 
 def test_parse_html_sec2md_builds_container_and_sections(tmp_path, monkeypatch):

--- a/tests/test_skill_describe_corpus.py
+++ b/tests/test_skill_describe_corpus.py
@@ -310,3 +310,52 @@ def test_describe_corpus_excludes_anchor_container_from_unsummarized(
     assert out["document_count"] == 4
     # Container is excluded; only alpha is summarized; beta + section owe one.
     assert out["summary_coverage"] == {"summarized": 1, "unsummarized": 2}
+
+
+def test_describe_corpus_summarized_container_not_double_subtracted(
+    seeded_project, capsys
+):
+    """If a container ever acquires a summary row (an agent runs save_summary on
+    it), it is already counted in ``summarized`` — it must not ALSO be subtracted
+    as a container, or the unsummarized tally undercounts (possibly negative).
+    The container is subtracted only when it has no summary row."""
+    from bartleby.db.chunks import ChunkInput, insert_document_chunks
+    from bartleby.db.schema import EMBEDDING_DIM
+
+    project = seeded_project["project"]
+    conn = open_db(project)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, token_count) "
+            "VALUES (?, ?, ?, ?)",
+            ("filing", "filing.htm", "/tmp/filing.htm", 0),
+        )
+        container_id = conn.last_insert_rowid()
+        cur.execute(
+            "INSERT INTO documents "
+            "(file_hash, file_name, file_path, token_count, "
+            " parent_document_id, anchor_id, section_title, section_order) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("filing#sec1", "filing.htm", "/tmp/filing.htm", 50,
+             container_id, "sec1", "Business", 0),
+        )
+        section_id = conn.last_insert_rowid()
+        insert_document_chunks(conn, section_id, [
+            ChunkInput(text="section body about the business operations here",
+                       embedding=[0.2] * EMBEDDING_DIM, chunk_index=0),
+        ])
+        # An agent summarized BOTH the section and the container.
+        for doc_id, title in ((section_id, "Sec"), (container_id, "Filing")):
+            cur.execute(
+                "INSERT INTO summaries (document_id, title, description, text, model) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (doc_id, title, "d", "t", "test"),
+            )
+    finally:
+        conn.close()
+
+    out = _run(project, capsys)
+    # 4 docs; summarized = alpha + section + container = 3; only beta owes one.
+    assert out["document_count"] == 4
+    assert out["summary_coverage"] == {"summarized": 3, "unsummarized": 1}


### PR DESCRIPTION
Part of #363. Critic-loop rework of #254 (EDGAR/iXBRL HTML anchor splitting, already merged). Resolves three confirmed production bugs on a fresh branch off omnibus HEAD.

## BUG 1 — pre-TOC content silently dropped
Slicing started at the first anchor target's top-level ancestor, so everything before it (the EDGAR cover page: registrant name, CIK, period, ticker, shares outstanding) landed in no section and vanished from FTS/embeddings — contradicting the original decision doc's "nothing dropped" invariant. Now `_convert_sections_bytes` emits a synthetic order-0 **Preamble** section (`anchor_id="__preamble__"`) for non-empty body content before the first target, with its own chunks/summary. The TOC nav block is excised from the preamble so navigation links aren't re-indexed as front matter.

## BUG 2 — out-of-order anchors duplicated content; over-harvesting
Targets were ordered by **link** occurrence, not **document** position, so a slice whose next boundary lay earlier in the document ran to end-of-body and double-indexed paragraphs. And `_resolve_toc_targets` accepted every `<a href="#…">` (in-text cross-refs like "see Item 1A", footnote markers, "back to top"), spawning spurious/non-monotone sections. The boundary/harvesting rule now:
- keep only **forward** links (link sits before its target), deduped by anchor_id (first wins) — drops back-to-top/footnote-return (backward) and cross-refs to already-listed sections (duplicates);
- take the **longest run contiguous in link order** — the TOC cluster — so a cross-reference to an un-listed section (separated from the TOC by dropped links) falls outside it;
- **sort by document position** before slicing, so every slice ends at the next target in document order and only the genuinely-last runs to end-of-body.

## BUG 3 — describe_corpus container double-subtract
`unsummarized = document_count - summarized - container_count` double-counted any container that had a summary row (counted in both `summarized` and `container_count`), undercounting (possibly negative). Now only containers **without** a summary row are subtracted.

## Constraints honored
Container-persists-last single-transaction atomicity intact; chunk writes only via `bartleby.db.chunks` helpers; EDGAR/sec2md only (docling untouched); no SCHEMA_VERSION bump (held at 9, no schema change — the preamble reuses existing section columns).

## Tests
Full suite green: **822 passed** (0 xfailed, 0 failed). New regression tests: preamble searchable end-to-end (BUG 1); out-of-document-order anchors don't duplicate (BUG 2a); in-text cross-reference links don't create spurious sections (BUG 2b); summarized container not double-subtracted (BUG 3).

Decision recorded in `docs/decisions/GH-0254-anchor-splitting-rework-0001.md` (the original doc gains a "superseded in part" forward-pointer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)