### PR TITLE
#403: shared positive/non-negative validators for pagination + id flags

### DIFF
--- a/bartleby/skill_scripts/list_documents.py
+++ b/bartleby/skill_scripts/list_documents.py
@@ -61,15 +61,16 @@ import argparse
 
 from bartleby.skill_runner import build_arg_parser, run
 from bartleby.skill_scripts._common import (
-    add_date_filter_args, add_file_like_arg, pagination_hint,
+    add_date_filter_args, add_file_like_arg, nonneg_int, pagination_hint,
+    positive_int,
 )
 
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("list_documents", __doc__)
     p.add_argument("--project", type=str, default=None)
-    p.add_argument("--limit", type=int, default=200)
-    p.add_argument("--offset", type=int, default=0)
+    p.add_argument("--limit", type=positive_int, default=200)
+    p.add_argument("--offset", type=nonneg_int, default=0)
     tier = p.add_mutually_exclusive_group()
     tier.add_argument(
         "--verbose",

--- a/bartleby/skill_scripts/list_findings.py
+++ b/bartleby/skill_scripts/list_findings.py
@@ -42,14 +42,16 @@ from __future__ import annotations
 import argparse
 
 from bartleby.skill_runner import build_arg_parser, run
-from bartleby.skill_scripts._common import memory_enabled, pagination_hint
+from bartleby.skill_scripts._common import (
+    memory_enabled, nonneg_int, pagination_hint, positive_int,
+)
 
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("list_findings", __doc__)
     p.add_argument("--project", type=str, default=None)
-    p.add_argument("--limit", type=int, default=200)
-    p.add_argument("--offset", type=int, default=0)
+    p.add_argument("--limit", type=positive_int, default=200)
+    p.add_argument("--offset", type=nonneg_int, default=0)
     p.add_argument(
         "--brief",
         action="store_true",

--- a/bartleby/skill_scripts/read_chunks.py
+++ b/bartleby/skill_scripts/read_chunks.py
@@ -119,8 +119,8 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         dest="around_chunk",
         help="Target chunk_id; returns target plus --window chunks on each side.",
     )
-    p.add_argument("--offset", type=int, default=0)
-    p.add_argument("--limit", type=int, default=50)
+    p.add_argument("--offset", type=nonneg_int, default=0)
+    p.add_argument("--limit", type=positive_int, default=50)
     p.add_argument(
         "--window",
         type=nonneg_int,

--- a/bartleby/skill_scripts/read_document.py
+++ b/bartleby/skill_scripts/read_document.py
@@ -27,6 +27,7 @@ import argparse
 
 from bartleby.config import load_config
 from bartleby.skill_runner import SkillError, build_arg_parser, run
+from bartleby.skill_scripts._common import positive_int
 
 
 DEFAULT_MAX_READ_TOKENS = 50_000
@@ -34,7 +35,7 @@ DEFAULT_MAX_READ_TOKENS = 50_000
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("read_document", __doc__)
-    p.add_argument("--document", type=int, required=True, dest="document_id")
+    p.add_argument("--document", type=positive_int, required=True, dest="document_id")
     mode = p.add_mutually_exclusive_group()
     mode.add_argument("--summary", action="store_true")
     mode.add_argument("--full", action="store_true")

--- a/docs/decisions/GH-0403-shared-pagination-validators-0001.md
+++ b/docs/decisions/GH-0403-shared-pagination-validators-0001.md
@@ -1,0 +1,31 @@
+# Shared positive/non-negative validators for pagination + id flags (issue #403)
+
+> Source: [#403](https://github.com/jswest/bartleby/issues/403)
+
+`--limit`/`--offset` and id flags were hand-validated unevenly across the skill
+scripts: `scan` and `search` already routed `--limit`/`--offset` through the
+shared `positive_int`/`nonneg_int` argparse `type=` validators in
+`bartleby/skill_scripts/_common.py`, but `read_chunks`, `list_documents`, and
+`list_findings` still took bare `type=int` for their pagination flags, and
+`read_document`'s `--document` id flag was bare `int`. A bare `int` accepts `0`
+and negatives, which then either silently mis-paginate or surface as opaque
+downstream errors.
+
+Fix is a narrow swap, not a new abstraction: `--offset` → `nonneg_int`,
+`--limit` → `positive_int`, and the `--document` id flag → `positive_int`,
+reusing the existing validator pair (no new helper invented). Because every
+skill funnels `parse_args` through the runner's `try`, an out-of-range value
+raises `argparse.ArgumentTypeError` → `SystemExit` → the
+`{"error", "code": "USAGE_ERROR"}` envelope on stdout with exit 1, *before* any
+DB/session is opened or query runs (the seam established in
+[#402](GH-0402-argparse-json-envelope-0001.md)). Behavior for valid inputs is
+unchanged.
+
+Deliberately **scoped down**: id-only flags on scripts that take no
+`--limit`/`--offset` (e.g. `merge_findings --into`, `delete_finding --finding`,
+`edit_finding`, `read_finding`, `save_summary`, `save_date`, `assign_tag`,
+`tag`) were left on bare `int` — outside this issue's pagination/id-pagination
+scope. No new helper, no central code module, no schema change. Each touched
+script's test file gained a parametrized case asserting that an out-of-range
+`--limit`/`--offset` (and a non-positive `--document`) yields the
+`USAGE_ERROR` envelope with exit 1.

--- a/tests/test_skill_list_documents.py
+++ b/tests/test_skill_list_documents.py
@@ -321,6 +321,20 @@ def test_list_documents_sort_rejects_unknown_value(seeded_project, capsys):
     assert json.loads(captured.out)["code"] == "USAGE_ERROR"
 
 
+@pytest.mark.parametrize("bad", [
+    ["--limit", "0"],     # positive_int rejects < 1
+    ["--limit", "-5"],
+    ["--offset", "-1"],   # nonneg_int rejects < 0
+])
+def test_list_documents_out_of_range_pagination_rejected(seeded_project, capsys, bad):
+    # The shared positive/non-negative validators (issue #403) reject out-of-range
+    # --limit/--offset at parse time, so the JSON envelope is emitted before any
+    # query runs.
+    code, captured = _run(capsys, ["--project", seeded_project["project"], *bad])
+    assert code == 1
+    assert json.loads(captured.out)["code"] == "USAGE_ERROR"
+
+
 def test_list_documents_date_filter_composes_with_tag(seeded_project, capsys):
     from bartleby.db.connection import open_db
     project = seeded_project["project"]

--- a/tests/test_skill_list_findings.py
+++ b/tests/test_skill_list_findings.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
@@ -131,6 +133,20 @@ def test_list_findings_pagination_hint(seeded_project, capsys):
     out = json.loads(capsys.readouterr().out)
     assert len(out["findings"]) == 1
     assert out["hint"] is None
+
+
+@pytest.mark.parametrize("bad", [
+    ["--limit", "0"],     # positive_int rejects < 1
+    ["--limit", "-5"],
+    ["--offset", "-1"],   # nonneg_int rejects < 0
+])
+def test_list_findings_out_of_range_pagination_rejected(seeded_project, capsys, bad):
+    # Shared positive/non-negative validators (issue #403) reject at parse time:
+    # the JSON usage envelope is emitted before any query runs.
+    with pytest.raises(SystemExit) as exc:
+        list_findings.main(["--project", seeded_project["project"], *bad])
+    assert exc.value.code == 1
+    assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"
 
 
 def test_list_findings_memory_off_scopes_to_own_session(seeded_project, capsys):

--- a/tests/test_skill_read_chunks.py
+++ b/tests/test_skill_read_chunks.py
@@ -610,3 +610,20 @@ def test_read_chunks_around_unknown_chunk(seeded_project, capsys):
     assert exc.value.code == 1
     out = json.loads(capsys.readouterr().out)
     assert out["code"] == "CHUNK_NOT_FOUND"
+
+
+@pytest.mark.parametrize("bad", [
+    ["--limit", "0"],     # positive_int rejects < 1
+    ["--limit", "-5"],
+    ["--offset", "-1"],   # nonneg_int rejects < 0
+])
+def test_read_chunks_out_of_range_pagination_rejected(seeded_project, capsys, bad):
+    # Shared positive/non-negative validators (issue #403) reject at parse time,
+    # so the JSON usage envelope is emitted before any query runs.
+    with pytest.raises(SystemExit) as exc:
+        read_chunks.main([
+            "--project", seeded_project["project"],
+            "--document", str(seeded_project["doc_a"]), *bad,
+        ])
+    assert exc.value.code == 1
+    assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"

--- a/tests/test_skill_read_document.py
+++ b/tests/test_skill_read_document.py
@@ -74,3 +74,15 @@ def test_read_document_force_bypasses_gate(seeded_project, capsys, monkeypatch):
     ])
     out = json.loads(capsys.readouterr().out)
     assert out["full_text"]
+
+
+@pytest.mark.parametrize("bad", ["0", "-1"])
+def test_read_document_non_positive_id_rejected(seeded_project, capsys, bad):
+    # The --document id flag uses the shared positive_int validator (issue #403):
+    # a non-positive id fails with the JSON usage envelope before any query runs.
+    with pytest.raises(SystemExit) as exc:
+        read_document.main([
+            "--project", seeded_project["project"], "--document", bad,
+        ])
+    assert exc.value.code == 1
+    assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"


### PR DESCRIPTION
Part of #413.

Swaps bare `type=int` to the existing shared `positive_int`/`nonneg_int` argparse validators in `bartleby/skill_scripts/_common.py` for the remaining hand-validated pagination/id flags:

- `read_chunks.py` — `--offset` → `nonneg_int`, `--limit` → `positive_int`
- `list_documents.py` — `--limit` → `positive_int`, `--offset` → `nonneg_int`
- `list_findings.py` — `--limit` → `positive_int`, `--offset` → `nonneg_int`
- `read_document.py` — `--document` id flag → `positive_int`

(`scan`/`search` already used the pair.) Out-of-range values now fail with the `{"error","code":"USAGE_ERROR"}` envelope at parse time — before any DB/session is opened or query runs (the runner seam from #402). Valid-input behavior is unchanged. No new helpers; id-only flags on non-paginating scripts (`merge_findings --into`, `delete_finding --finding`, etc.) were deliberately left out of scope.

Each touched script's test file gained a parametrized case asserting an out-of-range `--limit`/`--offset` (and a non-positive `--document`) yields the envelope. Full suite passes (863). Decision note: `docs/decisions/GH-0403-shared-pagination-validators-0001.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)