### PR TITLE
#410: dispatcher + runner JSON-contract tests

### DIFF
--- a/docs/decisions/GH-0410-dispatcher-runner-tests-0001.md
+++ b/docs/decisions/GH-0410-dispatcher-runner-tests-0001.md
@@ -1,0 +1,48 @@
+# GH-0410 — dispatcher + runner JSON-contract tests
+
+Issue #410 asked us to pin the dispatcher/runner JSON contract: UNKNOWN_SKILL,
+INTERNAL_ERROR, the bare-invocation envelope (#401), the argparse-usage envelope
+(#402), and conn-close/audit behavior on session-resolution failure (#407).
+
+## What the omnibus already covered (left untouched)
+
+By the time #410 ran, sibling issues had already landed most of the contract:
+
+- `tests/test_skill_runner.py` (from #339/#402/#407) already pins:
+  - `INTERNAL_ERROR` envelope + exit 1, with full mutation rollback across
+    `findings`/`chunks`/fts/vec while the audit row survives.
+  - read-only opens no transaction; `mutates=True` opens one.
+  - `USAGE_ERROR` envelope on a bad flag (argparse usage dump never reaches
+    stdout) — #402.
+  - `--help` still exits 0 with argparse's own help — #402.
+  - session-resolution failure closes the conn (no leak) and emits the envelope
+    with no audit row written — #407.
+- `tests/test_skill_dispatch.py` (from #401) already pins:
+  - bare invocation → `MISSING_SKILL` envelope on stdout, prose to stderr, exit 1.
+  - `-h/--help` → exit 0 with help text.
+  - unknown name → `UNKNOWN_SKILL` envelope + exit 1.
+  - `SCRIPTS` tuple is non-empty.
+
+## What #410 added (the genuine gaps)
+
+- **Runner — `NO_ACTIVE_PROJECT` envelope path.** No `--project` and no active
+  project (the autouse home-isolation fixture guarantees a fresh sandbox) now
+  asserts the `NO_ACTIVE_PROJECT` envelope + exit 1, *and* that `open_db` is
+  never called — the SkillError fires before the DB is opened, so there is no
+  conn to leak and no audit row. This was the one runner error arm with no test.
+- **Dispatcher — routing + remaining-argv passthrough.** A known name routes to
+  `bartleby.skill_scripts.<name>.main` with the name consumed and the rest of
+  argv handed through verbatim.
+- **Dispatcher — exit-code propagation.** A script that `sys.exit(2)` surfaces
+  code 2 to the caller unchanged; the dispatcher does not swallow `SystemExit`.
+
+## Explicitly NOT done (hard fence)
+
+Did not build the fragile parametrized "induce a failure in all ~23 scripts"
+sweep — per-script envelopes are pinned by their own tests. Smallest fix that
+fits: four new cases, no renames, no duplication.
+
+## Gate
+
+`uv run pytest tests/test_skill_runner.py tests/test_skill_dispatch.py` → 14
+passed; full `uv run pytest` → 867 passed.

--- a/tests/test_skill_dispatch.py
+++ b/tests/test_skill_dispatch.py
@@ -14,6 +14,8 @@ import pytest
 
 from bartleby.commands.skill import SCRIPTS, dispatch
 
+_SEARCH_MOD = __import__("bartleby.skill_scripts.search", fromlist=["main"])
+
 
 def test_bare_invocation_emits_error_envelope(capsys):
     """No script name -> JSON envelope on stdout + exit 1; prose to stderr."""
@@ -51,15 +53,14 @@ def test_known_name_routes_to_script_and_passes_remaining_argv(monkeypatch):
     """A known script name imports ``bartleby.skill_scripts.<name>`` and calls
     its ``main`` with the *remaining* argv — the dispatcher is a thin router, so
     the name is consumed and everything after it is handed through verbatim."""
-    seen: dict = {}
+    seen = {}
 
     def fake_main(argv):
         seen["argv"] = argv
 
     # ``search`` is a real entry in SCRIPTS; patch its module's main so we observe
     # routing without running the actual script.
-    module = __import__("bartleby.skill_scripts.search", fromlist=["main"])
-    monkeypatch.setattr(module, "main", fake_main)
+    monkeypatch.setattr(_SEARCH_MOD, "main", fake_main)
 
     dispatch(["search", "--query", "x", "--limit", "3"])
     assert seen["argv"] == ["--query", "x", "--limit", "3"]
@@ -72,8 +73,7 @@ def test_known_name_propagates_script_exit_code(monkeypatch):
     def exit_two(argv):
         sys.exit(2)
 
-    module = __import__("bartleby.skill_scripts.search", fromlist=["main"])
-    monkeypatch.setattr(module, "main", exit_two)
+    monkeypatch.setattr(_SEARCH_MOD, "main", exit_two)
 
     with pytest.raises(SystemExit) as exc:
         dispatch(["search"])

--- a/tests/test_skill_dispatch.py
+++ b/tests/test_skill_dispatch.py
@@ -8,6 +8,7 @@ only, and a non-zero exit. ``-h/--help`` must still exit 0 with help text.
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 
@@ -44,6 +45,39 @@ def test_unknown_skill_still_emits_error_envelope(capsys):
     assert exc.value.code == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["code"] == "UNKNOWN_SKILL"
+
+
+def test_known_name_routes_to_script_and_passes_remaining_argv(monkeypatch):
+    """A known script name imports ``bartleby.skill_scripts.<name>`` and calls
+    its ``main`` with the *remaining* argv — the dispatcher is a thin router, so
+    the name is consumed and everything after it is handed through verbatim."""
+    seen: dict = {}
+
+    def fake_main(argv):
+        seen["argv"] = argv
+
+    # ``search`` is a real entry in SCRIPTS; patch its module's main so we observe
+    # routing without running the actual script.
+    module = __import__("bartleby.skill_scripts.search", fromlist=["main"])
+    monkeypatch.setattr(module, "main", fake_main)
+
+    dispatch(["search", "--query", "x", "--limit", "3"])
+    assert seen["argv"] == ["--query", "x", "--limit", "3"]
+
+
+def test_known_name_propagates_script_exit_code(monkeypatch):
+    """The dispatcher does not swallow a script's ``SystemExit`` — a script that
+    exits non-zero (its own error envelope path) surfaces that code to the
+    caller unchanged."""
+    def exit_two(argv):
+        sys.exit(2)
+
+    module = __import__("bartleby.skill_scripts.search", fromlist=["main"])
+    monkeypatch.setattr(module, "main", exit_two)
+
+    with pytest.raises(SystemExit) as exc:
+        dispatch(["search"])
+    assert exc.value.code == 2
 
 
 def test_scripts_tuple_nonempty():

--- a/tests/test_skill_runner.py
+++ b/tests/test_skill_runner.py
@@ -236,6 +236,31 @@ def test_session_resolution_failure_closes_conn_keeps_envelope(
     assert _audit_rows(project, "session_fail_probe") == 0
 
 
+def test_no_active_project_emits_envelope_without_opening_db(capsys, monkeypatch):
+    """With no ``--project`` and no active project, the runner raises the
+    ``NO_ACTIVE_PROJECT`` SkillError *before* ``open_db`` — so the envelope
+    surfaces with exit 1 and the DB is never touched (no conn to leak, no audit
+    row). The autouse home-isolation fixture already guarantees a fresh sandbox
+    with no active-project pointer; we also assert ``open_db`` is never called.
+    """
+    def boom_open_db(name):  # pragma: no cover - must never run
+        raise AssertionError("open_db must not run when no project resolves")
+
+    monkeypatch.setattr("bartleby.skill_runner.open_db", boom_open_db)
+
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="no_project_probe",
+            parse_args=_parse_args,
+            work=_never,
+            argv=[],  # no --project, and the sandbox has no active project
+        )
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "NO_ACTIVE_PROJECT"
+    assert "error" in out
+
+
 def test_help_still_exits_zero(capsys):
     """``--help`` keeps argparse's clean exit-0 behavior — the envelope arm
     only swallows non-zero usage errors."""


### PR DESCRIPTION
Part of #413.

Pins the dispatcher/runner JSON contract. The omnibus already covered most of it
(INTERNAL_ERROR, rollback-keep-audit, txn seam, USAGE_ERROR + help-exits-0 from
#402, conn-close-on-session-failure from #407, and bare-invocation MISSING_SKILL
/ UNKNOWN_SKILL / help from #401), so this adds only the genuinely-missing cases:

- **runner — NO_ACTIVE_PROJECT**: no `--project` + no active project asserts the
  envelope + exit 1 AND that `open_db` is never called (no conn to leak, no audit row).
- **dispatcher — routing**: a known name routes to `skill_scripts.<name>.main` with
  the remaining argv passed through verbatim.
- **dispatcher — exit-code propagation**: a script's `SystemExit` code surfaces unchanged.

No all-scripts failure sweep (per-script envelopes are already pinned by their own
tests). Decision note: `docs/decisions/GH-0410-dispatcher-runner-tests-0001.md`.

Gate: targeted files 14 passed; full `uv run pytest` 867 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)