### PR TITLE
#401: bare bartleby skill returns a JSON error envelope

### DIFF
--- a/bartleby/commands/skill.py
+++ b/bartleby/commands/skill.py
@@ -52,9 +52,22 @@ def _print_help(stream=sys.stderr) -> None:
 
 
 def dispatch(argv: list[str]) -> None:
-    if not argv or argv[0] in ("-h", "--help"):
+    if argv and argv[0] in ("-h", "--help"):
         _print_help(sys.stdout)
         return
+
+    if not argv:
+        # No script named: emit the JSON error envelope (like every other
+        # skill error path) and send the usage help to stderr only.
+        _print_help(sys.stderr)
+        payload = {
+            "error": f"No skill script given. "
+                     f"Available: {', '.join(SCRIPTS)}.",
+            "code": "MISSING_SKILL",
+        }
+        json.dump(payload, sys.stdout, separators=(",", ":"))
+        sys.stdout.write("\n")
+        sys.exit(1)
 
     name, *rest = argv
     if name not in SCRIPTS:

--- a/bartleby/commands/skill.py
+++ b/bartleby/commands/skill.py
@@ -61,8 +61,7 @@ def dispatch(argv: list[str]) -> None:
         # skill error path) and send the usage help to stderr only.
         _print_help(sys.stderr)
         payload = {
-            "error": f"No skill script given. "
-                     f"Available: {', '.join(SCRIPTS)}.",
+            "error": f"No skill script given. Available: {', '.join(SCRIPTS)}.",
             "code": "MISSING_SKILL",
         }
         json.dump(payload, sys.stdout, separators=(",", ":"))

--- a/docs/decisions/GH-0401-bare-skill-json-envelope-0001.md
+++ b/docs/decisions/GH-0401-bare-skill-json-envelope-0001.md
@@ -1,0 +1,25 @@
+# Bare `bartleby skill` returns a JSON error envelope (issue #401)
+
+> Source: [#401](https://github.com/jswest/bartleby/issues/401)
+
+The dispatcher in `bartleby/commands/skill.py` lumped the empty-argv case in with
+`-h/--help`: `if not argv or argv[0] in ("-h", "--help")` both printed usage help
+to stdout and returned exit 0. So `bartleby skill` with **no script name** broke the
+skill contract that every other error path honors — a `{"error", "code"}` JSON
+envelope on stdout, exit non-zero — and instead emitted prose on stdout with a
+success code, which an agent parsing stdout as JSON would choke on.
+
+Fix splits the two cases in `dispatch`. `-h/--help` keeps its old behavior verbatim
+(usage help to stdout, return → exit 0). Empty argv now mirrors the existing
+unknown-skill path: usage prose goes to **stderr only** via `_print_help(sys.stderr)`,
+and a `{"error": "No skill script given. Available: …", "code": "MISSING_SKILL"}`
+envelope is written to stdout (compact JSON, matching the `UNKNOWN_SKILL` path's
+`separators` and trailing newline) followed by `sys.exit(1)`. The new
+`MISSING_SKILL` code names the missing-script condition distinctly from
+`UNKNOWN_SKILL` (a *named* script that isn't registered).
+
+Smallest fix that fits — no new helper, no shared envelope abstraction; the two
+error sites are short and intentionally parallel. Covered by
+`tests/test_skill_dispatch.py`: bare argv → `MISSING_SKILL` envelope on stdout + exit
+1 + prose on stderr only; `-h`/`--help` → exit 0 with usage on stdout; unknown name →
+`UNKNOWN_SKILL` envelope unchanged. No schema change.

--- a/tests/test_skill_dispatch.py
+++ b/tests/test_skill_dispatch.py
@@ -1,0 +1,50 @@
+"""Contract tests for the ``bartleby skill`` dispatcher (issue #401).
+
+A bare ``bartleby skill`` (no script name) must behave like every other skill
+error path: a ``{"error", "code"}`` JSON envelope on stdout, prose to stderr
+only, and a non-zero exit. ``-h/--help`` must still exit 0 with help text.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bartleby.commands.skill import SCRIPTS, dispatch
+
+
+def test_bare_invocation_emits_error_envelope(capsys):
+    """No script name -> JSON envelope on stdout + exit 1; prose to stderr."""
+    with pytest.raises(SystemExit) as exc:
+        dispatch([])
+    assert exc.value.code == 1
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert set(payload) == {"error", "code"}
+    assert payload["code"] == "MISSING_SKILL"
+    # Usage prose goes to stderr only, never stdout.
+    assert "usage: bartleby skill" not in captured.out
+    assert "usage: bartleby skill" in captured.err
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+def test_help_flag_exits_zero_with_help_text(flag, capsys):
+    """``-h/--help`` stays exit 0 with usage help on stdout (no envelope)."""
+    dispatch([flag])  # returns normally, no SystemExit
+    captured = capsys.readouterr()
+    assert "usage: bartleby skill" in captured.out
+
+
+def test_unknown_skill_still_emits_error_envelope(capsys):
+    """The pre-existing unknown-name path keeps its envelope + exit 1."""
+    with pytest.raises(SystemExit) as exc:
+        dispatch(["not_a_real_script"])
+    assert exc.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["code"] == "UNKNOWN_SKILL"
+
+
+def test_scripts_tuple_nonempty():
+    assert SCRIPTS, "the dispatcher must advertise at least one script"


### PR DESCRIPTION
Part of #413.

A bare `bartleby skill` (no script name) previously printed usage help to stdout and exited 0, breaking the skill contract that every other error path honors. The dispatcher in `bartleby/commands/skill.py` lumped the empty-argv case in with `-h/--help`.

This splits the two cases:
- Empty argv → `{"error","code"}` envelope with code `MISSING_SKILL` on stdout, exit 1, usage prose to stderr only (mirrors the existing `UNKNOWN_SKILL` path).
- `-h/--help` → unchanged: exit 0 with usage help on stdout.

Added `tests/test_skill_dispatch.py` covering all three cases. Full suite (838) passes. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)