### PR TITLE
#402: argparse usage errors emit the JSON error envelope

### DIFF
--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -107,11 +107,9 @@ def run(
     args_dict: dict[str, Any] = {}
 
     try:
-        # parse_args lives inside the try so an argparse usage error
-        # (a non-zero ``SystemExit`` from ``ArgumentParser.error()``) becomes
-        # the JSON envelope every other failure already emits, rather than
-        # argparse's raw stderr usage dump — agents parse one shape (issue
-        # #402). ``--help`` exits 0 and is re-raised untouched below.
+        # Inside the try so argparse usage errors become the JSON envelope
+        # instead of a raw stderr dump; --help (exit 0) is re-raised below.
+        # See docs/decisions/GH-0402-argparse-json-envelope-0001.md.
         args = parse_args(argv)
         args_dict = {k: v for k, v in vars(args).items() if v is not None}
 
@@ -148,11 +146,7 @@ def run(
         else:
             result = work(conn=conn, args=args, session_id=session_id)
     except SystemExit as e:
-        # argparse raises SystemExit: code 0 for ``--help``/``-h`` (let it
-        # through unchanged), non-zero for a usage/argument error (turn it into
-        # the envelope). parse_args fails before open_db, so there's no
-        # conn/session to log — this falls through to the shared emit path below.
-        if not e.code:  # None or 0 → clean exit (e.g. --help)
+        if not e.code:  # None or 0 → clean exit (e.g. --help); re-raise untouched
             raise
         error_envelope = {
             "error": "Invalid arguments. See --help for usage.",

--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -99,15 +99,22 @@ def run(
         pass
 
     start = time.perf_counter()
-    args = parse_args(argv)
-    args_dict = {k: v for k, v in vars(args).items() if v is not None}
 
     conn = None
     session_id: int | None = None
     result: dict | None = None
     error_envelope: dict | None = None
+    args_dict: dict[str, Any] = {}
 
     try:
+        # parse_args lives inside the try so an argparse usage error
+        # (a non-zero ``SystemExit`` from ``ArgumentParser.error()``) becomes
+        # the JSON envelope every other failure already emits, rather than
+        # argparse's raw stderr usage dump — agents parse one shape (issue
+        # #402). ``--help`` exits 0 and is re-raised untouched below.
+        args = parse_args(argv)
+        args_dict = {k: v for k, v in vars(args).items() if v is not None}
+
         project = args.project or get_active_project()
         if not project:
             raise SkillError(
@@ -140,6 +147,17 @@ def run(
                 result = work(conn=conn, args=args, session_id=session_id)
         else:
             result = work(conn=conn, args=args, session_id=session_id)
+    except SystemExit as e:
+        # argparse raises SystemExit: code 0 for ``--help``/``-h`` (let it
+        # through unchanged), non-zero for a usage/argument error (turn it into
+        # the envelope). parse_args fails before open_db, so there's no
+        # conn/session to log — this falls through to the shared emit path below.
+        if not e.code:  # None or 0 → clean exit (e.g. --help)
+            raise
+        error_envelope = {
+            "error": "Invalid arguments. See --help for usage.",
+            "code": "USAGE_ERROR",
+        }
     except SkillError as e:
         error_envelope = {"error": e.message, "code": e.code, **e.extra}
     except Exception as e:  # noqa: BLE001 — catch-all by design

--- a/docs/decisions/GH-0402-argparse-json-envelope-0001.md
+++ b/docs/decisions/GH-0402-argparse-json-envelope-0001.md
@@ -1,0 +1,32 @@
+# argparse usage errors emit the JSON error envelope (issue #402)
+
+> Source: [#402](https://github.com/jswest/bartleby/issues/402)
+
+A malformed flag/arg to a skill script used to fall through argparse's default
+`ArgumentParser.error()` path: a raw `usage: ...` dump to stderr plus
+`SystemExit(2)`. Agents parse skill output expecting *one* shape — the
+`{"error", "code"}` JSON envelope on stdout — so a usage error was the lone
+escape hatch that broke that contract.
+
+Fix is a single seam, not a per-script change. `bartleby/skill_runner.py`
+already runs every skill's `work()` inside a `try` that turns `SkillError` and
+any stray exception into the envelope. The `parse_args(argv)` call sat *outside*
+that `try`; it now moves *inside*, and a new `except SystemExit` arm catches
+argparse's exit. The arm splits on exit code: a falsy code (`None`/`0` — what
+argparse uses for `--help`/`-h`) is re-raised untouched so help still prints and
+exits 0, while any non-zero code (the usage/argument errors) becomes
+`{"error": "Invalid arguments. See --help for usage.", "code": "USAGE_ERROR"}`
+on stdout with exit 1. Parsing happens before any DB/session is opened, so the
+arm returns straight away with no conn/audit bookkeeping.
+
+Deliberately **not** done: no `ArgumentParser.error()`/`.exit()` subclass spread
+across the ~18 scripts — the runner is the one chokepoint every script funnels
+through, so one arm covers them all (smallest fix that fits). argparse still
+writes its own `usage:` line to stderr before raising; that's a separate stream
+and harmless — the contract is about the parseable shape on stdout, which is now
+always the envelope. The `USAGE_ERROR` code is an inline string constant, in
+keeping with the runner's existing `INTERNAL_ERROR`/`NO_ACTIVE_PROJECT` codes
+(no central code module exists). Two existing tests that asserted exit-2 on
+argparse conflicts (`scan` `--count-by` vs `--preview/--brief`,
+`list_documents` mutually-exclusive `--brief/--verbose` and `--sort` choices)
+were updated to assert exit 1 + `USAGE_ERROR`. No schema change.

--- a/tests/test_skill_list_documents.py
+++ b/tests/test_skill_list_documents.py
@@ -47,10 +47,12 @@ def test_list_documents_brief_projects_three_fields(seeded_project, capsys):
 
 
 def test_list_documents_brief_and_verbose_are_mutually_exclusive(seeded_project, capsys):
-    code, _ = _run(capsys, [
+    code, captured = _run(capsys, [
         "--project", seeded_project["project"], "--brief", "--verbose",
     ])
-    assert code == 2  # argparse mutually-exclusive-group error
+    # argparse mutually-exclusive-group error → JSON usage envelope (issue #402).
+    assert code == 1
+    assert json.loads(captured.out)["code"] == "USAGE_ERROR"
 
 
 def test_list_documents_verbose_includes_chunk_count(seeded_project, capsys):
@@ -311,10 +313,12 @@ def test_list_documents_sort_date_puts_undated_last(seeded_project, capsys):
 
 
 def test_list_documents_sort_rejects_unknown_value(seeded_project, capsys):
-    code, _ = _run(capsys, [
+    code, captured = _run(capsys, [
         "--project", seeded_project["project"], "--sort", "bogus",
     ])
-    assert code == 2  # argparse choices error
+    # argparse choices error → JSON usage envelope (issue #402).
+    assert code == 1
+    assert json.loads(captured.out)["code"] == "USAGE_ERROR"
 
 
 def test_list_documents_date_filter_composes_with_tag(seeded_project, capsys):

--- a/tests/test_skill_runner.py
+++ b/tests/test_skill_runner.py
@@ -153,3 +153,42 @@ def test_mutating_work_opens_a_transaction(seeded_project):
         mutates=True,
     )
     assert seen["in_transaction"] is True
+
+
+def _never(*, conn, args, session_id) -> dict:  # pragma: no cover - never runs
+    raise AssertionError("work() must not run when arg parsing fails")
+
+
+def test_bad_flag_emits_json_envelope_not_usage_dump(capsys):
+    """A malformed flag becomes the ``{"error","code"}`` envelope with a
+    non-zero exit — argparse's raw usage dump never reaches stderr, so agents
+    parse one shape (issue #402)."""
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="probe",
+            parse_args=_parse_args,
+            work=_never,
+            argv=["--bogus-flag"],
+        )
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    # stdout carries the envelope agents parse — not argparse's usage dump,
+    # which argparse writes to stderr only.
+    out = json.loads(captured.out)  # whole stdout is one JSON object
+    assert out["code"] == "USAGE_ERROR"
+    assert "error" in out
+
+
+def test_help_still_exits_zero(capsys):
+    """``--help`` keeps argparse's clean exit-0 behavior — the envelope arm
+    only swallows non-zero usage errors."""
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="probe",
+            parse_args=_parse_args,
+            work=_never,
+            argv=["--help"],
+        )
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out  # argparse printed its own help, untouched

--- a/tests/test_skill_scan.py
+++ b/tests/test_skill_scan.py
@@ -409,12 +409,13 @@ def test_scan_count_by_no_match_is_all_zeros(scan_corpus, capsys):
     assert out["documents"] == []
 
 
-def test_scan_count_by_rejects_preview_and_brief(scan_corpus):
+def test_scan_count_by_rejects_preview_and_brief(scan_corpus, capsys):
     for bad in (["--preview", "100"], ["--brief"]):
         with pytest.raises(SystemExit) as exc:
             _run(scan_corpus, [MARKER, "--count-by", "document", *bad])
-        # argparse-level conflict → exit 2.
-        assert exc.value.code == 2
+        # argparse-level conflict → the JSON usage envelope, exit 1 (issue #402).
+        assert exc.value.code == 1
+        assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"
 
 
 # ---------- --count-by '/regex/' (capture-group aggregate mode) ----------
@@ -546,11 +547,12 @@ def test_scan_count_by_rejects_bare_non_document_value(templated_corpus, capsys)
     assert json.loads(capsys.readouterr().out)["code"] == "INVALID_COUNT_BY"
 
 
-def test_scan_count_by_regex_rejects_preview_and_brief(templated_corpus):
+def test_scan_count_by_regex_rejects_preview_and_brief(templated_corpus, capsys):
     for bad in (["--preview", "100"], ["--brief"]):
         with pytest.raises(SystemExit) as exc:
             _run(templated_corpus, [BILL_MARKER, "--count-by", BILL_RE, *bad])
-        assert exc.value.code == 2
+        assert exc.value.code == 1
+        assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"
 
 
 # ---------- date scope (shared with list_documents / describe_corpus) ----------


### PR DESCRIPTION
Part of #413.

A malformed flag/arg to any skill script used to fall through argparse's default `error()` path — a raw `usage:` dump to stderr plus `SystemExit(2)` — breaking the single `{"error","code"}` JSON envelope agents parse for every other outcome.

## Change
- `bartleby/skill_runner.py`: moved `parse_args(argv)` inside `run()`'s existing `try` block and added a single `except SystemExit` arm. A falsy exit code (None/0 — argparse's `--help`/`-h` path) re-raises untouched so help still exits 0; any non-zero code becomes `{"error": "Invalid arguments. See --help for usage.", "code": "USAGE_ERROR"}` on stdout with exit 1, routed through the shared error-envelope emit path. No `ArgumentParser` subclassing across the scripts.
- Updated two existing tests (`scan` `--count-by` conflicts, `list_documents` mutually-exclusive `--brief/--verbose` and `--sort` choices) from exit-2 to exit-1 + `USAGE_ERROR`.
- Added runner tests: bad flag yields the envelope + non-zero exit; `--help` still exits 0.
- Decision note at `docs/decisions/GH-0402-argparse-json-envelope-0001.md`.

Full suite: 852 passed. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)