### PR TITLE
#371: lazy-import embedding stack for read-only skill scripts

### DIFF
--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -12,8 +12,6 @@ from bartleby.db.chunks import (
     delete_chunks_for,
     insert_finding_chunks,
 )
-from bartleby.ingest.chunk import chunk_markdown_string
-from bartleby.ingest.embed import embed_texts
 from bartleby.skill_runner import SkillError
 
 
@@ -260,7 +258,15 @@ def embed_body_chunks(body: str) -> list[ChunkInput]:
     concurrency). Hoisting it ahead of the first write keeps apsw's deferred
     transaction from grabbing a lock until the millisecond SQL tail. Returns
     ``[]`` for an empty body.
+
+    The chunker + embedder are imported lazily here (not at module top) so the
+    FTS-only read scripts that share this module — ``scan``, ``list_documents``,
+    ``read_chunks``, ``describe_corpus`` — never pay the embedding/model stack's
+    import cost just to import a helper they don't embed with (#371).
     """
+    from bartleby.ingest.chunk import chunk_markdown_string
+    from bartleby.ingest.embed import embed_texts
+
     rows = chunk_markdown_string(body)
     if not rows:
         return []

--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pydantic import BaseModel, Field
 
 from bartleby.config import ensure_provider_env, load_config
-from bartleby.ingest.embed import embed_texts
 from bartleby.providers import Provider, get_provider
 from bartleby.skill_runner import SkillError
 
@@ -456,6 +455,11 @@ def find_similar_tag(
         the configured ``SIMILARITY_THRESHOLD``.
 
     Embeddings are L2-normalized at the embedder, so dot-product is cosine.
+
+    ``embed_texts`` is imported lazily (not at module top) so the FTS-only read
+    scripts that share this module via ``resolve_scope`` — ``scan``,
+    ``list_documents``, ``read_chunks``, ``describe_corpus`` — never pay the
+    embedding/model stack's import cost (#371).
     """
     vocab = fetch_vocabulary(conn)
     if not vocab:
@@ -465,6 +469,8 @@ def find_similar_tag(
     for tag in vocab:
         if normalize_name(tag.name) == target_norm:
             return SimilarTag(tag.tag_id, tag.name, tag.description, 1.0)
+
+    from bartleby.ingest.embed import embed_texts
 
     proposed_emb, *existing_embs = embed_texts(
         [description] + [t.description for t in vocab]

--- a/docs/decisions/GH-0371-lazy-import-embedding-stack-0001.md
+++ b/docs/decisions/GH-0371-lazy-import-embedding-stack-0001.md
@@ -1,0 +1,15 @@
+# Lazy-import the embedding stack for read-only skill scripts (issue #371)
+
+> Source: [#371](https://github.com/jswest/bartleby/issues/371)
+
+The FTS-only read scripts (`scan`, `list_documents`, `read_chunks`, `describe_corpus`) paid the embedding/model stack's import cost on every invocation even though they never embed. The cost wasn't in those four scripts — it was in the two shared modules they import: `bartleby/skill_scripts/_common.py` imported the chunker (`chunk_markdown_string`) and `embed_texts` at module top, and `bartleby/skill_scripts/_tags.py` imported `embed_texts` at module top (`_tags.resolve_scope` is what all four read scripts pull in). Importing the chunker dragged in `docling` + `filetype` at module load.
+
+The fix is the smallest one that fits: move those top-level heavy imports to **function-local** imports inside the only functions that embed — `embed_body_chunks` in `_common.py` (the EMBED phase of the finding/summary write path) and `find_similar_tag` in `_tags.py` (the tag-similarity check). In `find_similar_tag` the import sits *after* the empty-vocab early-return and the normalized-name exact-match loop, so an exact-name hit never triggers it. The `db.chunks` typed helpers, `bartleby.config`, and `bartleby.providers` are all light and stay at module top.
+
+**Before/after (importing `bartleby.skill_scripts.scan` in a fresh interpreter):**
+- Modules loaded: **428 → 407** (21 fewer), eliminating all 15 `docling.*` / `filetype.*` submodules plus the lazy `bartleby.ingest.embed` loader. `numpy` still rides in via `sqlite-vec` on the DB connection — that's core read-path infrastructure, not the embedding stack, and is out of scope.
+- `-X importtime` cumulative for `scan` dropped from ~71.5ms to ~67ms; for `describe_corpus` ~72.6ms → ~67ms. The residual is shared infra (`apsw`, `sqlite_vec`→`numpy`, `pydantic`) that the read path legitimately needs; the structural module-set delta is the honest measure.
+
+A new regression test (`tests/test_skill_read_import_cost.py`) asserts in a *fresh interpreter* (so module caching can't mask a leak) that importing each of the four read scripts does not pull in `bartleby.ingest.embed`, `bartleby.ingest.chunk`, `sentence_transformers`, `torch`, `docling`, or `filetype`. Test monkeypatch targets that previously patched `_common.embed_texts` / `_common.chunk_markdown_string` / `_tags.embed_texts` were repointed at the source modules (`bartleby.ingest.embed.embed_texts`, `bartleby.ingest.chunk.chunk_markdown_string`), since those names are no longer module-level attributes — a function-local `from ... import` resolves the name fresh per call, so source-module patching is the only correct option.
+
+Out of scope (explicit, separate maintainer decision): the optional `skill batch` mode. No schema change.

--- a/tests/test_skill_delete_finding.py
+++ b/tests/test_skill_delete_finding.py
@@ -49,12 +49,12 @@ def _finding_exists(project, finding_id) -> bool:
 @pytest.fixture(autouse=True)
 def mock_embed(monkeypatch):
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.embed_texts",
+        "bartleby.ingest.embed.embed_texts",
         lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
     )
     from bartleby.ingest.chunk import ChunkRow
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.chunk_markdown_string",
+        "bartleby.ingest.chunk.chunk_markdown_string",
         lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
     )
 

--- a/tests/test_skill_edit_finding.py
+++ b/tests/test_skill_edit_finding.py
@@ -21,12 +21,12 @@ def mock_embed(monkeypatch):
     # Both scripts share `embed_texts` / `chunk_markdown_string` via _common;
     # patch there so the test never reaches BAAI.
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.embed_texts",
+        "bartleby.ingest.embed.embed_texts",
         lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
     )
     from bartleby.ingest.chunk import ChunkRow
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.chunk_markdown_string",
+        "bartleby.ingest.chunk.chunk_markdown_string",
         lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
     )
 

