### PR TITLE
skill: #432 shared --project arg + one-caller helper inlines

### DIFF
--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -64,12 +64,19 @@ def build_arg_parser(
     the JSON contract otherwise lives only in docstrings they never see (issue
     #47). The raw formatter must travel with the docstring, so it lives here
     rather than at each of the ~18 call sites.
+
+    ``--project`` is declared here too: ``run()`` unconditionally reads
+    ``args.project`` to resolve the corpus, so it is part of the runner's
+    contract with every script (issue #432). Each script's parser inherits it
+    from this factory rather than redeclaring the byte-identical line.
     """
-    return argparse.ArgumentParser(
+    parser = argparse.ArgumentParser(
         prog=prog,
         description=description,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument("--project", type=str, default=None)
+    return parser
 
 
 def _print_json(payload: Any) -> None:

--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -662,7 +662,7 @@ def _image_anchors(cur, image_ids: list[int]) -> dict[int, dict]:
 
     out: dict[int, dict] = {}
     for image_id, occurrences in by_image.items():
-        primary_doc, primary_page, primary_name, primary_date = occurrences[0]
+        _, primary_page, primary_name, primary_date = occurrences[0]
         out[image_id] = {
             "file_name": primary_name,
             "page_number": primary_page,

--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -186,43 +186,6 @@ def documents_matching_file_like(conn, patterns: list[str]) -> list[int]:
     ]
 
 
-def intersect_file_like_filter(
-    conn, base_ids: list[int] | None, file_like: list[str] | None,
-) -> list[int] | None:
-    """Fold ``--file-like`` into ``base_ids`` as an intersection.
-
-    Without patterns, ``base_ids`` passes through unchanged. With patterns, the
-    result is the intersection of the existing scope (if any) and the documents
-    whose ``file_name`` matches any pattern. An empty intersection yields ``[]``
-    so the caller short-circuits to zero hits.
-    """
-    if not file_like:
-        return base_ids
-    matched = documents_matching_file_like(conn, file_like)
-    if base_ids is None:
-        return matched
-    return sorted(set(base_ids) & set(matched))
-
-
-def intersect_tag_filter(
-    conn, in_documents: list[int] | None, tag_names: list[str] | None,
-) -> tuple[list[int] | None, list[str] | None]:
-    """Fold ``--tag`` into ``in_documents`` as an intersection.
-
-    Shared by ``search`` and ``scan``. Without tags, ``in_documents`` passes
-    through unchanged. With tags, the result is the intersection of the
-    explicit document set (if any) and the documents carrying any of the named
-    tags. An empty intersection yields ``[]`` — the caller short-circuits to
-    zero hits.
-    """
-    if not tag_names:
-        return in_documents, None
-    tagged = documents_with_any_tag(conn, resolve_tag_names(conn, tag_names))
-    if in_documents is None:
-        return tagged, tag_names
-    return sorted(set(in_documents) & set(tagged)), tag_names
-
-
 # ---------- scope resolution (tags + in_documents + date bounds) ----------
 
 
@@ -396,17 +359,23 @@ def resolve_scope(
     """Fold ``--tag`` ∩ ``--in-documents`` ∩ ``--file-like`` ∩ date bounds into one ``Scope``.
 
     The single scope resolver for ``list_documents``, ``scan``, ``search``, and
-    ``describe_corpus``. Tags and ``in_documents`` intersect via
-    ``intersect_tag_filter``; ``--file-like`` (LIKE patterns OR'd together) then
-    intersects that set via ``intersect_file_like_filter``; an active date bound
+    ``describe_corpus``. Tags and ``in_documents`` intersect; ``--file-like``
+    (LIKE patterns OR'd together) then intersects that set; an active date bound
     finally narrows the result (and accounts for the undated docs it drops).
+    Each intersection yields ``[]`` (short-circuit to zero hits) when empty, or
+    passes the prior scope through unchanged when its filter is absent.
     Unknown tags raise ``TAG_NOT_FOUND`` and malformed bounds raise ``INVALID_DATE``.
     """
     after = validate_date_bound("--authored-after", authored_after)
     before = validate_date_bound("--authored-before", authored_before)
 
-    scoped_docs, tag_names = intersect_tag_filter(conn, in_documents, tags)
-    scoped_docs = intersect_file_like_filter(conn, scoped_docs, file_like)
+    scoped_docs = in_documents
+    if tags:
+        tagged = documents_with_any_tag(conn, resolve_tag_names(conn, tags))
+        scoped_docs = tagged if scoped_docs is None else sorted(set(scoped_docs) & set(tagged))
+    if file_like:
+        matched = documents_matching_file_like(conn, file_like)
+        scoped_docs = matched if scoped_docs is None else sorted(set(scoped_docs) & set(matched))
     date_active = after is not None or before is not None
 
     if not date_active:
@@ -424,7 +393,7 @@ def resolve_scope(
     return Scope(
         document_ids=document_ids,
         in_documents=in_documents,
-        tags=tag_names,
+        tags=tags or None,
         file_like=file_like,
         authored_after=after,
         authored_before=before,

--- a/bartleby/skill_scripts/add_tag.py
+++ b/bartleby/skill_scripts/add_tag.py
@@ -58,7 +58,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--pattern", type=str, default=None,
         help="Extraction regex with a (?P<value>…) group. Requires --value-type.",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/assign_tag.py
+++ b/bartleby/skill_scripts/assign_tag.py
@@ -61,7 +61,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--chunk", type=positive_int, default=None, dest="chunk_id",
         help="Chunk to anchor a manual --value to (its citation source).",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/delete_finding.py
+++ b/bartleby/skill_scripts/delete_finding.py
@@ -49,7 +49,6 @@ from bartleby.skill_scripts._common import assert_findings_accessible, positive_
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("delete_finding", __doc__)
     p.add_argument("--finding", type=positive_int, required=True, dest="finding_id")
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/delete_tag.py
+++ b/bartleby/skill_scripts/delete_tag.py
@@ -20,7 +20,6 @@ from bartleby.skill_scripts._tags import require_tag_by_name
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("delete_tag", __doc__)
     p.add_argument("--tag", type=str, required=True)
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/describe_corpus.py
+++ b/bartleby/skill_scripts/describe_corpus.py
@@ -71,7 +71,6 @@ from bartleby.skill_scripts._tags import resolve_scope
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("describe_corpus", __doc__)
-    p.add_argument("--project", type=str, default=None)
     p.add_argument(
         "--top-n", type=positive_int, default=5, dest="top_n",
         help="How many largest-by-token documents to list (default 5).",

--- a/bartleby/skill_scripts/edit_finding.py
+++ b/bartleby/skill_scripts/edit_finding.py
@@ -59,7 +59,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument("--title", type=str, default=None)
     p.add_argument("--description", type=str, default=None)
     p.add_argument("--body-file", type=str, default=None, dest="body_file")
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/extract.py
+++ b/bartleby/skill_scripts/extract.py
@@ -65,7 +65,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--chunks", type=comma_int_list("chunk_id"), required=True,
         dest="chunk_ids", help="Comma-separated chunk ids, e.g. 4192,4193.",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/list_documents.py
+++ b/bartleby/skill_scripts/list_documents.py
@@ -68,7 +68,6 @@ from bartleby.skill_scripts._common import (
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("list_documents", __doc__)
-    p.add_argument("--project", type=str, default=None)
     p.add_argument("--limit", type=positive_int, default=200)
     p.add_argument("--offset", type=nonneg_int, default=0)
     tier = p.add_mutually_exclusive_group()

--- a/bartleby/skill_scripts/list_findings.py
+++ b/bartleby/skill_scripts/list_findings.py
@@ -49,7 +49,6 @@ from bartleby.skill_scripts._common import (
 
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("list_findings", __doc__)
-    p.add_argument("--project", type=str, default=None)
     p.add_argument("--limit", type=positive_int, default=200)
     p.add_argument("--offset", type=nonneg_int, default=0)
     p.add_argument(

--- a/bartleby/skill_scripts/merge_findings.py
+++ b/bartleby/skill_scripts/merge_findings.py
@@ -71,7 +71,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument("--body-file", type=str, required=True, dest="body_file")
     p.add_argument("--title", type=str, default=None)
     p.add_argument("--description", type=str, default=None)
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/merge_tags.py
+++ b/bartleby/skill_scripts/merge_tags.py
@@ -46,7 +46,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("merge_tags", __doc__)
     p.add_argument("--from", type=str, required=True, dest="from_name")
     p.add_argument("--into", type=str, required=True, dest="into_name")
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/read_chunks.py
+++ b/bartleby/skill_scripts/read_chunks.py
@@ -133,7 +133,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         default=None,
         help="Truncate each chunk's text to the first N chars (append '…' if trimmed).",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 
@@ -155,13 +154,7 @@ def _chunks_from_rows(rows, preview: int | None) -> list[dict]:
 def _read_by_chunk_ids(
     conn, chunk_ids: list[int], preview: int | None, *, mem: bool, session_id: int
 ) -> dict:
-    # De-dupe while preserving the agent's requested order.
-    seen: set[int] = set()
-    ordered: list[int] = []
-    for cid in chunk_ids:
-        if cid not in seen:
-            seen.add(cid)
-            ordered.append(cid)
+    ordered = list(dict.fromkeys(chunk_ids))  # dedup, preserve order
 
     placeholders = ",".join("?" * len(ordered))
     rows = {

--- a/bartleby/skill_scripts/read_document.py
+++ b/bartleby/skill_scripts/read_document.py
@@ -40,7 +40,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     mode.add_argument("--summary", action="store_true")
     mode.add_argument("--full", action="store_true")
     p.add_argument("--force", action="store_true")
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/read_finding.py
+++ b/bartleby/skill_scripts/read_finding.py
@@ -63,7 +63,6 @@ from bartleby.skill_scripts._common import (
 def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("read_finding", __doc__)
     p.add_argument("--finding", type=positive_int, required=True, dest="finding_id")
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/read_tags.py
+++ b/bartleby/skill_scripts/read_tags.py
@@ -33,7 +33,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--boolean-only", action="store_true", dest="boolean_only",
         help="List only boolean tags (value_type IS NULL), excluding value-tags.",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/rename_tag.py
+++ b/bartleby/skill_scripts/rename_tag.py
@@ -24,7 +24,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = build_arg_parser("rename_tag", __doc__)
     p.add_argument("--old", type=str, required=True)
     p.add_argument("--new", type=str, required=True)
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/save_date.py
+++ b/bartleby/skill_scripts/save_date.py
@@ -37,7 +37,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--clear", action="store_true",
         help="Set authored_date to NULL (mark the document undated).",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/save_finding.py
+++ b/bartleby/skill_scripts/save_finding.py
@@ -51,7 +51,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument("--title", type=str, required=True)
     p.add_argument("--description", type=str, required=True)
     p.add_argument("--body-file", type=str, required=True, dest="body_file")
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/save_summary.py
+++ b/bartleby/skill_scripts/save_summary.py
@@ -31,7 +31,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--authored-date", type=str, default=None, dest="authored_date",
         help="ISO 8601 YYYY-MM-DD. Silently stored as NULL if malformed.",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -235,7 +235,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     p.add_argument("--offset", type=nonneg_int, default=0)
     p.add_argument("--limit", type=positive_int, default=DEFAULT_LIMIT)
-    p.add_argument("--project", type=str, default=None)
     add_date_filter_args(p)
     args = p.parse_args(argv)
     if args.count_by and (args.preview is not None or args.brief):

--- a/bartleby/skill_scripts/search.py
+++ b/bartleby/skill_scripts/search.py
@@ -147,7 +147,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
             "under --brief."
         ),
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 
@@ -190,8 +189,6 @@ def _scope_clause(
     ``scope`` maps source_kind → either a list of allowed source_ids
     (filtered scope) or ``None`` (unrestricted — match all of that kind).
     """
-    if not scope:
-        return "0", []
     parts: list[str] = []
     params: list = []
     for kind, ids in scope.items():

--- a/bartleby/skill_scripts/tag.py
+++ b/bartleby/skill_scripts/tag.py
@@ -76,7 +76,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--force", action="store_true",
         help="Re-classify even when relevant assignments already exist.",
     )
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 

--- a/bartleby/skill_scripts/unassign_tag.py
+++ b/bartleby/skill_scripts/unassign_tag.py
@@ -33,7 +33,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         dest="document_ids", help="Comma-separated document ids, e.g. 1,2,3.",
     )
     p.add_argument("--tag", type=str, required=True)
-    p.add_argument("--project", type=str, default=None)
     return p.parse_args(argv)
 
 


### PR DESCRIPTION
Part of #447.

Mechanical residue cleanup in shared skill-script plumbing — zero user-visible behavior change.

**What changed**
- Hoisted the 23 byte-identical `p.add_argument("--project", ...)` lines into `skill_runner.build_arg_parser` (the factory every script already uses). `run()` reads `args.project` unconditionally, so the arg is part of the runner's contract.
- Inlined `intersect_tag_filter` / `intersect_file_like_filter` into their only caller, `resolve_scope`; tags echo computed as `tags or None`. The mechanical subset of #437 — `Scope.filters_dict`, the stale "shared by" docstrings, and other chain residue are left for #437.
- `read_chunks`: replaced the 7-line seen-set dedup with the sibling-script one-liner `list(dict.fromkeys(...))`.
- `search._scope_clause`: removed the unreachable empty-scope guard (the reachable `if not parts` path already covers zero-match).
- `_common._image_anchors`: renamed the unused `primary_doc` unpack slot to `_`.

**Net line delta:** -55 (22 insertions, 77 deletions across 26 files).

**Guard-test status:** `tests/test_skill_flag_conventions.py` green (56 passed) — the #411 guard introspects each script's built parser and is unaffected by the hoist. Full suite green (927 passed).