### PR TITLE
tests: #431 consolidate repeated test setup into shared helpers

### DIFF
--- a/tests/_skill_fixtures.py
+++ b/tests/_skill_fixtures.py
@@ -8,6 +8,7 @@ import bartleby.project
 from bartleby.db.chunks import (
     ChunkInput,
     insert_document_chunks,
+    insert_finding_chunks,
     insert_image_chunks,
     insert_summary_chunks,
 )
@@ -17,6 +18,51 @@ from bartleby.db.schema import EMBEDDING_DIM
 
 def _emb(seed: float = 0.0) -> list[float]:
     return [seed + 0.001 * j for j in range(EMBEDDING_DIM)]
+
+
+@pytest.fixture(autouse=True)
+def mock_embed(monkeypatch):
+    """Autouse stub so finding/summary skill tests never reach the real BGE model.
+
+    Patches the names ``skill_scripts._common`` looks up: a deterministic
+    ``embed_texts`` and a single-``ChunkRow`` ``chunk_markdown_string`` (the
+    latter keeps chunk_count assertions stable). Only active in modules that
+    import it.
+    """
+    monkeypatch.setattr(
+        "bartleby.ingest.embed.embed_texts",
+        lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
+    )
+    from bartleby.ingest.chunk import ChunkRow
+    monkeypatch.setattr(
+        "bartleby.ingest.chunk.chunk_markdown_string",
+        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
+    )
+
+
+def seed_finding(conn, session_id, *, title="A finding", description="hook",
+                 body="body", cited_chunk_ids=()) -> tuple[int, list[int]]:
+    """Insert a finding (+ one body chunk, + optional citations) directly.
+
+    Returns ``(finding_id, body_chunk_ids)``. The body chunk goes through the
+    typed ``insert_finding_chunks`` helper (chunks discipline).
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO findings (session_id, title, description, body) "
+        "VALUES (?, ?, ?, ?)",
+        (session_id, title, description, body),
+    )
+    finding_id = conn.last_insert_rowid()
+    body_chunk_ids = insert_finding_chunks(conn, finding_id, [
+        ChunkInput(text=body, embedding=_emb(), chunk_index=0),
+    ])
+    for chunk_id in cited_chunk_ids:
+        cur.execute(
+            "INSERT INTO finding_citations (finding_id, chunk_id) VALUES (?, ?)",
+            (finding_id, chunk_id),
+        )
+    return finding_id, body_chunk_ids
 
 
 def assert_chunk_tables_consistent(conn) -> None:

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -282,27 +282,10 @@ def test_scribe_writes_summary_when_provider_configured(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):
     # Configure summarization in the loaded config.
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: {
-            "summary_depth": "one-shot",
-            "provider": "anthropic",
-            "model": "test-model",
-            "temperature": 0.0,
-            "max_summarize_tokens": 50_000,
-        },
-    )
-
-    stub = _StubProvider(text="## Stub summary\n\nKey points appear here.")
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider",
-        lambda name, **kwargs: stub,
-    )
-    # Bypass docling for the summary chunking too — return one chunk.
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
+    stub = _summary_pipeline(
+        monkeypatch,
+        _StubProvider(text="## Stub summary\n\nKey points appear here."),
+        model="test-model",
     )
 
     src = _write_txt(tmp_path / "doc.txt", "Hello world summarized.")
@@ -352,23 +335,7 @@ def test_scribe_summarizes_existing_document_on_later_run(
 
     # Second run: summaries now configured. The file is already parsed (so it's
     # classified as skipped), yet the summarize pass still summarizes it.
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: {
-            "summary_depth": "one-shot", "provider": "anthropic",
-            "model": "test-model", "temperature": 0.0,
-            "max_summarize_tokens": 50_000,
-        },
-    )
-    stub = _StubProvider()
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider", lambda name, **kwargs: stub,
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
+    stub = _summary_pipeline(monkeypatch, model="test-model")
 
     scribe.main(project="test_proj", files=str(src))
     assert stub.calls == 1  # summarized exactly once
@@ -742,24 +709,42 @@ def _summary_config(**overrides):
     }
 
 
+def _summary_pipeline(monkeypatch, provider=None, **config_overrides):
+    """Wire up the single-provider summary pipeline in one call.
+
+    Performs the three setattrs the summarize-pass tests share: a summaries-on
+    ``load_config`` (with ``config_overrides`` like ``model=`` or
+    ``html_converter=``), a ``get_provider`` returning ``provider`` (a fresh
+    ``_StubProvider()`` by default), and the single-``ChunkRow``
+    ``chunk_markdown_string`` stub. Returns ``provider`` so callers can assert
+    on it (e.g. ``stub.calls``). Dual-provider (vision) tests wire their own
+    branching resolver and don't use this.
+    """
+    if provider is None:
+        provider = _StubProvider()
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.load_config",
+        lambda: _summary_config(**config_overrides),
+    )
+    monkeypatch.setattr(
+        "bartleby.ingest.resolve.get_provider", lambda name, **kwargs: provider,
+    )
+    from bartleby.ingest.chunk import ChunkRow
+    monkeypatch.setattr(
+        "bartleby.ingest.summary.chunk_markdown_string",
+        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
+    )
+    return provider
+
+
 def test_scribe_summarizes_many_documents_concurrently_in_one_run(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):
     """#188: summarization is its own concurrent pass. Several documents parsed in
     one run all get summarized through the summarize thread pool — not just the
     first — with the DB write staying on the single Writer thread."""
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: _summary_config(summarize_workers=3),
-    )
-    stub = _StubProvider(text="summary body")
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider", lambda name, **k: stub,
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
+    _summary_pipeline(
+        monkeypatch, _StubProvider(text="summary body"), summarize_workers=3,
     )
 
     srcs = [
@@ -809,18 +794,7 @@ def test_scribe_one_summary_failure_does_not_block_the_rest(
                 title="t", description="d", text="ok", authored_date=None,
             )
 
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: _summary_config(summarize_workers=3),
-    )
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider", lambda name, **k: _OneFailLLM(),
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
+    _summary_pipeline(monkeypatch, _OneFailLLM(), summarize_workers=3)
 
     srcs = [
         str(_write_txt(tmp_path / f"d{i}.txt", f"Body of document {i}."))
@@ -1594,24 +1568,9 @@ def test_scribe_interleaves_image_chunks_into_summary_input(
 def test_scribe_persists_authored_date_from_summary(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: {
-            "summary_depth": "one-shot",
-            "provider": "anthropic", "model": "m",
-            "temperature": 0.0, "max_summarize_tokens": 50_000,
-        },
-    )
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider",
-        lambda name, **kwargs: _StubProvider(
-            text="summary body", authored_date="2024-09-12",
-        ),
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
+    _summary_pipeline(
+        monkeypatch,
+        _StubProvider(text="summary body", authored_date="2024-09-12"),
     )
 
     src = _write_txt(tmp_path / "doc.txt", "Dated document body.")
@@ -1873,22 +1832,10 @@ def test_scribe_splits_anchored_edgar_filing_end_to_end(
     """A TOC-anchored iXBRL filing ingested with html_converter=sec2md splits into
     a zero-chunk container + N section documents, each with its own summary; the
     container owes no summary (#254)."""
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: {
-            "summary_depth": "one-shot", "html_converter": "sec2md",
-            "provider": "anthropic", "model": "test-model",
-            "temperature": 0.0, "max_summarize_tokens": 50_000,
-        },
-    )
-    stub = _StubProvider(text="## Section summary\n\nKey points.")
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider", lambda name, **k: stub,
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
+    stub = _summary_pipeline(
+        monkeypatch,
+        _StubProvider(text="## Section summary\n\nKey points."),
+        html_converter="sec2md", model="test-model",
     )
 
     src = _write_txt(tmp_path / "filing.htm", _ANCHORED_IXBRL)
