### PR TITLE
#409: cover read_chunks --around-chunk mode

### DIFF
--- a/docs/decisions/GH-0409-read-chunks-around-coverage-0001.md
+++ b/docs/decisions/GH-0409-read-chunks-around-coverage-0001.md
@@ -1,0 +1,39 @@
+# GH-0409 — read_chunks `--around-chunk` window coverage
+
+**Date:** 2026-06-11
+**Issue:** #409 (part of omnibus #413)
+
+## Context
+
+`read_chunks --around-chunk <id>` returns a target chunk plus `--window N`
+neighbours on each side, in `chunk_index` order, scoped to the target's
+`(source_kind, source_id)`. The only around-mode tests that existed
+(`tests/test_skill_read_chunks.py`) exercised the memory wall — a foreign
+finding chunk raising `MEMORY_OFF`, and a session's own finding being
+readable. The window arithmetic and the not-found path had no coverage.
+
+(The issue body was stale: it asked for tests that "already exist." We filled
+the genuine gaps rather than duplicating the memory-wall cases. No
+mode-mismatch-rejection test — #406 is a docstring caveat, not enforced
+behaviour.)
+
+## Decision
+
+Added six tests covering the around-mode window mechanics against a freshly
+seeded 9-chunk document (`_wide_document` helper, built on the existing
+`seeded_project` fixture and the typed `insert_document_chunks` helper):
+
+- interior target with the **default window** (asserts `window == 3` and the
+  symmetric ±3 neighbourhood);
+- an **explicit `--window 1`** (echoes the window, returns ±1);
+- **`--window 0`** (target alone);
+- **clamping at document start** (target at index 0, no negative indexes);
+- **clamping at document end** (target at the last index, no overrun);
+- an unknown id raising the canonical **`CHUNK_NOT_FOUND`** code.
+
+Clamping is asserted via observed behaviour (the BETWEEN range simply returns
+fewer rows at the edges) — no production code changed; this is test-only.
+
+## Scope
+
+Touches `tests/test_skill_read_chunks.py` only.

