### PR TITLE
ingestion: #434 delete dead members in ingest pipeline

### DIFF
--- a/bartleby/ingest/chunk.py
+++ b/bartleby/ingest/chunk.py
@@ -1,6 +1,6 @@
 """Convert + chunk facade for non-PDF, non-image files.
 
-PDFs are dispatched by ``bartleby.commands.scribe`` directly to the pdfplumber
+PDFs are dispatched by ``bartleby.ingest.parsers`` directly to the pdfplumber
 or docling backends; standalone image files go through the image pipeline.
 This module covers HTML / Markdown (via docling) and plain text.
 """

--- a/bartleby/ingest/edgar.py
+++ b/bartleby/ingest/edgar.py
@@ -32,7 +32,7 @@ _ENVELOPE_MARKERS = (b"<SEC-DOCUMENT>", b"<SEC-HEADER>")
 _DOCUMENT_RE = re.compile(r"<DOCUMENT>(.*?)</DOCUMENT>", re.DOTALL)
 _TEXT_RE = re.compile(r"<TEXT>(.*?)</TEXT>", re.DOTALL)
 _META_RE = re.compile(
-    r"^<(TYPE|SEQUENCE|FILENAME|DESCRIPTION)>(.*)$", re.MULTILINE
+    r"^<(TYPE|FILENAME)>(.*)$", re.MULTILINE
 )
 
 # Some bodies wrap their real payload in an <XBRL>/<XML> shell inside <TEXT>.
