### PR TITLE
#407: close conn on session-resolution failure in skill_runner

### DIFF
--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -8,7 +8,11 @@ and calls :func:`run`. The runner:
 - Resolves or auto-creates the active session (skill scripts always run
   inside a session — see SPEC §5.4 / §6 intro).
 - Times the call.
-- Writes one ``audit_logs`` row per invocation (success or failure).
+- Writes one ``audit_logs`` row per invocation (success or failure) once a
+  session is resolved. A failure *before* session resolution (no active
+  project, DB open/schema error, or session resolution itself raising) has no
+  session to attribute the call to, so it surfaces only in the error envelope;
+  the DB connection is still closed on every path where it was opened.
 - Prints either the worker's dict result, or
   ``{"error": ..., "code": ...}`` on failure, to stdout.
 - Exits 0 on success and 1 on failure.
@@ -165,18 +169,21 @@ def run(
         f"error: {error_envelope['code']}" if error_envelope else None
     )
 
-    if conn is not None and session_id is not None:
-        try:
-            log_call(
-                conn,
-                session_id=session_id,
-                tool_name=tool_name,
-                args=args_dict,
-                result_summary=summary,
-                duration_ms=duration_ms,
-            )
-        except Exception:  # never let logging mask the real outcome
-            pass
+    if conn is not None:
+        # log_call needs a resolved session_id (its FK target); close must run
+        # on every opened path regardless, or the conn leaks. See module docstring.
+        if session_id is not None:
+            try:
+                log_call(
+                    conn,
+                    session_id=session_id,
+                    tool_name=tool_name,
+                    args=args_dict,
+                    result_summary=summary,
+                    duration_ms=duration_ms,
+                )
+            except Exception:  # never let logging mask the real outcome
+                pass
         conn.close()
 
     if error_envelope is not None:

--- a/docs/decisions/GH-0407-skill-runner-conn-close-0001.md
+++ b/docs/decisions/GH-0407-skill-runner-conn-close-0001.md
@@ -1,0 +1,32 @@
+# skill_runner closes the conn on every opened path, not just resolved sessions (issue #407)
+
+> Source: [#407](https://github.com/jswest/bartleby/issues/407)
+
+`run()` opens the DB (`open_db`), then resolves or creates the active session.
+The teardown block gated *both* `conn.close()` and the audit `log_call` on a
+single `if conn is not None and session_id is not None:`. That conflates two
+unrelated concerns: closing the connection is a *resource* obligation, while the
+audit write needs a resolved `session_id` as its FK target. If `open_db`
+succeeded but session resolution then raised (a `BARTLEBY_SESSION_NAME` lookup
+or `ensure_active_session` failure), `session_id` stayed `None`, the guard was
+false, and the open `conn` leaked — every such failure dropping a connection.
+
+Fix splits the guard into nested conditions: `if conn is not None:` always
+closes, and `log_call` stays nested under `if session_id is not None:`. Closing
+now happens on every path where the DB was opened, including the pre-session
+failure; the audit row still requires a resolved session (it has nowhere to be
+attributed otherwise) and that failure surfaces only in the stdout error
+envelope. The JSON envelope and exit codes are unchanged.
+
+The module docstring previously claimed "one `audit_logs` row per invocation
+(success or failure)" unconditionally; that was never quite true (a failure
+before session resolution writes none). It now states the row is written *once
+a session is resolved*, and that the conn is closed on every opened path
+regardless.
+
+Smallest fix that fits: no helper, no `finally`, no behavior change beyond the
+leak. Test `test_session_resolution_failure_closes_conn_keeps_envelope` wraps
+`open_db` in a proxy that records `close()` (apsw's `Connection.close` is
+read-only, so it can't be patched in place), forces session resolution to
+raise, and asserts the conn was closed, the envelope is the standard
+`INTERNAL_ERROR` shape, and no audit row was written. No schema change.

--- a/tests/test_skill_runner.py
+++ b/tests/test_skill_runner.py
@@ -179,6 +179,63 @@ def test_bad_flag_emits_json_envelope_not_usage_dump(capsys):
     assert "error" in out
 
 
+def test_session_resolution_failure_closes_conn_keeps_envelope(
+    seeded_project, capsys, monkeypatch
+):
+    """If ``open_db`` succeeds but session resolution then raises, the runner
+    still closes the conn (no leak) and emits the standard error envelope —
+    even though no audit row can be written (issue #407). We wrap ``open_db`` to
+    record close calls and force session resolution to raise.
+    """
+    project = seeded_project["project"]
+    closed: list[bool] = []
+    real_open_db = run.__globals__["open_db"]
+
+    class TrackingConn:
+        """Proxy that delegates to a real apsw conn but records close().
+
+        apsw.Connection.close is read-only, so we can't patch it in place;
+        wrapping is the least-magic way to observe that the runner closed it.
+        """
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def close(self, *a, **k):
+            closed.append(True)
+            return self._inner.close(*a, **k)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    def tracking_open_db(name):
+        return TrackingConn(real_open_db(name))
+
+    monkeypatch.setattr("bartleby.skill_runner.open_db", tracking_open_db)
+
+    def boom_session(*a, **k):
+        raise RuntimeError("session resolution exploded")
+
+    monkeypatch.setattr("bartleby.skill_runner.ensure_active_session", boom_session)
+
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="session_fail_probe",
+            parse_args=_parse_args,
+            work=_never,
+            argv=["--project", project],
+        )
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "INTERNAL_ERROR"
+    assert "error" in out
+
+    # The conn opened before the failure was closed — no leak.
+    assert closed == [True]
+    # No session resolved → no audit row for this tool.
+    assert _audit_rows(project, "session_fail_probe") == 0
+
+
 def test_help_still_exits_zero(capsys):
     """``--help`` keeps argparse's clean exit-0 behavior — the envelope arm
     only swallows non-zero usage errors."""


### PR DESCRIPTION
Part of #413.

`skill_runner.run()` gated both `conn.close()` and the audit `log_call` on a single `conn is not None and session_id is not None` guard. When `open_db` succeeded but session resolution then raised, `session_id` stayed `None`, the guard was false, and the open `conn` leaked (no audit row either).

Fix splits the guard: close whenever `conn is not None`; keep `log_call` nested under `session_id is not None` (the audit row needs a resolved session as its FK target). The JSON envelope and exit codes are unchanged, and the module docstring's "one audit_logs row per invocation" claim is reconciled with actual behavior. Added a test that forces session resolution to fail after `open_db` and asserts the conn is closed (no leak), the envelope is the standard `INTERNAL_ERROR` shape, and no audit row is written. Decision note: `docs/decisions/GH-0407-skill-runner-conn-close-0001.md`. Full suite green (853 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)