### PR TITLE
#404: apply add_tag's normalized-name dup check in rename_tag

### DIFF
--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -88,6 +88,21 @@ def get_tag_by_name(conn, name: str) -> TagRow | None:
     return TagRow(*row) if row else None
 
 
+def find_tag_by_normalized_name(conn, name: str) -> TagRow | None:
+    """Return an existing tag whose name normalizes equal to ``name``, else None.
+
+    The normalized leg of conflict detection that ``add_tag`` runs via
+    ``find_similar_tag`` (catching ``"NYSEG"`` ≡ ``"ny-seg"``), without the
+    embedding/similarity leg. ``rename_tag`` uses this so renaming onto a
+    normalized-equal tag is refused, not silently duplicated.
+    """
+    target_norm = normalize_name(name)
+    for tag in fetch_vocabulary(conn):
+        if normalize_name(tag.name) == target_norm:
+            return tag
+    return None
+
+
 def require_tag_by_name(conn, name: str) -> TagRow:
     """``get_tag_by_name`` that raises ``TAG_NOT_FOUND`` instead of returning None.
 

--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -89,12 +89,9 @@ def get_tag_by_name(conn, name: str) -> TagRow | None:
 
 
 def find_tag_by_normalized_name(conn, name: str) -> TagRow | None:
-    """Return an existing tag whose name normalizes equal to ``name``, else None.
+    """Return the first tag whose normalized name equals ``normalize_name(name)``, else None.
 
-    The normalized leg of conflict detection that ``add_tag`` runs via
-    ``find_similar_tag`` (catching ``"NYSEG"`` ≡ ``"ny-seg"``), without the
-    embedding/similarity leg. ``rename_tag`` uses this so renaming onto a
-    normalized-equal tag is refused, not silently duplicated.
+    Normalized-equality check only — no embedding/similarity leg.
     """
     target_norm = normalize_name(name)
     for tag in fetch_vocabulary(conn):

