### PR TITLE
#406: document that out-of-mode read_chunks flags are ignored

### DIFF
--- a/bartleby/skill_scripts/read_chunks.py
+++ b/bartleby/skill_scripts/read_chunks.py
@@ -19,6 +19,11 @@ Three modes (mutually exclusive):
       derived from the target chunk — no need to pass --document. Works
       for any source kind, though image chunks have no neighbors.
 
+The modes are mutually exclusive: pick one, and any flags belonging to the
+other modes are silently ignored (e.g. ``--window`` is read only in
+``--around-chunk`` mode, ``--offset``/``--limit`` only in ``--document``
+mode).
+
 In a memory-off session the finding wall (see ``read_finding``) extends here:
 finding-kind chunks authored by *another* session are walled off so an
 evaluation run can't read prior conclusions by chunk_id. ``--chunks`` drops

--- a/docs/decisions/GH-0406-read-chunks-mode-doc-0001.md
+++ b/docs/decisions/GH-0406-read-chunks-mode-doc-0001.md
@@ -1,0 +1,22 @@
+# `read_chunks` documents that out-of-mode flags are ignored (issue #406)
+
+> Source: [#406](https://github.com/jswest/bartleby/issues/406)
+
+`read_chunks` has three mutually-exclusive modes (`--document`, `--chunks`,
+`--around-chunk`). Flags belonging to one mode (e.g. `--window`, `--offset`,
+`--limit`) are simply unread when another mode is selected — they are silently
+ignored rather than rejected.
+
+The fix is a **doc line, not enforcement code**. A one-sentence caveat was added
+to the existing mode-grouped flag documentation near the top of
+`bartleby/skill_scripts/read_chunks.py` (the module docstring, which also feeds
+the `--help` text via `build_arg_parser("read_chunks", __doc__)`), stating
+plainly that flags belonging to the other modes are silently ignored.
+
+This was the decision reached in the plan interview for #406: the out-of-mode
+flags are *inert, not unsafe*, and the issue's own acceptance criteria accept the
+docstring alternative over rejection logic. Adding a `p.error()` leg would require
+explicit-vs-default flag detection (argparse can't otherwise tell a passed default
+from an omitted flag) — that's over-building for an inert condition. Behavior is
+therefore unchanged; only the docstring/`--help` text gains the caveat. No schema
+change. `tests/test_skill_read_chunks.py` (29 tests) still passes unmodified.


### PR DESCRIPTION
Part of #413. Doc-line fix per plan-interview decision (no enforcement code).

`read_chunks` has three mutually-exclusive modes (`--document`, `--chunks`, `--around-chunk`). Flags belonging to the other modes (e.g. `--window`, `--offset`, `--limit`) are silently ignored when another mode is chosen. This adds a one-sentence caveat to the module docstring — which also feeds `--help` via `build_arg_parser("read_chunks", __doc__)` — stating that plainly.

The flags are inert, not unsafe, so no rejection logic / `p.error()` leg / explicit-vs-default detection. Behavior is unchanged. Decision recorded in `docs/decisions/GH-0406-read-chunks-mode-doc-0001.md`. `tests/test_skill_read_chunks.py` (29 tests) passes unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)