@@ -2450,23 +2397,7 @@ def test_scribe_timings_includes_decoupled_summarize_stage(
     inflated by the second pass (one merged record per document, issue #167)."""
     import json
 
-    monkeypatch.setattr(
-        "bartleby.commands.scribe.load_config",
-        lambda: {
-            "summary_depth": "one-shot", "provider": "anthropic",
-            "model": "test-model", "temperature": 0.0,
-            "max_summarize_tokens": 50_000,
-        },
-    )
-    stub = _StubProvider()
-    monkeypatch.setattr(
-        "bartleby.ingest.resolve.get_provider", lambda name, **kwargs: stub,
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.summary.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
+    stub = _summary_pipeline(monkeypatch, model="test-model")
 
     _write_txt(tmp_path / "a.txt", "First doc with some words.")
     _write_txt(tmp_path / "b.txt", "Second doc with other words.")

--- a/tests/test_skill_delete_finding.py
+++ b/tests/test_skill_delete_finding.py
@@ -7,33 +7,15 @@ import json
 import pytest
 
 from bartleby.skill_scripts import delete_finding, save_finding
-from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.session import start_session
 from tests._skill_fixtures import (  # noqa: F401
     assert_chunk_tables_consistent,
+    mock_embed,
     project_env,
+    seed_finding,
     seeded_project,
 )
-
-
-def _seed_finding_as(conn, session_id, title="Foreign draft") -> int:
-    """Insert a minimal finding owned by ``session_id``; return its id."""
-    conn.cursor().execute(
-        "INSERT INTO findings (session_id, title, description, body) "
-        "VALUES (?, ?, ?, ?)",
-        (session_id, title, "hook", "body"),
-    )
-    finding_id = conn.last_insert_rowid()
-    insert_finding_chunks(conn, finding_id, [
-        ChunkInput(
-            text="body",
-            embedding=[0.01 * i for i in range(EMBEDDING_DIM)],
-            chunk_index=0,
-        ),
-    ])
-    return finding_id
 
 
 def _finding_exists(project, finding_id) -> bool:
@@ -44,19 +26,6 @@ def _finding_exists(project, finding_id) -> bool:
         ).fetchone()[0] == 1
     finally:
         conn.close()
-
-
-@pytest.fixture(autouse=True)
-def mock_embed(monkeypatch):
-    monkeypatch.setattr(
-        "bartleby.ingest.embed.embed_texts",
-        lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.chunk.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
 
 
 def _seed_finding(seeded_project, tmp_path, capsys) -> dict:
@@ -177,7 +146,7 @@ def test_delete_finding_memory_off_other_session(seeded_project, capsys):
             ("author", 1),
         )
         author = conn.last_insert_rowid()
-        finding_id = _seed_finding_as(conn, author)
+        finding_id, _ = seed_finding(conn, author)
     finally:
         conn.close()
 
@@ -201,7 +170,7 @@ def test_delete_finding_memory_off_own_session(seeded_project, capsys):
 
     conn = open_db(project)
     try:
-        finding_id = _seed_finding_as(conn, info["session_id"], title="own")
+        finding_id, _ = seed_finding(conn, info["session_id"], title="own")
     finally:
         conn.close()
 

--- a/tests/test_skill_edit_finding.py
+++ b/tests/test_skill_edit_finding.py
@@ -8,27 +8,12 @@ import pytest
 
 from bartleby.skill_scripts import edit_finding, save_finding
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from tests._skill_fixtures import (  # noqa: F401
     assert_chunk_tables_consistent,
+    mock_embed,
     project_env,
     seeded_project,
 )
-
-
-@pytest.fixture(autouse=True)
-def mock_embed(monkeypatch):
-    # Both scripts share `embed_texts` / `chunk_markdown_string` via _common;
-    # patch there so the test never reaches BAAI.
-    monkeypatch.setattr(
-        "bartleby.ingest.embed.embed_texts",
-        lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.chunk.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
 
 
 def _seed_finding(seeded_project, tmp_path, capsys, *, body_suffix: str = "") -> dict:

--- a/tests/test_skill_list_findings.py
+++ b/tests/test_skill_list_findings.py
@@ -6,36 +6,13 @@ import json
 
 import pytest
 
-from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.skill_scripts import list_findings
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
-
-
-def _emb() -> list[float]:
-    return [0.01 * i for i in range(EMBEDDING_DIM)]
-
-
-def _seed_finding(conn, *, session_id, title, description, body="body",
-                  cited_chunk_ids=()):
-    """Insert a finding (+ optional citations) directly, returning its id."""
-    cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO findings (session_id, title, description, body) "
-        "VALUES (?, ?, ?, ?)",
-        (session_id, title, description, body),
-    )
-    finding_id = conn.last_insert_rowid()
-    insert_finding_chunks(conn, finding_id, [
-        ChunkInput(text=body, embedding=_emb(), chunk_index=0),
-    ])
-    for chunk_id in cited_chunk_ids:
-        cur.execute(
-            "INSERT INTO finding_citations (finding_id, chunk_id) VALUES (?, ?)",
-            (finding_id, chunk_id),
-        )
-    return finding_id
+from tests._skill_fixtures import (  # noqa: F401
+    project_env,
+    seed_finding,
+    seeded_project,
+)
 
 
 def _active_session_id(project):
@@ -63,10 +40,10 @@ def test_list_findings_happy_path(seeded_project, capsys):
             "AND source_id=? ORDER BY chunk_index LIMIT 1",
             (seeded_project["doc_a"],),
         ).fetchone()[0]
-        _seed_finding(conn, session_id=session_id, title="First",
-                      description="oldest", cited_chunk_ids=[doc_chunk])
-        _seed_finding(conn, session_id=session_id, title="Second",
-                      description="newest", cited_chunk_ids=[])
+        seed_finding(conn, session_id=session_id, title="First",
+                     description="oldest", cited_chunk_ids=[doc_chunk])
+        seed_finding(conn, session_id=session_id, title="Second",
+                     description="newest", cited_chunk_ids=[])
     finally:
         conn.close()
 
@@ -95,8 +72,8 @@ def test_list_findings_brief_projects_three_fields(seeded_project, capsys):
             "AND source_id=? ORDER BY chunk_index LIMIT 1",
             (seeded_project["doc_a"],),
         ).fetchone()[0]