--- a/bartleby/skill_scripts/rename_tag.py
+++ b/bartleby/skill_scripts/rename_tag.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """rename_tag — change a tag's name (assignments preserved).
 
-Errors if the new name already exists; use ``merge_tags`` to combine.
+Errors if the new name already exists — by the same normalized-name check
+``add_tag`` runs, so ``"NYSEG"`` collides with an existing ``"ny-seg"`` rather
+than creating a duplicate; use ``merge_tags`` to combine. A case/punctuation-
+only self-rename of the same tag (e.g. ``"ny-seg"`` → ``"NYSEG"``) is allowed.
 
 Output:
     {"status": "renamed", "tag_id": int, "old_name": str, "new_name": str}
@@ -13,7 +16,7 @@ import argparse
 
 from bartleby.skill_runner import SkillError, build_arg_parser, run
 from bartleby.skill_scripts._tags import (
-    get_tag_by_name, normalize_name, require_tag_by_name,
+    find_tag_by_normalized_name, normalize_name, require_tag_by_name,
 )
 
 
@@ -37,11 +40,13 @@ def work(*, conn, args, session_id) -> dict:
 
     tag = require_tag_by_name(conn, args.old)
 
-    existing = get_tag_by_name(conn, new_name)
+    # tag_id guard lets a case/punctuation-only self-rename through.
+    existing = find_tag_by_normalized_name(conn, new_name)
     if existing is not None and existing.tag_id != tag.tag_id:
         raise SkillError(
             "TAG_EXISTS",
-            f"A tag named {new_name!r} already exists. "
+            f"A tag named {existing.name!r} already exists "
+            f"(normalized-equal to {new_name!r}). "
             "Use merge_tags if you want to combine them.",
         )
 

--- a/docs/decisions/GH-0404-rename-tag-normalized-dup-0001.md
+++ b/docs/decisions/GH-0404-rename-tag-normalized-dup-0001.md
@@ -1,0 +1,19 @@
+# `rename_tag` applies `add_tag`'s normalized-name dup check (issue #404)
+
+> Source: [#404](https://github.com/jswest/bartleby/issues/404)
+
+`add_tag` guards against duplicates through `find_similar_tag`, whose
+normalized-name leg collapses `"NYSEG"`, `"nyseg"`, and `"ny-seg"` to one key
+and refuses the second. `rename_tag` had only an *exact*-match lookup
+(`get_tag_by_name`), so renaming `"ny-seg"` → `"NYSEG"` onto an existing
+`"NYSEG"` slipped past and created a normalized-duplicate pair — exactly what
+`add_tag` exists to prevent. This aligns the two paths: `rename_tag` now runs
+the same normalized-equality check via a new `_tags.find_tag_by_normalized_name`
+helper (built on the existing `normalize_name` + `fetch_vocabulary`), and raises
+the same `TAG_EXISTS` envelope on collision. The `tag_id != target` guard is
+retained so a case/punctuation-only *self*-rename of the same tag (e.g.
+`"ny-seg"` → `"NYSEG"`) is still allowed. Deliberately scoped to the
+normalized-equality leg only — no embedding/similarity check on rename (renaming
+is a deliberate act on a named tag, not a fuzzy proposal like `add_tag`), and no
+new abstraction beyond the one shared helper. Additive, no schema change;
+`merge_tags` remains the path to actually combine two distinct tags.

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -209,6 +209,55 @@ def test_rename_tag_refuses_existing_target(seeded_project, capsys):
     assert out["code"] == "TAG_EXISTS"
 
 
+def test_rename_tag_refuses_normalized_equal_target(seeded_project, capsys):
+    # add_tag catches "NYSEG" ≡ "ny-seg" via its normalized leg; rename_tag
+    # must too — renaming "ny-seg" onto a normalized-equal "NYSEG" is refused,
+    # not silently duplicated.
+    conn = open_db(seeded_project["project"])
+    try:
+        cur = conn.cursor()
+        cur.execute("INSERT INTO tags (name, description) VALUES ('ny-seg', 'd1')")
+        cur.execute("INSERT INTO tags (name, description) VALUES ('NYSEG', 'd2')")
+    finally:
+        conn.close()
+
+    with pytest.raises(SystemExit):
+        rename_tag.main([
+            "--project", seeded_project["project"],
+            "--old", "ny-seg", "--new", "NYSEG",
+        ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "TAG_EXISTS"
+
+
+def test_rename_tag_allows_case_punctuation_self_rename(seeded_project, capsys):
+    # A normalized-equal self-rename (same tag_id) must pass the collision
+    # guard — the tag_id != target check lets "ny-seg" → "NYSEG" through.
+    conn = open_db(seeded_project["project"])
+    try:
+        conn.cursor().execute(
+            "INSERT INTO tags (name, description) VALUES ('ny-seg', 'd1')"
+        )
+    finally:
+        conn.close()
+
+    rename_tag.main([
+        "--project", seeded_project["project"],
+        "--old", "ny-seg", "--new", "NYSEG",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "renamed"
+    assert out["new_name"] == "NYSEG"
+
+    conn = open_db(seeded_project["project"])
+    try:
+        assert conn.cursor().execute(
+            "SELECT name FROM tags WHERE name = 'NYSEG'"
+        ).fetchone()[0] == "NYSEG"
+    finally:
+        conn.close()
+
+
 def test_merge_tags_moves_assignments_and_deletes_source(seeded_project, capsys):
     conn = open_db(seeded_project["project"])
     try:


### PR DESCRIPTION
Part of #413.

`rename_tag` used only an exact-match collision lookup, so renaming `"ny-seg"` onto an existing `"NYSEG"` slipped past and created the normalized-duplicate pair `add_tag` exists to prevent (its `find_similar_tag` normalized leg catches `"NYSEG"` ≡ `"ny-seg"`).

This adds a shared `_tags.find_tag_by_normalized_name` helper (built on the existing `normalize_name` + `fetch_vocabulary`, normalized-equality only — no embedding/similarity leg) and uses it in `rename_tag`, raising the same `TAG_EXISTS` `{"error","code"}` envelope on collision. The `tag_id != target` guard keeps a case/punctuation-only self-rename of the same tag allowed.

Additive, no schema change. Tests: added `test_rename_tag_refuses_normalized_equal_target` and `test_rename_tag_allows_case_punctuation_self_rename`; full suite (835) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)