### PR TITLE
cli: #443 derive skill SCRIPTS registry from package dir

### DIFF
--- a/bartleby/commands/skill.py
+++ b/bartleby/commands/skill.py
@@ -10,33 +10,23 @@ from __future__ import annotations
 
 import importlib
 import json
+import pkgutil
 import sys
 
+from bartleby import skill_scripts
 
-SCRIPTS = (
-    "describe_corpus",
-    "list_documents",
-    "search",
-    "scan",
-    "read_chunks",
-    "read_document",
-    "save_summary",
-    "save_date",
-    "save_finding",
-    "edit_finding",
-    "delete_finding",
-    "merge_findings",
-    "list_findings",
-    "read_finding",
-    "read_tags",
-    "add_tag",
-    "delete_tag",
-    "rename_tag",
-    "merge_tags",
-    "tag",
-    "assign_tag",
-    "unassign_tag",
-    "extract",
+
+# The dispatchable scripts are exactly the non-underscore modules of the
+# ``bartleby.skill_scripts`` package (``_common``/``_tags`` are shared helpers,
+# not skills). Derive the allowlist from the package directory so a new script
+# is dispatchable on drop-in, with no parallel edit here. Sorted for a stable
+# help/error ordering.
+SCRIPTS = tuple(
+    sorted(
+        m.name
+        for m in pkgutil.iter_modules(skill_scripts.__path__)
+        if not m.name.startswith("_")
+    )
 )
 
 

--- a/docs/decisions/GH-0443-derive-scripts-registry-0001.md
+++ b/docs/decisions/GH-0443-derive-scripts-registry-0001.md
@@ -1,0 +1,67 @@
+# GH-0443 — derive the skill SCRIPTS registry from the package directory
+
+Issue #443 (tier-2 dry-sweep judgment bet) replaced the hand-maintained 23-name
+`SCRIPTS` tuple in `bartleby/commands/skill.py` with a derivation over the
+`bartleby.skill_scripts` package: the non-underscore modules, sorted.
+
+## What changed
+
+`SCRIPTS` is now
+
+```python
+SCRIPTS = tuple(
+    sorted(
+        m.name
+        for m in pkgutil.iter_modules(skill_scripts.__path__)
+        if not m.name.startswith("_")
+    )
+)
+```
+
+The package `__init__.py` is empty, so this costs no extra import. The
+`UNKNOWN_SKILL` / `MISSING_SKILL` JSON envelopes and `_print_help` are byte-for-byte
+unchanged — only the *source* of the name set moved from a literal to the directory.
+
+## Why deriving is correct
+
+The package exists solely to hold skill scripts. The literal tuple was, element for
+element, the directory listing minus its two shared-helper modules (`_common.py`,
+`_tags.py`) — both of which already follow the underscore convention. Every new
+script previously required a parallel edit to this tuple or it silently failed
+dispatch with `UNKNOWN_SKILL`; deriving removes that duplicate source of truth.
+
+Dispatch remains an **allowlist**: a name not present in the derived tuple still gets
+the `UNKNOWN_SKILL` JSON error, so the derivation does not open the door to arbitrary
+module / dotted-path injection — underscore exclusion plus "must be a real module in
+this one package" is the whole gate.
+
+## What is no longer handled (the trade)
+
+- A module dropped into `bartleby/skill_scripts/` can no longer be kept out of agent
+  dispatch by omitting it from a registry — exclusion now requires the underscore
+  prefix. Acceptable: the package holds only skill scripts, and the underscore
+  convention for non-script modules already held.
+- The stderr help listing's hand-grouped ordering is given up for alphabetical.
+  `SKILL.md` is the agent-facing reference for what to call, so that ordering carried
+  no weight.
+
+## How the test now guards the derivation
+
+`tests/test_skill_flag_conventions.py` previously kept its *own* hand-copied `SCRIPTS`
+roster and `test_guard_roster_matches_dispatcher` asserted the two hand-copies agreed
+(the #411 blind-spot guard). That recreated the very duplication #443 removes. The
+test now:
+
+- imports `SCRIPTS` from the dispatcher (one source of truth) for its parametrized
+  convention guards (#403/#405/#408/#111), and
+- `test_dispatcher_roster_derives_from_package` asserts the *derivation property*
+  itself — `SCRIPTS` equals the sorted non-underscore modules of
+  `bartleby.skill_scripts`, is non-empty, and contains no underscore-prefixed
+  names — rather than pinning a hand-copied 23-name list.
+
+So the guard still fails loudly if the dispatcher ever drifts from the package, but it
+asserts the rule instead of mirroring a frozen snapshot of its output.
+
+---
+*Filed from the 2026-06-11 dry sweep (dead/wet/bloat audit; every item adversarially
+verified by an independent defender pass).*

--- a/tests/test_skill_flag_conventions.py
+++ b/tests/test_skill_flag_conventions.py
@@ -25,9 +25,12 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import pkgutil
 
 import pytest
 
+from bartleby import skill_scripts
+from bartleby.commands.skill import SCRIPTS
 from bartleby.skill_scripts._common import nonneg_int, positive_int
 
 
@@ -74,15 +77,9 @@ def _action_for(parser: argparse.ArgumentParser, option: str):
     return next((a for a in parser._actions if option in a.option_strings), None)
 
 
-# The skill scripts whose argparse parser we introspect (everything but the
-# ``_``-prefixed shared modules).
-SCRIPTS = [
-    "add_tag", "assign_tag", "delete_finding", "delete_tag", "describe_corpus",
-    "edit_finding", "extract", "list_documents", "list_findings",
-    "merge_findings", "merge_tags", "read_chunks", "read_document",
-    "read_finding", "read_tags", "rename_tag", "save_date", "save_finding",
-    "save_summary", "scan", "search", "tag", "unassign_tag",
-]
+# The skill scripts whose argparse parser we introspect are exactly the
+# dispatcher's roster (everything but the ``_``-prefixed shared modules); we
+# reuse ``SCRIPTS`` imported from the dispatcher rather than re-listing them.
 
 # Scripts that identify a *single existing* tag — the selector must be ``--tag``
 # (#405). ``add_tag`` is excluded: its ``--name`` names a tag being *created*.
@@ -91,19 +88,25 @@ SCRIPTS = [
 EXISTING_TAG_SCRIPTS = ["delete_tag", "assign_tag", "unassign_tag", "extract", "tag"]
 
 
-def test_guard_roster_matches_dispatcher():
-    """The guard's SCRIPTS roster must equal the dispatcher's (#411 blind spot).
-
-    This list is hand-copied from the dispatcher; without this assertion a
-    script added to ``bartleby.commands.skill.SCRIPTS`` tomorrow would silently
-    escape every convention guard above. Pin them so a divergence fails here.
+def test_dispatcher_roster_derives_from_package():
+    """The dispatcher's SCRIPTS is *derived* from the package, not hand-listed
+    (#443). It must be exactly the non-underscore modules of
+    ``bartleby.skill_scripts``, sorted — so a script dropped into that package
+    is dispatchable (and convention-guarded above) with no parallel edit, while
+    ``_``-prefixed shared modules stay excluded.
     """
-    from bartleby.commands.skill import SCRIPTS as DISPATCHER_SCRIPTS
-
-    assert set(SCRIPTS) == set(DISPATCHER_SCRIPTS), (
-        "the convention-guard roster has drifted from the dispatcher's SCRIPTS; "
-        "add the new script(s) to this test's SCRIPTS list so the flag "
-        "conventions are enforced on them too"
+    derived = sorted(
+        m.name
+        for m in pkgutil.iter_modules(skill_scripts.__path__)
+        if not m.name.startswith("_")
+    )
+    assert list(SCRIPTS) == derived, (
+        "the dispatcher's SCRIPTS must equal the sorted non-underscore modules "
+        "of bartleby.skill_scripts; it is no longer a hand-maintained list"
+    )
+    assert SCRIPTS, "the dispatcher must advertise at least one script"
+    assert not any(name.startswith("_") for name in SCRIPTS), (
+        "underscore-prefixed helper modules must never appear in SCRIPTS"
     )
 
 # Scripts that support corpus scoping — each must carry ``--in-documents`` (#408).


### PR DESCRIPTION
Part of #447.

Replace the hand-maintained 23-name `SCRIPTS` tuple in `bartleby/commands/skill.py` with a derivation over the `bartleby.skill_scripts` package — the non-underscore modules, sorted via `pkgutil.iter_modules`. A new skill script is now dispatchable on drop-in with no parallel edit; the `_common`/`_tags` shared helpers stay excluded by the underscore convention. The `UNKNOWN_SKILL`/`MISSING_SKILL` JSON envelopes and `_print_help` are unchanged (only help/error ordering moves from hand-grouped to alphabetical).

**Dispatch-contract test now asserts the derivation.** The #411 guard in `tests/test_skill_flag_conventions.py` previously kept its *own* hand-copied `SCRIPTS` roster and `test_guard_roster_matches_dispatcher` asserted the two hand-copies agreed — recreating the very duplication this issue removes. The test now imports `SCRIPTS` from the dispatcher (one source of truth) for its parametrized convention guards, and `test_dispatcher_roster_derives_from_package` asserts the derivation *property* itself: `SCRIPTS` equals the sorted non-underscore modules of `bartleby.skill_scripts`, is non-empty, and contains no underscore-prefixed names.

Ships `docs/decisions/GH-0443-derive-scripts-registry-0001.md` (README.md left for the stage-manager).

**Net line delta:** code −7 (skill.py +14/−24, test +24/−21); plus the +67-line decision-log entry.

Gate: `uv run pytest` → 927 passed.