--- a/tests/test_skill_extract.py
+++ b/tests/test_skill_extract.py
@@ -19,12 +19,12 @@ from tests._skill_fixtures import _emb, project_env  # noqa: F401
 def stub_embed(monkeypatch):
     """add_tag runs a similarity check that embeds; stub it (no model load)."""
     from bartleby.db.schema import EMBEDDING_DIM
-    from bartleby.skill_scripts import _tags as tags_helpers
 
     def _stub(texts):
         return [[0.0] * EMBEDDING_DIM for _ in texts]
 
-    monkeypatch.setattr(tags_helpers, "embed_texts", _stub)
+    # find_similar_tag imports embed_texts lazily from its source module (#371).
+    monkeypatch.setattr("bartleby.ingest.embed.embed_texts", _stub)
 
 
 def _doc(conn, file_hash, file_name) -> int:

--- a/tests/test_skill_merge_findings.py
+++ b/tests/test_skill_merge_findings.py
@@ -39,12 +39,12 @@ def _seed_finding_as(conn, session_id, title="Foreign draft") -> int:
 @pytest.fixture(autouse=True)
 def mock_embed(monkeypatch):
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.embed_texts",
+        "bartleby.ingest.embed.embed_texts",
         lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
     )
     from bartleby.ingest.chunk import ChunkRow
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.chunk_markdown_string",
+        "bartleby.ingest.chunk.chunk_markdown_string",
         lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
     )
 