-        _seed_finding(conn, session_id=session_id, title="Cited",
-                      description="hook", cited_chunk_ids=[doc_chunk])
+        seed_finding(conn, session_id=session_id, title="Cited",
+                     description="hook", cited_chunk_ids=[doc_chunk])
     finally:
         conn.close()
 
@@ -117,8 +94,8 @@ def test_list_findings_pagination_hint(seeded_project, capsys):
     conn = open_db(project)
     try:
         for i in range(3):
-            _seed_finding(conn, session_id=session_id, title=f"f{i}",
-                          description="x")
+            seed_finding(conn, session_id=session_id, title=f"f{i}",
+                         description="x")
     finally:
         conn.close()
 
@@ -163,7 +140,7 @@ def test_list_findings_memory_off_scopes_to_own_session(seeded_project, capsys):
             ("author", 1),
         )
         author = conn.last_insert_rowid()
-        _seed_finding(conn, session_id=author, title="hidden", description="x")
+        seed_finding(conn, session_id=author, title="hidden", description="x")
     finally:
         conn.close()
 
@@ -171,8 +148,8 @@ def test_list_findings_memory_off_scopes_to_own_session(seeded_project, capsys):
     info = start_session(project, memory_enabled=False)
     conn = open_db(project)
     try:
-        _seed_finding(conn, session_id=info["session_id"],
-                      title="mine", description="y")
+        seed_finding(conn, session_id=info["session_id"],
+                     title="mine", description="y")
     finally:
         conn.close()
 

