### PR TITLE
fix: #254 conservative TOC excision + double-linked TOC contiguity (Part of #363)

### DIFF
--- a/bartleby/ingest/sec2md.py
+++ b/bartleby/ingest/sec2md.py
@@ -167,6 +167,26 @@ def _convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
     if len(targets) < _MIN_SECTIONS_TO_SPLIT:
         return []
 
+    # Excise the TOC's dedicated navigation block(s) from the tree BEFORE slicing,
+    # so navigation isn't re-indexed as preamble front-matter. We remove only the
+    # PURE-nav container of each link — a block holding nothing but the run's links
+    # and whitespace — never a block that also wraps real prose. A cover page that
+    # shares one page-div with the nav keeps its prose (only the inner link-list div
+    # is pulled); a content paragraph with an inline cross-reference link has no nav
+    # container and is left wholly intact. This is what stops the over-excision that
+    # silently dropped co-resident content (the data-loss defect this fix repairs).
+    # Excising whole nav containers (incl. ones nested below the top level) is why
+    # this is a tree edit, not a top-level skip-set: the slice walks the cleaned
+    # tree and every remaining byte lands in exactly one section.
+    toc_link_ids = {id(el) for el in toc_link_els}
+    nav_blocks = {
+        id(nav): nav
+        for el in toc_link_els
+        if (nav := _enclosing_nav_block(el, body, toc_link_ids)) is not None
+    }
+    for nav in nav_blocks.values():
+        nav.extract()
+
     # Slice boundaries are the top-level ancestors of each target, IN DOCUMENT
     # ORDER (targets are already so ordered). Each slice ends at the next
     # target's boundary; only the genuine last target runs to end-of-body. A
@@ -178,13 +198,7 @@ def _convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
         for anchor_id, title, target_el in targets
     ]
     first_start = boundaries[0][2]
-    # The TOC nav block(s) sit before the first target but are navigation, not
-    # content — exclude their top-level ancestors so the preamble is the cover
-    # page, not a re-render of the link list.
-    toc_blocks = {id(_top_level_ancestor(el, body)) for el in toc_link_els}
-    preamble_fragment = _slice_between(
-        _first_body_child(body), first_start, skip=toc_blocks,
-    )
+    preamble_fragment = _slice_between(_first_body_child(body), first_start)
     slices: list[tuple[str, str | None, str]] = []
     if preamble_fragment.strip():
         slices.append((_PREAMBLE_ANCHOR_ID, _PREAMBLE_TITLE, preamble_fragment))
@@ -238,29 +252,36 @@ def _resolve_toc_targets(soup, body):
     The rule: a real TOC is a contiguous cluster of *forward* links — each link
     sits earlier in the document than the section it points at, and the cluster
     is uninterrupted in link order. We walk every internal link in link order,