--- a/tests/test_skill_read_import_cost.py
+++ b/tests/test_skill_read_import_cost.py
@@ -28,20 +28,15 @@ FORBIDDEN = ("bartleby.ingest.embed", "sentence_transformers", "torch",
 
 @pytest.mark.parametrize("script", READ_SCRIPTS)
 def test_read_script_import_skips_embedding_stack(script: str) -> None:
-    forbidden = ",".join(repr(m) for m in FORBIDDEN)
+    forbidden_repr = ",".join(repr(m) for m in FORBIDDEN)
     code = (
-        "import sys\n"
+        f"import sys\n"
         f"import bartleby.skill_scripts.{script}\n"
-        f"forbidden = ({forbidden},)\n"
-        "leaked = [m for m in forbidden "
-        "if any(k == m or k.startswith(m + '.') for k in sys.modules)]\n"
-        "assert not leaked, leaked\n"
-        "print('OK')\n"
+        f"forbidden = ({forbidden_repr},)\n"
+        f"leaked = [m for m in forbidden if any(k == m or k.startswith(m + '.') for k in sys.modules)]\n"
+        f"assert not leaked, leaked\n"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True, text=True,
-    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert result.returncode == 0, (
         f"importing {script} leaked heavy modules:\n"
         f"stdout={result.stdout!r}\nstderr={result.stderr!r}"

--- a/tests/test_skill_read_import_cost.py
+++ b/tests/test_skill_read_import_cost.py
@@ -1,0 +1,48 @@
+"""Read-only skill scripts must not import the embedding/model stack (#371).
+
+``scan``, ``list_documents``, ``read_chunks``, and ``describe_corpus`` are
+FTS-only read paths. They share ``_common`` / ``_tags``, which used to import
+the chunker + ``embed_texts`` at module top — dragging ``docling`` / ``filetype``
+(and the lazy ``sentence_transformers`` model loader) into every invocation. The
+heavy imports are now function-local to the helpers that actually embed
+(``embed_body_chunks`` / ``find_similar_tag``), so a read-script *import* never
+pays for them. Each assertion runs in a fresh interpreter so a module another
+test already imported can't mask a regression.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+READ_SCRIPTS = ("scan", "list_documents", "read_chunks", "describe_corpus")
+
+# The embedding/model stack the read path must never pull in at import. (numpy
+# is intentionally excluded: it rides in via sqlite-vec on the DB connection,
+# which is core read-path infrastructure, not the embedding stack.)
+FORBIDDEN = ("bartleby.ingest.embed", "sentence_transformers", "torch",
+             "docling", "filetype", "bartleby.ingest.chunk")
+
+
+@pytest.mark.parametrize("script", READ_SCRIPTS)
+def test_read_script_import_skips_embedding_stack(script: str) -> None:
+    forbidden = ",".join(repr(m) for m in FORBIDDEN)
+    code = (
+        "import sys\n"
+        f"import bartleby.skill_scripts.{script}\n"
+        f"forbidden = ({forbidden},)\n"
+        "leaked = [m for m in forbidden "
+        "if any(k == m or k.startswith(m + '.') for k in sys.modules)]\n"
+        "assert not leaked, leaked\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, (
+        f"importing {script} leaked heavy modules:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )

--- a/tests/test_skill_save_finding.py
+++ b/tests/test_skill_save_finding.py
@@ -19,12 +19,12 @@ from tests._skill_fixtures import (  # noqa: F401
 @pytest.fixture(autouse=True)
 def mock_embed(monkeypatch):
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.embed_texts",
+        "bartleby.ingest.embed.embed_texts",
         lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
     )
     from bartleby.ingest.chunk import ChunkRow
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.chunk_markdown_string",
+        "bartleby.ingest.chunk.chunk_markdown_string",
         lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
     )
 

--- a/tests/test_skill_save_summary.py
+++ b/tests/test_skill_save_summary.py
@@ -21,13 +21,13 @@ def mock_embed(monkeypatch):
     # save_summary embeds via _common.embed_body_chunks; patch the names where
     # that helper looks them up.
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.embed_texts",
+        "bartleby.ingest.embed.embed_texts",
         lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
     )
     # Force single-chunk output so chunk_count assertions stay stable.
     from bartleby.ingest.chunk import ChunkRow
     monkeypatch.setattr(
-        "bartleby.skill_scripts._common.chunk_markdown_string",
+        "bartleby.ingest.chunk.chunk_markdown_string",
         lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
     )
 

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -49,7 +49,9 @@ def stub_embed(monkeypatch):
             norm = sum(v * v for v in vec) ** 0.5 or 1.0
             out.append([v / norm for v in vec])
         return out
-    monkeypatch.setattr(tags_helpers, "embed_texts", _stub)
+    # find_similar_tag imports embed_texts lazily from its source module
+    # (#371), so patch it there rather than on _tags.
+    monkeypatch.setattr("bartleby.ingest.embed.embed_texts", _stub)
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of #413.

FTS-only read scripts (`scan`, `list_documents`, `read_chunks`, `describe_corpus`) paid the embedding/model stack's import cost on every invocation. The cost lived in the two shared modules they import — `_common.py` imported the chunker (`chunk_markdown_string`) + `embed_texts` at module top, and `_tags.py` imported `embed_texts` at module top (`resolve_scope`, which all four read scripts pull in, lives there). Importing the chunker dragged in `docling` + `filetype`.

## Fix
Move those heavy imports to **function-local** lazy imports inside the only functions that embed: `embed_body_chunks` (`_common`) and `find_similar_tag` (`_tags`). In `find_similar_tag` the import sits after the empty-vocab/exact-name early returns, so a name match never triggers it. `db.chunks`, `config`, and `providers` are light and stay at module top.

The optional `skill batch` mode is explicitly out of scope (separate maintainer decision).

## Before/after (importing `bartleby.skill_scripts.scan`, fresh interpreter)
- Modules loaded: **428 → 407** (21 fewer), eliminating all 15 `docling.*` / `filetype.*` submodules + the lazy `bartleby.ingest.embed` loader.
- `-X importtime` cumulative: `scan` ~71.5ms → ~67ms; `describe_corpus` ~72.6ms → ~67ms. (`numpy` still rides in via `sqlite-vec` on the DB connection — core read-path infra, not the embedding stack, out of scope. The structural module-set delta is the honest measure.)

## Tests
- New `tests/test_skill_read_import_cost.py`: asserts in a *fresh interpreter* (so module caching can't mask a leak) that importing each of the four read scripts does not pull `bartleby.ingest.embed`/`chunk`, `sentence_transformers`, `torch`, `docling`, or `filetype`.
- Repointed finding/tag test monkeypatch targets from `_common.embed_texts` / `_common.chunk_markdown_string` / `_tags.embed_texts` to the source modules (the names are no longer module-level attributes; function-local `from ... import` resolves fresh per call).
- Full suite: 844 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)