--- a/tests/test_skill_merge_findings.py
+++ b/tests/test_skill_merge_findings.py
@@ -7,46 +7,15 @@ import json
 import pytest
 
 from bartleby.skill_scripts import merge_findings, save_finding
-from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.session import start_session
 from tests._skill_fixtures import (  # noqa: F401
     assert_chunk_tables_consistent,
+    mock_embed,
     project_env,
+    seed_finding,
     seeded_project,
 )
-
-
-def _seed_finding_as(conn, session_id, title="Foreign draft") -> int:
-    """Insert a minimal finding owned by ``session_id``; return its id."""
-    conn.cursor().execute(
-        "INSERT INTO findings (session_id, title, description, body) "
-        "VALUES (?, ?, ?, ?)",
-        (session_id, title, "hook", "body"),
-    )
-    finding_id = conn.last_insert_rowid()
-    insert_finding_chunks(conn, finding_id, [
-        ChunkInput(
-            text="body",
-            embedding=[0.01 * i for i in range(EMBEDDING_DIM)],
-            chunk_index=0,
-        ),
-    ])
-    return finding_id
-
-
-@pytest.fixture(autouse=True)
-def mock_embed(monkeypatch):
-    monkeypatch.setattr(
-        "bartleby.ingest.embed.embed_texts",
-        lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.chunk.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
 
 
 def _doc_chunk_ids(project, doc_id) -> list[int]:
@@ -350,7 +319,7 @@ def test_merge_memory_off_foreign_source_rejected(seeded_project, tmp_path, caps
             ("author", 1),
         )
         author = conn.last_insert_rowid()
-        foreign_src = _seed_finding_as(conn, author)
+        foreign_src, _ = seed_finding(conn, author)
     finally:
         conn.close()
 

--- a/tests/test_skill_read_chunks.py
+++ b/tests/test_skill_read_chunks.py
@@ -6,27 +6,27 @@ import json
 
 import pytest
 
-from bartleby.db.chunks import ChunkInput, insert_finding_chunks
+from bartleby.db.chunks import ChunkInput
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.session import start_session
 from bartleby.skill_scripts import read_chunks
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
+from tests._skill_fixtures import (  # noqa: F401
+    project_env,
+    seed_finding,
+    seeded_project,
+)
 
 
 def _seed_finding_chunk(conn, *, session_id: int, body: str = "finding body") -> int:
-    """Insert a finding owned by ``session_id`` and return its body chunk_id."""
-    cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO findings (session_id, title, description, body) "
-        "VALUES (?, ?, ?, ?)",
-        (session_id, "secret finding", "hook", body),
-    )
-    finding_id = conn.last_insert_rowid()
-    emb = [0.01 * i for i in range(EMBEDDING_DIM)]
-    [chunk_id] = insert_finding_chunks(
-        conn, finding_id,
-        [ChunkInput(text=body, embedding=emb, chunk_index=0)],
+    """Seed a foreign-walled finding and return its body chunk_id.
+
+    Title is fixed at ``"secret finding"`` because the memory-wall leak tests
+    assert that exact string never appears in a walled response — a different
+    title would make those assertions vacuous.
+    """
+    _, [chunk_id] = seed_finding(
+        conn, session_id=session_id, title="secret finding", body=body,
     )
     return chunk_id
 

--- a/tests/test_skill_read_finding.py
+++ b/tests/test_skill_read_finding.py
@@ -6,41 +6,18 @@ import json
 
 import pytest
 
-from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.skill_scripts import read_finding
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
-
-
-def _emb() -> list[float]:
-    return [0.01 * i for i in range(EMBEDDING_DIM)]
+from tests._skill_fixtures import (  # noqa: F401
+    project_env,
+    seed_finding,
+    seeded_project,
+)
 
 
 def _active_session_id(project):
     from bartleby.session import ensure_active_session
     return ensure_active_session(project)
-
-
-def _seed_finding(conn, *, session_id, title="A finding",
-                  description="one-line hook", body="finding body",
-                  cited_chunk_ids=()):
-    cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO findings (session_id, title, description, body) "
-        "VALUES (?, ?, ?, ?)",
-        (session_id, title, description, body),
-    )
-    finding_id = conn.last_insert_rowid()
-    body_chunk_ids = insert_finding_chunks(conn, finding_id, [
-        ChunkInput(text=body, embedding=_emb(), chunk_index=0),
-    ])
-    for chunk_id in cited_chunk_ids:
-        cur.execute(
-            "INSERT INTO finding_citations (finding_id, chunk_id) VALUES (?, ?)",
-            (finding_id, chunk_id),
-        )
-    return finding_id, body_chunk_ids
 
 
 def _run(capsys, argv):