-    resolve it to a body target, and keep only forward links to ids not already
-    listed (first link to an id wins). A "back to top" / footnote-return link
-    points backward and is dropped; an in-text cross-reference to an
-    already-listed section is a duplicate and is dropped; a cross-reference to an
-    *un*-listed section is forward, but it sits in the body interrupted from the
-    TOC by other (now-dropped) links, so it falls outside the longest contiguous
-    run. We take that longest run — the TOC — then **sort it by document
-    position** before returning. Sorting is what makes link order irrelevant: a
-    TOC that lists sections out of document order no longer produces a slice
-    whose next boundary lies earlier in the document (which would run to
-    end-of-body and duplicate content).
+    resolve it to a body target, and keep every forward link, INCLUDING duplicate
+    links to an already-listed anchor (a classic EDGAR TOC links both the item
+    title and the page number to one id — both must stay so the run reads as
+    contiguous). A "back to top" / footnote-return link points backward and is
+    dropped, breaking the run there; a cross-reference to an *un*-listed section is
+    forward but sits in the body interrupted from the TOC by other (dropped) links,
+    so it falls outside the longest contiguous run. We take that longest run, then
+    require it to be a DEDICATED nav block (links living in a container of nothing
+    but links — not inline in a content paragraph) before trusting it as a TOC.
+    Finally we **dedup by anchor** (one target per id, first link's text wins) and
+    **sort by document position**. Sorting makes link order irrelevant: a TOC that
+    lists sections out of document order no longer produces a slice whose next
+    boundary lies earlier in the document (which would run to end-of-body and
+    duplicate content).
     """
     pos = {id(el): i for i, el in enumerate(body.descendants)}
 
-    seen: set[str] = set()
+    # Collect EVERY forward internal link, INCLUDING duplicate links that point at
+    # an already-listed anchor. The classic EDGAR TOC links both the item title and
+    # the page number to the same id; keeping the duplicate in this sequence is
+    # what lets it count as contiguous. Dropping it here (the #254-rework behaviour)
+    # left a `link_idx` gap that collapsed every run to length 1, so a double-linked
+    # TOC no longer split — the regression this fix repairs. The final TARGET list
+    # is deduped after the run is chosen, so each anchor still yields one section.
     links: list[_TocLink] = []
     for link_idx, a in enumerate(soup.find_all("a")):
         href = a.get("href") or ""
         if not href.startswith("#") or len(href) < 2:
             continue
         anchor_id = href[1:]
-        if anchor_id in seen:
-            continue
         target = body.find(id=anchor_id)
         if target is None or id(target) not in pos:
             continue
@@ -270,15 +291,44 @@ def _resolve_toc_targets(soup, body):
         # "back to top" or footnote-return link points the other way.
         if link_pos is None or link_pos >= target_pos:
             continue
-        seen.add(anchor_id)
         links.append(_TocLink(
             target_pos, anchor_id, a.get_text(strip=True), target, a, link_idx,
         ))
 
     run = _longest_contiguous_run(links)
     run.sort(key=lambda link: link.target_pos)
-    targets = [(link.anchor_id, link.text, link.target) for link in run]
-    toc_link_els = [link.el for link in run]
+
+    # A genuine TOC is a DEDICATED navigation block — its links sit in a container
+    # that holds nothing but links and whitespace (a link-list div, or a TOC table's
+    # rows/cells). Two adjacent forward links inline in a content paragraph
+    # ("…including <a>Part II</a> and <a>Part III</a>…") also form a 2-link run, but
+    # they are prose cross-references, not a table of contents. Require at least
+    # ``_MIN_SECTIONS_TO_SPLIT`` of the run's links to live in such a nav container;
+    # otherwise this is not a TOC and the file ingests whole. (This is the same nav
+    # detection the excision pass uses, so a run that splits always has a nav block
+    # to excise, and a run inline in prose neither splits nor excises.)
+    run_link_ids = {id(link.el) for link in run}
+    nav_links = [
+        link for link in run
+        if _enclosing_nav_block(link.el, body, run_link_ids) is not None
+    ]
+    if len(nav_links) < _MIN_SECTIONS_TO_SPLIT:
+        return [], []
+
+    # Dedup the winning run by anchor: one section per id, first link's text wins.
+    # Duplicate (item+page) links kept the run contiguous above; they must not
+    # spawn a second slice for the same anchor. ``toc_link_els`` keeps ALL the
+    # run's links (incl. duplicates) so the excision pass can recognise their
+    # blocks as navigation.
+    seen: set[str] = set()
+    targets: list[tuple[str, str, object]] = []
+    toc_link_els: list[object] = []
+    for link in run:
+        toc_link_els.append(link.el)
+        if link.anchor_id in seen:
+            continue
+        seen.add(link.anchor_id)
+        targets.append((link.anchor_id, link.text, link.target))
     return targets, toc_link_els
 
 
@@ -300,11 +350,15 @@ class _TocLink(NamedTuple):
 def _longest_contiguous_run(links: list[_TocLink]) -> list[_TocLink]:
     """The longest cluster of links that is uninterrupted in link order — the TOC.
 
-    ``links`` is the forward, deduped internal links in link order. A gap in
-    their ``link_idx`` means a non-TOC link (a dropped back-to-top, or a forward
-    cross-reference whose target *was* already in the TOC) sat between two kept
-    links, so the run breaks there. The longest run wins; ties keep the earliest
-    (the TOC sits at the top, ahead of any in-body link cluster).
+    ``links`` is the forward internal links in link order, INCLUDING duplicate
+    links to an already-listed anchor (the item+page double-link of a classic
+    EDGAR TOC). A gap in their ``link_idx`` means a *dropped* link — a backward
+    "back to top"/footnote-return, or a dangling href with no in-document target —
+    sat between two kept links, so the run breaks there. Duplicate forward links to
+    a listed anchor are NOT dropped, so they keep the run contiguous; the anchor
+    dedup happens on the chosen run, not here (otherwise a double-linked TOC would
+    gap-collapse to length 1 and never split). The longest run wins; ties keep the
+    earliest (the TOC sits at the top, ahead of any in-body link cluster).
     """
     if not links:
         return []
@@ -329,18 +383,64 @@ def _top_level_ancestor(el, body):
     return el
 
 
-def _slice_between(start, end, *, skip: set[int] | None = None) -> str:
+def _is_pure_nav_block(block, toc_link_ids: set[int]) -> bool:
+    """True when ``block`` holds nothing but TOC links and whitespace.
+
+    A nav block is one whose every scrap of text lives inside one of the run's TOC
+    ``<a>`` elements. A block that carries any text *outside* those links —
+    cover-page prose sharing the TOC's page-div, or a content paragraph that merely
+    contains forward links — is content, not nav, and must be kept so that text
+    still lands in a section. We walk the block's text nodes and reject it the
+    moment we find non-whitespace text not enclosed by a TOC link.
+    """
+    from bs4 import NavigableString
+
+    for node in block.descendants:
+        if not isinstance(node, NavigableString) or not node.strip():
+            continue
+        # This non-whitespace text must sit inside one of the run's TOC links.
+        ancestor = node.parent
+        while ancestor is not None and ancestor is not block.parent:
+            if id(ancestor) in toc_link_ids:
+                break
+            ancestor = ancestor.parent
+        else:  # walked out of the block without hitting a TOC link → real content
+            return False
+    return True
+
+
+def _enclosing_nav_block(link_el, body, toc_link_ids: set[int]):
+    """The OUTERMOST ancestor of ``link_el`` (below ``body``) that is still a pure
+    nav block — the dedicated navigation container to excise — or ``None``.
+
+    Walking outward, a TOC's ``<a>`` is wrapped in cells/rows/list-items/divs that
+    hold only links; the container stops being pure-nav the moment an ancestor also
+    wraps real prose (e.g. a cover-page div that merely *contains* the nav div, or a
+    content paragraph with an inline cross-reference). Returning the outermost
+    pure-nav ancestor lets the caller excise the whole nav block (the table, the
+    link-list div) while leaving co-resident prose in place; returning ``None`` for
+    a link with no nav container at all is how an inline prose link is recognised as
+    not-a-TOC.
+    """
+    nav = None
+    el = link_el
+    while el.parent is not None and el.parent is not body:
+        el = el.parent
+        if _is_pure_nav_block(el, toc_link_ids):
+            nav = el
+    return nav
+
+
+def _slice_between(start, end) -> str:
     """Serialize every top-level sibling from ``start`` up to (not incl) ``end``.
 
-    Top-level blocks whose ``id()`` is in ``skip`` are omitted — used to drop the
-    TOC nav block(s) from the preamble slice so navigation isn't re-indexed as
-    front-matter content.
+    The TOC nav block(s) have already been excised from the tree by the caller, so
+    every remaining sibling is real content; nothing is filtered here.
     """
     parts: list[str] = []
     node = start
     while node is not None and node is not end:
         if getattr(node, "name", None) is not None:
-            if skip is None or id(node) not in skip:
-                parts.append(str(node))
+            parts.append(str(node))
         node = node.find_next_sibling()
     return "".join(parts)

--- a/docs/decisions/GH-0254-toc-excision-fix-0001.md
+++ b/docs/decisions/GH-0254-toc-excision-fix-0001.md
@@ -1,0 +1,88 @@
+# TOC-excision data-loss + double-linked-TOC contiguity fix (issue #254)
+
+> Source: [#254](https://github.com/jswest/bartleby/issues/254) (final critic-loop rework under omnibus [#363](https://github.com/jswest/bartleby/issues/363))
+
+The anchor-splitting rework (see
+[`GH-0254-anchor-splitting-rework-0001.md`](./GH-0254-anchor-splitting-rework-0001.md))
+restored "every byte of content lands in exactly one section, nothing dropped" —
+but the critic's empirical second pass found the invariant still failed in two
+edge shapes, plus one regression. This pass fixes all three in
+`bartleby/ingest/sec2md.py`. No schema change (held at SCHEMA_VERSION 9).
+
+## Defect 1 — TOC-block excision deleted real content (DATA LOSS)
+
+To keep the TOC nav out of the synthetic preamble, the rework excised the
+**top-level ancestor** of each TOC link (`toc_blocks = {id(_top_level_ancestor(el))
+…}`, fed to `_slice_between(skip=…)`). A top-level block is a coarse unit, so this
+over-excised whenever the nav did not occupy a block of its own:
+
+- **Cover text sharing the TOC's page-div.** A genuine TOC nested inside the same
+  top-level page-`<div>` as the cover prose (registrant name, CIK, period) caused
+  the whole div — cover text included — to be skipped. The cover facts vanished
+  from every section, FTS, and embeddings.
+- **Two inline forward links in a content paragraph.** Prose like "…including
+  <a>Part II</a> and <a>Part III</a>…" is not a TOC, but the two forward links form
+  a run (`_MIN_SECTIONS_TO_SPLIT = 2`). The doc mis-split, and the host paragraph —
+  the run's top-level ancestor — was excised, so its prose hit token-count 0 across
+  all chunks.
+
+**Fix — excise only a *pure nav container*, and only treat the run as a TOC when it
+has one.**
+
+- `_is_pure_nav_block(block, link_ids)` is true only when **every** non-whitespace
+  text node in `block` lives inside one of the run's `<a>` links — i.e. the block
+  holds nothing but TOC links and whitespace.
+- `_enclosing_nav_block(link, body, link_ids)` returns the **outermost** ancestor
+  (below `<body>`) that is still pure-nav, or `None`. For a link-list div it returns
+  the div; for a TOC table it returns the whole table (cells/rows/table are each
+  pure-nav); for an inline prose link it returns `None`.
+- **Excision is now a tree edit, not a top-level skip-set.** Before slicing,
+  `_convert_sections_bytes` `.extract()`s each link's enclosing nav block from the
+  soup. Removing the *nav container* — even one nested below the top level — leaves
+  co-resident prose in place: the cover page sharing a div keeps its text (only the
+  inner link-list div is pulled), and the slice walk then puts every remaining byte
+  into exactly one section. `_slice_between` no longer needs a `skip` set.
+- **TOC gate.** `_resolve_toc_targets` now requires at least `_MIN_SECTIONS_TO_SPLIT`
+  of the run's links to have a non-`None` enclosing nav block. An inline-prose run
+  has none, so it is not a TOC: the file ingests whole and nothing is excised. This
+  reuses the same nav detection as the excision, so a run that splits always has a
+  nav block to remove, and a run inline in prose neither splits nor excises.
+
+The decision doc's "every byte lands in exactly one section / nothing dropped"
+invariant holds again: content that co-resides with TOC links now lands in the
+preamble (or its section); only the pure-nav container is removed.
+
+## Defect 2 — double-linked EDGAR TOCs stopped splitting (REGRESSION)
+
+The classic EDGAR TOC table links **both** the item title and the page number to
+the same anchor. The rework deduped by `anchor_id` while collecting links
+(`if anchor_id in seen: continue`), so every second (page-number) link was skipped.
+That left gaps in the surviving links' `link_idx`, and `_longest_contiguous_run`
+treats a `link_idx` gap as a run break — so every run collapsed to length 1 → `[]`
+→ whole-file ingest. The pre-rework code split these correctly.
+
+**Fix — measure contiguity over kept-or-duplicate links; dedup the target list, not
+the run.**
+
+- The link-collection loop keeps **every** forward link, including duplicate links
+  to an already-listed anchor. Consecutive item+page links stay adjacent in
+  `link_idx`, so the run survives at full length and the table still splits.
+- The `seen`/anchor dedup moved **after** the run is chosen: each anchor still
+  yields exactly one target (one section per id), and the first link's text wins as
+  the title (the item title, not the page number).
+- A backward "back to top" / footnote-return link is still excluded (not forward),
+  so it still breaks the run; an in-text forward cross-reference to a listed anchor
+  is now kept for contiguity but collapses out in the target dedup — it does not
+  create a second slice. The out-of-order, cross-reference, and preamble behaviours
+  from the prior rework are unchanged.
+
+## Unchanged invariants
+
+- Preamble still captures pre-TOC content; out-of-document-order anchors still don't
+  duplicate; in-text cross-reference / back-to-top / footnote-return links still
+  don't create spurious sections; targets are still sorted by document position
+  before slicing.
+- Container persists **last** in one `persist_parse` transaction; all chunk writes
+  go through `bartleby.db.chunks` typed helpers; EDGAR/sec2md only, docling
+  untouched.
+- No schema change — held at SCHEMA_VERSION 9.

--- a/tests/test_ingest_edgar.py
+++ b/tests/test_ingest_edgar.py
@@ -252,6 +252,69 @@ _CROSSREF_FILING = b"""<?xml version="1.0"?>
 </html>
 """
 
+# A GENUINE TOC that shares ONE top-level page-div with the cover text: registrant
+# name and CIK sit in the same div as the nav link list. Excising the whole div to
+# drop the nav would take the cover text with it (DATA LOSS). The cover prose must
+# survive in the preamble; only the pure-nav portion is navigation.
+_TOC_SHARES_DIV_FILING = b"""<?xml version="1.0"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+<body>
+<div>
+<p>Registrant name STARLIGHT AEROSPACE INCORPORATED, Central Index Key 0001999888.</p>
+<p>Annual report for the fiscal period ended December 31, 2025, ticker STAR outstanding.</p>
+<div>
+<a href="#sec_business">Business</a>
+<a href="#sec_risk">Risk Factors</a>
+</div>
+</div>
+<h2 id="sec_business">Business</h2>
+<p>We build rockets and launch them into orbit for customers worldwide today.</p>
+<h2 id="sec_risk">Risk Factors</h2>
+<p>Rockets are dangerous and may explode on the launch pad without any warning.</p>
+</body>
+</html>
+"""
+
+# NO real TOC: two adjacent forward links sit INLINE inside one content paragraph
+# ("…including Part II and Part III…"). The 2-link run would win, mis-split the
+# doc, and (under the old excision rule) excise the host paragraph — losing its
+# prose. The file must ingest whole and keep every word.
+_INLINE_LINKS_FILING = b"""<?xml version="1.0"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+<body>
+<p>This overview summarizes the filing including <a href="#partII">Part II</a> and
+<a href="#partIII">Part III</a> which discuss the financial results in great detail.</p>
+<h2 id="partII">Part II</h2>
+<p>We build rockets and launch them into orbit for customers worldwide today.</p>
+<h2 id="partIII">Part III</h2>
+<p>Rockets are dangerous and may explode on the launch pad without any warning.</p>
+</body>
+</html>
+"""
+
+# The classic EDGAR double-linked TOC: a table whose every row links BOTH the item
+# title AND the page number to the SAME anchor. Deduping by anchor before measuring
+# contiguity drops every page-number link, leaving link_idx gaps that collapse the
+# run to length 1 → no split (REGRESSION). Contiguity must be computed over the
+# kept-or-duplicate links so the run survives and the file splits.
+_DOUBLE_LINKED_TOC_FILING = b"""<?xml version="1.0"?>
+<html xmlns:ix="http://www.xbrl.org/2013/inlineXBRL">
+<body>
+<table>
+<tr><td><a href="#sec_business">Item 1. Business</a></td><td><a href="#sec_business">5</a></td></tr>
+<tr><td><a href="#sec_risk">Item 1A. Risk Factors</a></td><td><a href="#sec_risk">12</a></td></tr>
+<tr><td><a href="#sec_glossary">Item 2. Glossary</a></td><td><a href="#sec_glossary">20</a></td></tr>
+</table>
+<h2 id="sec_business">Business</h2>
+<p>We build rockets and launch them into orbit for customers worldwide today.</p>
+<h2 id="sec_risk">Risk Factors</h2>
+<p>Rockets are dangerous and may explode on the launch pad without any warning.</p>
+<h2 id="sec_glossary">Glossary of Terms</h2>
+<p>Apogee is the highest point in an orbit reached by a spacecraft during flight.</p>
+</body>
+</html>
+"""
+
 
 @pytest.fixture
 def edgar_project(tmp_path, monkeypatch):
@@ -361,6 +424,62 @@ def test_convert_sections_ignores_in_text_cross_reference_links():
         for s in sections for c in s.result.chunks
     )
     assert occurrences == 1
+
+
+def test_convert_sections_keeps_cover_text_sharing_div_with_toc():
+    """A genuine TOC sharing ONE page-div with the cover text splits the filing,
+    but the cover prose is NOT excised with the nav block — only the pure-nav
+    portion is dropped, so the cover-page facts survive in the preamble (DATA-LOSS
+    defect: the old rule excised the whole shared div)."""
+    sections = sec2md._convert_sections_bytes(_TOC_SHARES_DIV_FILING)
+    # It still splits into the two real sections (preceded by the preamble).
+    assert [s.anchor_id for s in sections] == [
+        sec2md._PREAMBLE_ANCHOR_ID, "sec_business", "sec_risk",
+    ]
+    # The cover text — co-resident with the TOC in one div — lands in the preamble.
+    preamble_text = " ".join(c.text for c in sections[0].result.chunks)
+    assert "STARLIGHT AEROSPACE" in preamble_text
+    assert "0001999888" in preamble_text
+    # Every byte still accounted for: the risk paragraph appears exactly once.
+    occurrences = sum(
+        c.text.lower().count("explode")
+        for s in sections for c in s.result.chunks
+    )
+    assert occurrences == 1
+
+
+def test_convert_sections_does_not_split_on_inline_content_links():
+    """Two adjacent forward links INLINE in a content paragraph (not a dedicated
+    nav block) are prose cross-references, not a TOC: the file does NOT mis-split
+    AND the host paragraph's prose is not dropped (DATA-LOSS defect)."""
+    sections = sec2md._convert_sections_bytes(_INLINE_LINKS_FILING)
+    # No TOC → ingest whole.
+    assert sections == []
+    # And nothing is lost: converting the file whole keeps the host paragraph's
+    # prose (a non-zero token count), where the old excision rule would have
+    # dropped it.
+    whole = sec2md.convert_bytes(_INLINE_LINKS_FILING)
+    whole_text = " ".join(c.text.lower() for c in whole.chunks)
+    assert "this overview summarizes the filing" in whole_text
+
+
+def test_convert_sections_splits_double_linked_toc():
+    """A TOC table that links BOTH the item title and the page number to the same
+    anchor still forms one contiguous run and splits into the correct sections —
+    deduping the final target list must not let duplicate links break run
+    contiguity (REGRESSION the rework introduced)."""
+    sections = sec2md._convert_sections_bytes(_DOUBLE_LINKED_TOC_FILING)
+    assert [s.anchor_id for s in sections] == [
+        "sec_business", "sec_risk", "sec_glossary",
+    ]
+    # One section per anchor despite the doubled links; titles take the first
+    # (item-title) link, not the page number.
+    assert [s.title for s in sections] == [
+        "Item 1. Business", "Item 1A. Risk Factors", "Item 2. Glossary",
+    ]
+    assert any("rockets" in c.text.lower() for c in sections[0].result.chunks)
+    assert any("explode" in c.text.lower() for c in sections[1].result.chunks)
+    assert any("apogee" in c.text.lower() for c in sections[2].result.chunks)
 
 
 def test_persist_parse_preamble_section_is_searchable(edgar_project, tmp_path):


### PR DESCRIPTION
Part of #363. Final critic-loop rework of #254 — two confirmed edge-case defects in `bartleby/ingest/sec2md.py` from the critic's empirical second pass, both fixed conservatively.

## Defect 1 — TOC-block excision deleted real content (DATA LOSS)
Excising the **top-level ancestor** of each TOC link over-excised whenever the nav didn't occupy a block of its own:
- a genuine TOC sharing one page-`<div>` with cover text dropped the cover prose from every section/FTS;
- two adjacent inline forward links in a content paragraph ("…including <a>Part II</a> and <a>Part III</a>…") both mis-split the doc and excised the host paragraph (token count 0).

**Fix:** only excise a **pure nav container** — a block holding nothing but the run's links and whitespace — performed as a tree edit (`.extract()`) so even a nav block nested below the top level is removed while co-resident prose stays put. The run must also live in such a nav container before it is trusted as a TOC, so inline-prose links no longer split. Co-resident content now lands in the preamble; nothing is dropped, and "every byte lands in exactly one section" holds again.

## Defect 2 — double-linked EDGAR TOCs stopped splitting (REGRESSION)
The classic EDGAR TOC links **both** the item title and the page number to the same anchor. Deduping by `anchor_id` before measuring contiguity left `link_idx` gaps that collapsed every run to length 1 → no split.

**Fix:** keep duplicate forward links so they preserve run contiguity; dedup the final **target** list after the run is chosen — one section per anchor, item-title text wins.

## Tests / gate
Regression tests added in `tests/test_ingest_edgar.py` for: (a) TOC sharing a div with cover text → cover present; (b) inline two-link no-TOC → no mis-split, no content lost; (c) double-linked TOC → splits correctly; plus the prior preamble / out-of-order / cross-ref fixtures re-confirmed. Full suite green: **829 passed, 0 xfailed, 0 failed**. No schema change (SCHEMA_VERSION held at 9).

Decision doc: `docs/decisions/GH-0254-toc-excision-fix-0001.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)