### PR TITLE
skill: #437 collapse scope-filter indirection chain in _tags.py

### DIFF
--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -136,8 +136,8 @@ def resolve_documents(
 def resolve_tag_names(conn, names: list[str]) -> list[int]:
     """Resolve tag names → tag_ids; raise ``TAG_NOT_FOUND`` on any miss.
 
-    Order is preserved across the input list. Used by `list_documents`,
-    `search`, and any future consumer of `--tag`.
+    Order is preserved across the input list. The named query unit behind
+    ``resolve_scope``'s ``--tag`` intersection.
     """
     placeholders = ",".join("?" * len(names))
     rows = conn.cursor().execute(
@@ -218,7 +218,7 @@ class Scope:
     means "whole corpus" (no filter), ``[]`` means "a filter was applied but it
     matched nothing" (short-circuit to zero results). The remaining fields echo
     the *requested* filter so a response can be self-describing via
-    ``filters_dict``.
+    ``echo_into``.
     """
 
     document_ids: list[int] | None
@@ -244,34 +244,24 @@ class Scope:
             or self.date_active
         )
 
-    def filters_dict(self) -> dict | None:
-        """The self-describing ``filters`` echo, or ``None`` when unfiltered.
-
-        Shared by ``scan`` and ``describe_corpus`` so both surface scope
-        identically. ``list_documents`` predates this and keeps its own
-        top-level shape (the issue mandates no behavior change there).
-        """
-        if not self.active:
-            return None
-        return {
-            "tags": self.tags,
-            "in_documents": self.in_documents,
-            "file_like": self.file_like,
-            "authored_after": self.authored_after,
-            "authored_before": self.authored_before,
-            "include_nulls": self.include_nulls,
-            "excluded_null_dated": self.excluded_null_dated,
-        }
-
     def echo_into(self, env: dict) -> dict:
-        """Attach the ``filters`` echo to ``env`` in place when scoped; return it.
+        """Attach the self-describing ``filters`` echo to ``env`` in place when
+        scoped; return it.
 
-        Folds the "compute filters_dict, set the key only if non-None" dance that
-        ``scan`` and ``describe_corpus`` would otherwise each repeat.
+        Folds the "set the ``filters`` key only when a filter is active" dance
+        that ``search``, ``scan``, ``describe_corpus``, and ``list_documents``
+        would otherwise each repeat.
         """
-        filters = self.filters_dict()
-        if filters is not None:
-            env["filters"] = filters
+        if self.active:
+            env["filters"] = {
+                "tags": self.tags,
+                "in_documents": self.in_documents,
+                "file_like": self.file_like,
+                "authored_after": self.authored_after,
+                "authored_before": self.authored_before,
+                "include_nulls": self.include_nulls,
+                "excluded_null_dated": self.excluded_null_dated,
+            }
         return env
 
     def restrict_in(self, col: str) -> tuple[str, list]:

--- a/docs/decisions/GH-0437-collapse-scope-filter-chain-0001.md
+++ b/docs/decisions/GH-0437-collapse-scope-filter-chain-0001.md
@@ -1,0 +1,59 @@
+# GH-0437 — collapse the single-caller scope-filter indirection chain in _tags.py
+
+Issue #437 (tier-2 dry-sweep judgment bet) finished the residue left after #432
+inlined `intersect_tag_filter` / `intersect_file_like_filter` into
+`resolve_scope`: it folds `Scope.filters_dict` into its sole caller
+`Scope.echo_into` and corrects two docstrings that still advertised consumers
+which no longer exist.
+
+## What changed
+
+- `Scope.filters_dict` (the 18-line "build the self-describing `filters` echo,
+  or `None` when unfiltered" method) is gone. Its dict literal now lives inline in
+  `Scope.echo_into`, guarded directly by `if self.active:` — `echo_into` was its
+  only caller (whole-repo grep), and every script that surfaces a filters echo
+  (`search`, `scan`, `describe_corpus`, `list_documents`) calls `echo_into`, never
+  `filters_dict`.
+- `resolve_tag_names`'s docstring no longer claims "Used by `list_documents`,
+  `search`, and any future consumer of `--tag`." Its only caller is
+  `resolve_scope` (those scripts route their `--tag` exclusively through
+  `resolve_scope`); the docstring now names it the query unit behind
+  `resolve_scope`'s `--tag` intersection.
+- The `Scope` class docstring's "self-describing via `filters_dict`" now points at
+  `echo_into`, the surviving entry point.
+
+No call sites changed: the four consumers already called `echo_into`. The emitted
+`filters` dict is byte-for-byte identical — same keys, same order, same
+`if self.active` gate — so scope echo semantics are unchanged.
+
+## Why collapsing is correct
+
+`intersect_tag_filter`, `intersect_file_like_filter`, and `filters_dict` were
+built as reusable seams: the two intersect helpers so scripts could compose
+tag/file-like filtering individually, `filters_dict` as a shared echo formatter.
+But `resolve_scope` became the single documented entry point for scoping, and
+every current consumer (`search.py`, `scan.py`, `list_documents.py`,
+`describe_corpus.py`) routes through it; the only `filters_dict` caller is
+`echo_into` directly below it. The seams each had exactly one caller and
+docstrings naming consumers that had migrated away — speculative generality.
+
+After this collapse there is no standalone tag-intersection, file-like-intersection,
+or filters-echo helper. A future script wanting one of those pieces *without* full
+scope resolution would have to call `resolve_scope` or re-extract a few lines. That
+is the right trade: all four current consumers already use `resolve_scope` as the
+single entry point, the underlying named query units (`documents_with_any_tag`,
+`documents_matching_file_like`, `resolve_tag_names`) remain available, and this
+repo's smallest-fix culture extracts the seam when the second caller actually
+arrives rather than carrying it speculatively.
+
+## What was NOT touched
+
+The memory wall is untouched. `memory_enabled=0` excluding prior-session findings
+is enforced in `search.py` at script level (load-bearing per CLAUDE.md); this change
+is confined to `_tags.py` scope-echo plumbing and does not reach that path. The
+`document_ids` resolution (the actual filter set, tags ∩ in_documents ∩ file_like ∩
+date bounds) is unchanged — only the echo-formatting indirection collapsed.
+
+---
+*Filed from the 2026-06-11 dry sweep (dead/wet/bloat audit; every item adversarially
+verified by an independent defender pass).*


### PR DESCRIPTION
Part of #447.

Finishes the residue left after #432 inlined `intersect_tag_filter` / `intersect_file_like_filter` into `resolve_scope`:

- **Inlined `Scope.filters_dict` into `Scope.echo_into`** (its sole caller). The emitted `filters` dict is **byte-for-byte identical** — same seven keys, same order, same `if self.active` gate. All four consumers (`search`, `scan`, `describe_corpus`, `list_documents`) already call `echo_into`, never `filters_dict`.
- **Corrected two stale docstrings**: `resolve_tag_names`'s "Used by list_documents, search" (its only caller is now `resolve_scope`) and the `Scope` class docstring's `filters_dict` reference (now `echo_into`).

**Scope semantics unchanged** — `document_ids` resolution (tags ∩ in_documents ∩ file_like ∩ date bounds) is identical; only the echo-formatting indirection collapsed. **Memory wall untouched** — `memory_enabled=0` enforcement lives in `search.py` at script level and is not on this path.

Ships its own decision-log entry `docs/decisions/GH-0437-collapse-scope-filter-chain-0001.md` (README not touched).

Net **-10 lines** in `_tags.py` (28 deleted, 18 added). `uv run pytest`: **925 passed**.