@@ -63,7 +40,7 @@ def test_read_finding_happy_path(seeded_project, capsys):
             )
         ]
         body = f"Claim one[^{cited[0]}] and claim two[^{cited[1]}]."
-        finding_id, body_chunk_ids = _seed_finding(
+        finding_id, body_chunk_ids = seed_finding(
             conn, session_id=session_id, title="PM25 equity",
             description="who bears the brunt", body=body, cited_chunk_ids=cited,
         )
@@ -112,7 +89,7 @@ def test_read_finding_dangling_citation(seeded_project, capsys):
             )
         ]
         body = f"Live claim[^{cited[0]}] and orphaned claim[^{cited[1]}]."
-        finding_id, _ = _seed_finding(
+        finding_id, _ = seed_finding(
             conn, session_id=session_id, body=body, cited_chunk_ids=cited,
         )
         # Drop the cited document's chunks; ON DELETE CASCADE strips the
@@ -137,7 +114,7 @@ def test_read_finding_no_citations(seeded_project, capsys):
 
     conn = open_db(project)
     try:
-        finding_id, _ = _seed_finding(conn, session_id=session_id)
+        finding_id, _ = seed_finding(conn, session_id=session_id)
     finally:
         conn.close()
 
@@ -169,7 +146,7 @@ def test_read_finding_memory_off_other_session(seeded_project, capsys):
             ("author", 1),
         )
         author = conn.last_insert_rowid()