--- a/tests/test_skill_read_chunks.py
+++ b/tests/test_skill_read_chunks.py
@@ -492,3 +492,121 @@ def test_read_chunks_around_memory_off_own_finding_allowed(seeded_project, capsy
     assert out["mode"] == "around"
     assert out["target"]["chunk_id"] == own
     assert [c["chunk_id"] for c in out["chunks"]] == [own]
+
+
+# --- around-chunk window mechanics (#409) --------------------------------
+
+
+def _wide_document(project: str, n: int = 9) -> tuple[int, list[int]]:
+    """Insert a fresh document with ``n`` text chunks; return (doc_id, chunk_ids).
+
+    chunk_ids are returned in chunk_index order (0..n-1) so tests can pick an
+    interior target and assert the returned neighbourhood by id.
+    """
+    from bartleby.db.chunks import insert_document_chunks
+
+    conn = open_db(project)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, "
+            "page_count, token_count) VALUES (?, ?, ?, ?, ?)",
+            ("wide-hash", "wide.pdf", "/tmp/wide.pdf", 1, 100),
+        )
+        doc_id = conn.last_insert_rowid()
+        emb = [0.01 * i for i in range(EMBEDDING_DIM)]
+        chunk_ids = insert_document_chunks(conn, doc_id, [
+            ChunkInput(text=f"wide chunk {i}", embedding=emb, chunk_index=i,
+                       section_heading=None, page_number=None, content_type="text")
+            for i in range(n)
+        ])
+    finally:
+        conn.close()
+    return doc_id, chunk_ids
+
+
+def test_read_chunks_around_interior_default_window(seeded_project, capsys):
+    """Interior target with the default window returns 3 neighbours on each side."""
+    project = seeded_project["project"]
+    doc_id, chunk_ids = _wide_document(project, n=9)
+    target = chunk_ids[4]  # chunk_index 4, comfortably interior for window 3
+
+    read_chunks.main(["--project", project, "--around-chunk", str(target)])
+    out = json.loads(capsys.readouterr().out)
+    assert out["mode"] == "around"
+    assert out["window"] == 3  # default window
+    assert out["target"]["chunk_id"] == target
+    assert out["target"]["chunk_index"] == 4
+    assert out["target"]["source_kind"] == "document"
+    assert out["target"]["source_id"] == doc_id
+    assert out["target"]["source_name"] == "wide.pdf"
+    # 3 each side + target, in chunk_index order.
+    assert [c["chunk_id"] for c in out["chunks"]] == chunk_ids[1:8]
+    assert [c["chunk_index"] for c in out["chunks"]] == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_read_chunks_around_explicit_window(seeded_project, capsys):
+    """--window N returns N neighbours on each side and echoes the window."""
+    project = seeded_project["project"]
+    _doc_id, chunk_ids = _wide_document(project, n=9)
+    target = chunk_ids[4]
+
+    read_chunks.main([
+        "--project", project, "--around-chunk", str(target), "--window", "1",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["window"] == 1
+    assert [c["chunk_index"] for c in out["chunks"]] == [3, 4, 5]
+
+
+def test_read_chunks_around_window_zero_returns_only_target(seeded_project, capsys):
+    """--window 0 returns the target chunk alone."""
+    project = seeded_project["project"]
+    _doc_id, chunk_ids = _wide_document(project, n=9)
+    target = chunk_ids[4]
+
+    read_chunks.main([
+        "--project", project, "--around-chunk", str(target), "--window", "0",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["window"] == 0
+    assert [c["chunk_id"] for c in out["chunks"]] == [target]
+    assert [c["chunk_index"] for c in out["chunks"]] == [4]
+
+
+def test_read_chunks_around_clamps_at_document_start(seeded_project, capsys):
+    """A target at chunk_index 0 has no left neighbours — the window clamps."""
+    project = seeded_project["project"]
+    _doc_id, chunk_ids = _wide_document(project, n=9)
+    target = chunk_ids[0]
+
+    read_chunks.main(["--project", project, "--around-chunk", str(target)])
+    out = json.loads(capsys.readouterr().out)
+    # No negative indexes; just the target and its 3 right neighbours.
+    assert [c["chunk_index"] for c in out["chunks"]] == [0, 1, 2, 3]
+    assert out["chunks"][0]["chunk_id"] == target
+
+
+def test_read_chunks_around_clamps_at_document_end(seeded_project, capsys):
+    """A target at the last chunk_index has no right neighbours — the window clamps."""
+    project = seeded_project["project"]
+    _doc_id, chunk_ids = _wide_document(project, n=9)
+    target = chunk_ids[-1]  # chunk_index 8
+
+    read_chunks.main(["--project", project, "--around-chunk", str(target)])
+    out = json.loads(capsys.readouterr().out)
+    # No overrun past the last chunk; target and its 3 left neighbours only.
+    assert [c["chunk_index"] for c in out["chunks"]] == [5, 6, 7, 8]
+    assert out["chunks"][-1]["chunk_id"] == target
+
+
+def test_read_chunks_around_unknown_chunk(seeded_project, capsys):
+    """--around-chunk with an id that is no chunk at all raises CHUNK_NOT_FOUND."""
+    with pytest.raises(SystemExit) as exc:
+        read_chunks.main([
+            "--project", seeded_project["project"],
+            "--around-chunk", "999999",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "CHUNK_NOT_FOUND"


### PR DESCRIPTION
Part of #413.

Fills the genuine gaps in `read_chunks --around-chunk` test coverage. The memory-wall around-mode cases already existed in `tests/test_skill_read_chunks.py`; this adds the window mechanics that had none:

- interior target with the **default window** (asserts `window == 3` and the symmetric ±3 neighbourhood)
- an explicit **`--window 1`**
- **`--window 0`** (target alone)
- **clamping at document start** (index 0, no negative neighbours)
- **clamping at document end** (last index, no overrun)
- an unknown id raising the canonical **`CHUNK_NOT_FOUND`** code

No mode-mismatch-rejection test — #406 is a docstring caveat, not enforced behaviour. Test-only; no production code changed. New `_wide_document` helper seeds a 9-chunk doc so an interior target has a full neighbourhood.

`uv run pytest tests/test_skill_read_chunks.py` (29 passed) and the full suite (846 passed) both green.

Decision: `docs/decisions/GH-0409-read-chunks-around-coverage-0001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)