### PR TITLE
#397: unify read_chunks not-found error codes

### DIFF
--- a/bartleby/skill_scripts/read_chunks.py
+++ b/bartleby/skill_scripts/read_chunks.py
@@ -280,7 +280,7 @@ def _read_by_document(conn, args) -> dict:
                 f"did you mean --chunks {args.document_id}?"
             )
         raise SkillError(
-            "UNKNOWN_DOCUMENT",
+            "DOCUMENT_NOT_FOUND",
             f"No document with id {args.document_id}.",
             **extra,
         )

--- a/docs/decisions/GH-0370-read-chunks-structured-error-cross-namespace-hint-0001.md
+++ b/docs/decisions/GH-0370-read-chunks-structured-error-cross-namespace-hint-0001.md
@@ -14,9 +14,11 @@ integer space, and `read_chunks` accepts both kinds (`--document`, `--chunks`,
 
 ## What we changed
 
-- **Unknown `--document` returns `{"error", "code": "UNKNOWN_DOCUMENT"}`** with
-  a non-zero exit (renamed from the prior `DOCUMENT_NOT_FOUND`, to match the
-  issue's contract). No path emits a raw traceback for a bad id — the runner's
+- **Unknown `--document` returns `{"error", "code": "DOCUMENT_NOT_FOUND"}`** with
+  a non-zero exit. (Issue #397 reverted the short-lived `UNKNOWN_DOCUMENT` name
+  back to the canonical `*_NOT_FOUND` codes — `DOCUMENT_NOT_FOUND` /
+  `CHUNK_NOT_FOUND` — now used across the whole skill surface.) No path emits a
+  raw traceback for a bad id — the runner's
   catch-all already prevents leaked tracebacks, and this seam now raises a
   *meaningful* code rather than relying on that backstop.
 - **Cross-namespace hint, one direction at a time.** When the unknown

--- a/tests/test_skill_read_chunks.py
+++ b/tests/test_skill_read_chunks.py
@@ -74,7 +74,7 @@ def test_read_chunks_unknown_document(seeded_project, capsys):
         ])
     assert exc.value.code == 1
     out = json.loads(capsys.readouterr().out)
-    assert out["code"] == "UNKNOWN_DOCUMENT"
+    assert out["code"] == "DOCUMENT_NOT_FOUND"
     assert "hint" not in out
 
 
@@ -130,7 +130,7 @@ def test_read_chunks_unknown_document_that_is_a_chunk_id(seeded_project, capsys)
         ])
     assert exc.value.code == 1
     out = json.loads(capsys.readouterr().out)
-    assert out["code"] == "UNKNOWN_DOCUMENT"
+    assert out["code"] == "DOCUMENT_NOT_FOUND"
     assert out["hint"] == (
         f"{chunk_id} is a chunk_id — did you mean --chunks {chunk_id}?"
     )


### PR DESCRIPTION
Part of #413.

Renames the unknown-document error code in `read_chunks` from the one-off `UNKNOWN_DOCUMENT` to the canonical `DOCUMENT_NOT_FOUND`, aligning it with the `*_NOT_FOUND` convention used across the rest of the skill surface (`CHUNK_NOT_FOUND` was already in place). Pure rename — the cross-namespace hint from #370 and the error-envelope shape are unchanged; SKILL.md never named these codes, so no SKILL.md edit. `assign_tag.py`'s separate `UNKNOWN_CHUNK` is out of scope and untouched.

Updates the two test assertions in `tests/test_skill_read_chunks.py` and adds a one-line note to the GH-0370 decision file. Full suite: 833 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)