-        finding_id, _ = _seed_finding(conn, session_id=author)
+        finding_id, _ = seed_finding(conn, session_id=author)
     finally:
         conn.close()
 
@@ -192,7 +169,7 @@ def test_read_finding_memory_off_own_session(seeded_project, capsys):
 
     conn = open_db(project)
     try:
-        finding_id, _ = _seed_finding(
+        finding_id, _ = seed_finding(
             conn, session_id=info["session_id"], title="own", description="mine",
         )
     finally:

--- a/tests/test_skill_save_finding.py
+++ b/tests/test_skill_save_finding.py
@@ -8,25 +8,12 @@ import pytest
 
 from bartleby.skill_scripts import save_finding
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from tests._skill_fixtures import (  # noqa: F401
     assert_chunk_tables_consistent,
+    mock_embed,
     project_env,
     seeded_project,
 )
-
-
-@pytest.fixture(autouse=True)
-def mock_embed(monkeypatch):
-    monkeypatch.setattr(
-        "bartleby.ingest.embed.embed_texts",
-        lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
-    )
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.chunk.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
 
 
 def test_save_finding_with_inline_citations(seeded_project, tmp_path, capsys):

--- a/tests/test_skill_save_summary.py
+++ b/tests/test_skill_save_summary.py
@@ -8,28 +8,12 @@ import pytest
 
 from bartleby.skill_scripts import save_summary
 from bartleby.db.connection import open_db
-from bartleby.db.schema import EMBEDDING_DIM
 from tests._skill_fixtures import (  # noqa: F401
     assert_chunk_tables_consistent,
+    mock_embed,
     project_env,
     seeded_project,
 )
-
-
-@pytest.fixture(autouse=True)
-def mock_embed(monkeypatch):
-    # save_summary embeds via _common.embed_body_chunks; patch the names where
-    # that helper looks them up.
-    monkeypatch.setattr(
-        "bartleby.ingest.embed.embed_texts",
-        lambda texts: [[0.01 * i for _ in range(EMBEDDING_DIM)] for i in range(len(texts))],
-    )
-    # Force single-chunk output so chunk_count assertions stay stable.
-    from bartleby.ingest.chunk import ChunkRow
-    monkeypatch.setattr(
-        "bartleby.ingest.chunk.chunk_markdown_string",
-        lambda md: [ChunkRow(text=md, section_heading=None, content_type=None)],
-    )
 
 
 def test_save_summary_creates_new_summary(seeded_project, capsys):


### PR DESCRIPTION
Part of #447.

Consolidated the repeated `tests/` setup into helpers the suite already owns:

- **5 `_seed_finding*` copies → 1 shared `seed_finding`** in `tests/_skill_fixtures.py` (`seed_finding(conn, session_id, *, title="A finding", description="hook", body="body", cited_chunk_ids=()) -> (finding_id, body_chunk_ids)`). Covers `delete`/`merge` (`_seed_finding_as`), `read_finding`, `list_findings`, and `read_chunks`. The two `save_finding.main`-based `_seed_finding` fixtures (delete/edit) are out of scope and untouched.
- **5 byte-identical `mock_embed` copies → 1 autouse fixture** in `tests/_skill_fixtures.py`, imported into delete/merge/save_finding/save_summary/edit_finding (test_scribe's own different `mock_embed` left alone).
- **7 inline 3-monkeypatch summary-pipeline blocks → 1 `_summary_pipeline`** in `tests/test_scribe.py` (reuses `_summary_config`, returns the provider for `stub.calls` assertions). The 2 dual-provider vision sites keep their branching resolver inline — a genuinely different setup, not the simple pipeline.

**Net line delta: -175** (132 insertions, 307 deletions across 10 files).

**Memory-wall test preserved:** `tests/test_skill_read_chunks.py` still seeds the foreign finding with the exact title `"secret finding"` (pinned in one place in the `_seed_finding_chunk` wrapper) that the leak assertion at the bottom of `test_read_chunks_memory_off_drops_foreign_finding_chunk` checks is excluded — the assertion stays non-vacuous.

No test removed or renamed. Full suite green (925 passed); simplify-refactor gate run over the touched files (already clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)