@@ -51,9 +51,7 @@ _HTML_OPENERS = ("<html", "<!doctype", "<?xml", "<xbrl", "<div", "<table", "<spa
 @dataclass
 class InnerDocument:
     type: str | None
-    sequence: str | None
     filename: str | None
-    description: str | None
     text: str
 
 
@@ -86,9 +84,7 @@ def parse(raw: bytes) -> list[InnerDocument]:
         docs.append(
             InnerDocument(
                 type=meta.get("type"),
-                sequence=meta.get("sequence"),
                 filename=meta.get("filename"),
-                description=meta.get("description"),
                 text=body,
             )
         )

--- a/bartleby/ingest/parsers.py
+++ b/bartleby/ingest/parsers.py
@@ -197,13 +197,14 @@ def _parse_html_sec2md(
     """
     if on_stage is not None:
         on_stage("extracting")
-    sections = sec2md_pipeline.convert_sections(archived)
+    file_bytes = archived.read_bytes()
+    sections = sec2md_pipeline.convert_sections_bytes(file_bytes)
     if sections:
         return _parse_html_sec2md_split(
-            archived, sections, file_hash=file_hash, file_name=file_name,
-            on_stage=on_stage,
+            archived, sections, file_bytes=file_bytes,
+            file_hash=file_hash, file_name=file_name, on_stage=on_stage,
         )
-    result = sec2md_pipeline.convert(archived)
+    result = sec2md_pipeline.convert_bytes(file_bytes)
     if on_stage is not None and result.chunks:
         on_stage("embedding")
     chunks = _build_sec2md_chunks(result)
@@ -217,6 +218,7 @@ def _parse_html_sec2md_split(
     archived: Path,
     sections: list,
     *,
+    file_bytes: bytes,
     file_hash: str,
     file_name: str,
     on_stage: Callable[[str], None] | None = None,
@@ -228,7 +230,6 @@ def _parse_html_sec2md_split(
     is one atomic write unit — the Writer persists the container last."""
     if on_stage is not None:
         on_stage("embedding")
-    file_bytes = archived.read_bytes()
     parsed_sections: list[ParsedSection] = []
     total_tokens = 0
     for sec in sections:

--- a/bartleby/ingest/pdfplumber.py
+++ b/bartleby/ingest/pdfplumber.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import io
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
 
 import pdfplumber
 from PIL import Image
@@ -93,8 +92,7 @@ class PdfPage:
     page_number: int           # 1-indexed
     text: str                  # extracted text (may be empty, OCR, or raw PDF text)
     content_type: str | None   # 'text' | 'ocr' | None (caller routes None pages to VLM)
-    is_sparse: bool
-    page_render_png: bytes | None  # populated only when is_sparse
+    page_render_png: bytes | None  # populated only when the page is sparse
     embedded_images: list[EmbeddedImage] = field(default_factory=list)
 
 
@@ -110,25 +108,18 @@ def convert(
     *,
     sparse_text_threshold: int,
     ocr_min_confidence: int,
-    on_progress: Callable[[int, int], None] | None = None,
 ) -> PdfResult:
     """Extract text + embedded images from a PDF, with OCR fallback for sparse pages.
 
-    OCR runs inline per-page so each page is fully resolved before its
-    ``on_progress`` tick fires — the progress bar never lies about being done
-    while Tesseract grinds in the background.
-
-    ``on_progress(pages_done, total)`` is called once with ``(0, total)`` after
-    the PDF is opened so callers can size a progress bar, then again after
-    every page with ``(page_number, total)``.
+    OCR runs inline per-page so each page is fully resolved before the caller
+    sees it — the page is never reported done while Tesseract grinds in the
+    background.
     """
     pages: list[PdfPage] = []
     full_text_parts: list[str] = []
 
     with pdfplumber.open(str(path)) as pdf:
         page_count = len(pdf.pages)
-        if on_progress is not None:
-            on_progress(0, page_count)
 
         for ix, page in enumerate(pdf.pages):
             page_number = ix + 1
@@ -183,13 +174,9 @@ def convert(
                 page_number=page_number,
                 text=text,
                 content_type=content_type,
-                is_sparse=is_sparse,
                 page_render_png=page_render_png,
                 embedded_images=embedded_images,
             ))
-
-            if on_progress is not None:
-                on_progress(page_number, page_count)
 
     return PdfResult(
         full_text="\n\f\n".join(full_text_parts),

--- a/bartleby/ingest/sec2md.py
+++ b/bartleby/ingest/sec2md.py
@@ -87,15 +87,6 @@ def is_ixbrl(path: Path) -> bool:
     return _IXBRL_MARKER in head
 
 
-def convert(path: Path) -> Sec2mdResult:
-    """Convert one iXBRL `.htm`/`.html` filing on disk into chunks.
-
-    Thin wrapper over :func:`convert_bytes` — sec2md doesn't accept file
-    paths, so we read the bytes off disk and hand them over.
-    """
-    return convert_bytes(path.read_bytes())
-
-
 def convert_bytes(html: bytes) -> Sec2mdResult:
     """Convert iXBRL/SEC HTML bytes into chunks ready for embedding.
 
@@ -138,7 +129,7 @@ def convert_bytes(html: bytes) -> Sec2mdResult:
     )
 
 
-def convert_sections(path: Path) -> list[Sec2mdSection]:
+def convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
     """Split a TOC-anchored filing into per-section conversions (#254).
 
     Returns one :class:`Sec2mdSection` per internal anchor the table of contents
@@ -151,10 +142,6 @@ def convert_sections(path: Path) -> list[Sec2mdSection]:
     top-level ancestors of each anchor target, so every byte of content lands in
     exactly one section and nothing is duplicated or dropped.
     """
-    return _convert_sections_bytes(path.read_bytes())
-
-
-def _convert_sections_bytes(html: bytes) -> list[Sec2mdSection]:
     _require_sec2md()
     from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
 

--- a/bartleby/ingest/summarize.py
+++ b/bartleby/ingest/summarize.py
@@ -44,7 +44,6 @@ class SummaryResult:
     description: str
     text: str
     model: str
-    truncated_from_tokens: int | None  # None when not truncated
     authored_date: str | None  # ISO 8601, NULL when not stated or malformed
 
 
@@ -109,6 +108,5 @@ def summarize(
         description=summary.description,
         text=text,
         model=model,
-        truncated_from_tokens=total_tokens if truncated else None,
         authored_date=normalize_authored_date(summary.authored_date),
     )

--- a/bartleby/ingest/writer.py
+++ b/bartleby/ingest/writer.py
@@ -143,7 +143,6 @@ class FailedUnit:
     stage: str
     error: str
     attempts: int
-    last_attempt: str
 
     @property
     def capped(self) -> bool:
@@ -240,40 +239,17 @@ class Writer:
         ).fetchall()
         return [PendingImage(*r) for r in rows]
 
-    def summary_exists(self, document_id: int) -> bool:
-        return self.conn.cursor().execute(
-            "SELECT 1 FROM summaries WHERE document_id = ?", (document_id,)
-        ).fetchone() is not None
-
-    def summarizable_chunk_count(self, document_id: int) -> int:
-        """Indexed chunks attributable to a document: its own document chunks
-        plus image chunks joined through ``document_images``.
-
-        Zero means there's nothing real to summarize (an image-only doc whose
-        images carry no OCR/description, say) — the summary stage skips such a
-        doc rather than feed the model trace garbage (issue #80), and it counts
-        as summary-complete.
-        """
-        return self.conn.cursor().execute(
-            "SELECT "
-            "  (SELECT COUNT(*) FROM chunks "
-            "   WHERE source_kind = 'document' AND source_id = ?) "
-            "+ (SELECT COUNT(*) FROM chunks c "
-            "     JOIN document_images di ON di.image_id = c.source_id "
-            "   WHERE c.source_kind = 'image' AND di.document_id = ?)",
-            (document_id, document_id),
-        ).fetchone()[0]
-
     def documents_needing_summary(self) -> list[PendingSummary]:
         """Every parsed document that still owes a summary: no ``summaries`` row
         yet, and at least one indexed (summarizable) chunk.
 
         This is the work-list for the summarize pass (issue #167), which runs
         after the parse/caption drain rather than inline per document. The
-        ``> 0`` chunk guard mirrors :meth:`summarizable_chunk_count`, so an
-        image-only doc with nothing extractable is never offered to the model
-        (issue #80) and isn't counted as owed. Capped documents *are* returned —
-        the pass surfaces them as still-incomplete instead of dropping them.
+        ``> 0`` chunk guard (its own document chunks plus image chunks joined
+        through ``document_images``) means an image-only doc with nothing
+        extractable is never offered to the model (issue #80) and isn't counted
+        as owed. Capped documents *are* returned — the pass surfaces them as
+        still-incomplete instead of dropping them.
         """
         rows = self.conn.cursor().execute(
             "SELECT d.document_id, d.file_hash, d.file_name "
@@ -298,8 +274,9 @@ class Writer:
         image-only doc has no document chunks). We build from whatever indexed
         chunks exist so the summarizer always sees real, indexed content —
         never raw trace text, which makes the model confabulate (issue #80).
-        Callers gate on :meth:`summarizable_chunk_count` > 0, so this never
-        returns empty in practice.
+        Callers gate on the same ``> 0`` chunk count as
+        :meth:`documents_needing_summary`, so this never returns empty in
+        practice.
         """
         cur = self.conn.cursor()
         img_rows = cur.execute(
@@ -590,7 +567,7 @@ class Writer:
     def failures(self) -> list[FailedUnit]:
         """Every still-unresolved failed unit, oldest attempt first."""
         rows = self.conn.cursor().execute(
-            "SELECT file_hash, file_name, stage, error, attempts, last_attempt "
+            "SELECT file_hash, file_name, stage, error, attempts "
             "FROM failed_ingests ORDER BY last_attempt, file_name"
         ).fetchall()
         return [FailedUnit(*r) for r in rows]

--- a/tests/test_ingest_edgar.py
+++ b/tests/test_ingest_edgar.py
@@ -100,8 +100,6 @@ def test_parse_splits_inner_documents():
     assert types == ["10-K", "EX-99.1", "GRAPHIC", "EX-101.INS"]
     first = docs[0]
     assert first.filename == "acme-10k.htm"
-    assert first.sequence == "1"
-    assert first.description == "FORM 10-K"
     assert "Risk factors and revenue figures." in first.text
 
 
@@ -134,14 +132,13 @@ def test_classify_routes_each_inner_document():
 
 def test_classify_skips_empty():
     assert edgar.classify(
-        InnerDocument(type="10-K", sequence="1", filename="a.htm",
-                      description=None, text="")
+        InnerDocument(type="10-K", filename="a.htm", text="")
     ) == "skip"
 
 
 def test_classify_html_by_body_sniff_when_filename_uninformative():
     doc = InnerDocument(
-        type="10-K", sequence="1", filename=None, description=None,
+        type="10-K", filename=None,
         text="<?xml version='1.0'?>\n<html xmlns:ix='...'>...</html>",
     )
     assert edgar.classify(doc) == "html"
@@ -149,7 +146,7 @@ def test_classify_html_by_body_sniff_when_filename_uninformative():
 
 def test_classify_skips_uuencoded_without_filename_hint():
     doc = InnerDocument(
-        type="GRAPHIC", sequence="1", filename=None, description=None,
+        type="GRAPHIC", filename=None,
         text="begin 644 image\nM_]C_X``02D9)\nend",
     )
     assert edgar.classify(doc) == "skip"
@@ -333,7 +330,7 @@ def _write(tmp_path, name, content: bytes):
 
 
 def test_convert_sections_splits_toc_anchored_filing():
-    sections = sec2md._convert_sections_bytes(_ANCHORED_FILING)
+    sections = sec2md.convert_sections_bytes(_ANCHORED_FILING)
     assert [s.anchor_id for s in sections] == [
         "sec_business", "sec_risk", "sec_glossary",
     ]
@@ -348,7 +345,7 @@ def test_convert_sections_splits_toc_anchored_filing():
 
 
 def test_convert_sections_returns_empty_without_toc():
-    assert sec2md._convert_sections_bytes(_UNANCHORED_FILING) == []
+    assert sec2md.convert_sections_bytes(_UNANCHORED_FILING) == []
 
 
 def test_convert_sections_ignores_dangling_anchors():
@@ -361,14 +358,14 @@ def test_convert_sections_ignores_dangling_anchors():
 <h2 id="real">Real</h2>
 <p>This is the only anchor that actually resolves to a target in the body here.</p>
 </body></html>"""
-    assert sec2md._convert_sections_bytes(html) == []
+    assert sec2md.convert_sections_bytes(html) == []
 
 
 def test_convert_sections_emits_preamble_for_pre_toc_content():
     """Body content before the first TOC target (the EDGAR cover page) lands in a
     synthetic order-0 preamble section rather than being silently dropped (BUG 1).
     The TOC nav block itself is not re-indexed as preamble."""
-    sections = sec2md._convert_sections_bytes(_PREAMBLE_FILING)
+    sections = sec2md.convert_sections_bytes(_PREAMBLE_FILING)
     assert sections[0].anchor_id == sec2md._PREAMBLE_ANCHOR_ID
     assert sections[0].order == 0
     # The cover-page facts are searchable in the preamble section's chunks.
@@ -386,7 +383,7 @@ def test_convert_sections_does_not_duplicate_out_of_document_order_anchors():
     """A TOC that lists anchors out of document order is sliced in DOCUMENT order,
     so no section's slice runs to end-of-body and duplicates a later section's
     content (BUG 2a)."""
-    sections = sec2md._convert_sections_bytes(_OUT_OF_ORDER_FILING)
+    sections = sec2md.convert_sections_bytes(_OUT_OF_ORDER_FILING)
     # Sliced in document order regardless of TOC link order.
     assert [s.anchor_id for s in sections] == ["sec_business", "sec_risk"]
     # The risk paragraph ("explode") appears in exactly one section, once.
@@ -404,7 +401,7 @@ def test_convert_sections_ignores_in_text_cross_reference_links():
     """In-text cross-references ("see Risk Factors") and "back to top" links do
     not create spurious sections — only the contiguous TOC link cluster does
     (BUG 2b)."""
-    sections = sec2md._convert_sections_bytes(_CROSSREF_FILING)
+    sections = sec2md.convert_sections_bytes(_CROSSREF_FILING)
     assert [s.anchor_id for s in sections] == [
         "sec_business", "sec_risk", "sec_glossary",
     ]
@@ -421,7 +418,7 @@ def test_convert_sections_keeps_cover_text_sharing_div_with_toc():
     but the cover prose is NOT excised with the nav block — only the pure-nav
     portion is dropped, so the cover-page facts survive in the preamble (DATA-LOSS
     defect: the old rule excised the whole shared div)."""
-    sections = sec2md._convert_sections_bytes(_TOC_SHARES_DIV_FILING)
+    sections = sec2md.convert_sections_bytes(_TOC_SHARES_DIV_FILING)
     # It still splits into the two real sections (preceded by the preamble).
     assert [s.anchor_id for s in sections] == [
         sec2md._PREAMBLE_ANCHOR_ID, "sec_business", "sec_risk",
@@ -442,7 +439,7 @@ def test_convert_sections_does_not_split_on_inline_content_links():
     """Two adjacent forward links INLINE in a content paragraph (not a dedicated
     nav block) are prose cross-references, not a TOC: the file does NOT mis-split
     AND the host paragraph's prose is not dropped (DATA-LOSS defect)."""
-    sections = sec2md._convert_sections_bytes(_INLINE_LINKS_FILING)
+    sections = sec2md.convert_sections_bytes(_INLINE_LINKS_FILING)
     # No TOC → ingest whole.
     assert sections == []
     # And nothing is lost: converting the file whole keeps the host paragraph's
@@ -458,7 +455,7 @@ def test_convert_sections_splits_double_linked_toc():
     anchor still forms one contiguous run and splits into the correct sections —
     deduping the final target list must not let duplicate links break run
     contiguity (REGRESSION the rework introduced)."""
-    sections = sec2md._convert_sections_bytes(_DOUBLE_LINKED_TOC_FILING)
+    sections = sec2md.convert_sections_bytes(_DOUBLE_LINKED_TOC_FILING)
     assert [s.anchor_id for s in sections] == [
         "sec_business", "sec_risk", "sec_glossary",
     ]

--- a/tests/test_ingest_pdfplumber.py
+++ b/tests/test_ingest_pdfplumber.py
@@ -68,7 +68,7 @@ def test_convert_text_only_pdf(tmp_path):
     assert len(result.pages) == 2
     assert "page one" in result.pages[0].text.lower()
     assert "page two" in result.pages[1].text.lower()
-    assert all(not p.is_sparse for p in result.pages)
+    assert all(p.content_type == "text" for p in result.pages)
     assert all(p.page_render_png is None for p in result.pages)
     assert all(p.embedded_images == [] for p in result.pages)
     # full_text concatenates everything.
@@ -83,7 +83,7 @@ def test_convert_extracts_embedded_image(tmp_path):
 
     assert result.page_count == 1
     page = result.pages[0]
-    assert not page.is_sparse
+    assert page.content_type == "text"
     # At least one embedded image is detected and cropped to PNG bytes.
     assert len(page.embedded_images) >= 1
     img = page.embedded_images[0]
@@ -101,7 +101,6 @@ def test_convert_marks_sparse_pages_and_saves_render(tmp_path):
 
     assert result.page_count == 1
     page = result.pages[0]
-    assert page.is_sparse
     # OCR on a page with just "abc" cannot clear the 100-char threshold, so
     # content_type=None and text="" — the caller will route the page render
     # through the VLM instead.
@@ -146,14 +145,12 @@ def test_convert_degrades_to_vlm_when_ocr_raises(tmp_path, monkeypatch):
 
     # Sparse page: OCR raised → routed to the VLM (content_type None, no text),
     # with its render preserved so the caller can hand it to the VLM.
-    assert sparse_page.is_sparse
     assert sparse_page.content_type is None
     assert sparse_page.text == ""
     assert sparse_page.page_render_png is not None
     assert sparse_page.page_render_png.startswith(b"\x89PNG")
 
     # Non-sparse page is untouched by the OCR failure — still chunks as text.
-    assert not text_page.is_sparse
     assert text_page.content_type == "text"
     assert "plenty of text" in text_page.text.lower()
 
@@ -287,22 +284,3 @@ def test_reject_if_html_passes_a_real_pdf(tmp_path):
     _text_pdf(src, ["A genuine PDF with plenty of text. " * 4])
     # A valid PDF starts with %PDF — no exception.
     pp.reject_if_html(src)
-
-
-def test_convert_calls_on_progress_with_total_then_each_page(tmp_path):
-    src = tmp_path / "multi.pdf"
-    _text_pdf(src, [
-        ("Page one body. " * 12),
-        ("Page two body. " * 12),
-        ("Page three body. " * 12),
-    ])
-    seen: list[tuple[int, int]] = []
-    pp.convert(
-        src,
-        sparse_text_threshold=100,
-        ocr_min_confidence=30,
-        on_progress=lambda done, total: seen.append((done, total)),
-    )
-    # First call signals the total; later calls report each page.
-    assert seen[0] == (0, 3)
-    assert seen[1:] == [(1, 3), (2, 3), (3, 3)]

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -136,7 +136,7 @@ def test_persist_summary_and_caption_stamp_run(project_conn):
     writer.persist_summary(
         document_id,
         SummaryResult(title="T", description="D", text="S", model="m",
-                      truncated_from_tokens=None, authored_date=None),
+                      authored_date=None),
         [_chunk("summary chunk")],
     )
 
@@ -244,7 +244,7 @@ def test_persist_summary_clears_failed_ingest(project_conn):
     writer.persist_summary(
         document_id,
         SummaryResult(title="T", description="D", text="S", model="m",
-                      truncated_from_tokens=None, authored_date=None),
+                      authored_date=None),
         [_chunk("summary chunk")],
     )
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -50,7 +50,6 @@ def test_summarize_short_doc_no_truncation_note():
     assert result.title == "Doc Title"
     assert result.description == "A one-line hook describing the document."
     assert result.text == "this is a summary"
-    assert result.truncated_from_tokens is None
     assert p.captured_text == "short document"
 
 
@@ -86,7 +85,6 @@ def test_summarize_long_doc_truncates_input_and_appends_note():
         max_summarize_tokens=10,
     )
 
-    assert result.truncated_from_tokens == total
     # Truncation note is appended to text only (title/description are unaffected).
     assert result.title == "Doc Title"
     assert result.text.startswith("summary body")


### PR DESCRIPTION
Part of #447.

Pure shrink (net **-81 lines**), zero user-visible behavior change; SCHEMA_VERSION stays 9. Each member grep-verified dead across bartleby/, web/, scripts/, and tests/ before removal.

Deleted:
- `pdfplumber.convert` `on_progress` parameter (no production caller; superseded by per-document worker-lane progress) + now-unused `Callable` import
- `PdfPage.is_sparse` write-only field (consumers derive from content_type/page_render_png)
- `Writer.summary_exists` / `Writer.summarizable_chunk_count` dead methods; reworded two stale docstring cross-refs to describe the inline `>0` guard
- `InnerDocument.sequence` / `.description` write-only fields; narrowed `_META_RE` to TYPE|FILENAME
- `SummaryResult.truncated_from_tokens` write-only field
- `FailedUnit.last_attempt` write-only field + its SELECT column (DB column + ORDER BY retained)
- `sec2md.convert` / `convert_sections` single-caller path facades; renamed `_convert_sections_bytes` -> `convert_sections_bytes`; parsers now reads file bytes once
- corrected stale `chunk.py` dispatch docstring (commands.scribe -> ingest.parsers)

No member turned out to be actually-referenced; all targets confirmed dead. Full suite green (926 passed); v0.9.2 guard tests untouched (29 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)