### PR TITLE
skill: #438 delete unreachable validate_value_type

### DIFF
--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -557,21 +557,6 @@ _VALUE_GROUP = "value"
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
-def validate_value_type(raw: str | None) -> str | None:
-    """Return a validated ``value_type`` (or None for a boolean tag).
-
-    Raises ``INVALID_VALUE_TYPE`` on anything outside :data:`VALUE_TYPES`.
-    """
-    if raw is None:
-        return None
-    if raw not in VALUE_TYPES:
-        raise SkillError(
-            "INVALID_VALUE_TYPE",
-            f"--value-type must be one of {', '.join(VALUE_TYPES)}; got {raw!r}.",
-        )
-    return raw
-
-
 def compile_pattern(pattern: str):
     """Compile a value-tag pattern with re2, requiring a ``(?P<value>…)`` group.
 

--- a/bartleby/skill_scripts/add_tag.py
+++ b/bartleby/skill_scripts/add_tag.py
@@ -41,7 +41,6 @@ from bartleby.skill_scripts._tags import (
     compile_pattern,
     find_similar_tag,
     normalize_name,
-    validate_value_type,
 )
 
 
@@ -76,10 +75,12 @@ def work(*, conn, args, session_id) -> dict:
             "Tag name must contain at least one alphanumeric character.",
         )
 
-    # Value-tag: --value-type and --pattern are all-or-nothing. Validate the
-    # type and compile the pattern (re2, must expose (?P<value>…)) before any
-    # write so a malformed value-tag never lands.
-    value_type = validate_value_type(args.value_type)
+    # Value-tag: --value-type and --pattern are all-or-nothing. argparse's
+    # ``choices=list(VALUE_TYPES)`` already constrains args.value_type to None
+    # or a valid type before work() runs, so we read it directly and only need
+    # to compile the pattern (re2, must expose (?P<value>…)) before any write
+    # so a malformed value-tag never lands.
+    value_type = args.value_type
     pattern = args.pattern
     if (value_type is None) != (pattern is None):
         raise SkillError(

--- a/docs/decisions/GH-0438-delete-validate-value-type-0001.md
+++ b/docs/decisions/GH-0438-delete-validate-value-type-0001.md
@@ -1,0 +1,57 @@
+# GH-0438 — delete `validate_value_type`; argparse `choices=` already guards it
+
+**Date:** 2026-06-11
+**Issue:** #438 (part of omnibus #447)
+
+## Decision
+
+`validate_value_type` in `_tags.py` is deleted, and the `INVALID_VALUE_TYPE`
+error code is removed from the vocabulary. `add_tag.work()` now reads
+`args.value_type` directly.
+
+## Why the guard is unreachable
+
+`validate_value_type`'s only caller in the entire repo was `add_tag.work()`. Its
+job was to raise `INVALID_VALUE_TYPE` when `args.value_type` was anything outside
+`VALUE_TYPES = ("number", "string", "date")`. But `add_tag`'s argparse
+declaration already pins that flag:
+
+```python
+p.add_argument(
+    "--value-type", dest="value_type", choices=list(VALUE_TYPES), default=None, ...
+)
+```
+
+`choices=list(VALUE_TYPES)` makes argparse reject any other value during
+`parse_args` — and `parse_args` runs *outside* (before) the runner's `work()`
+call (`skill_runner.run` calls `parse_args` at the top, then `work` only after;
+see `GH-0402-argparse-json-envelope-0001.md`). So by the time
+`validate_value_type(args.value_type)` would have run, `args.value_type` is
+provably `None` or a member of `VALUE_TYPES`. The `raw not in VALUE_TYPES` branch
+can never fire — the function was a dead identity check and `INVALID_VALUE_TYPE`
+was an unreachable code.
+
+## What the user sees (unchanged behavior surface)
+
+An invalid `--value-type` no longer produces a JSON `{"code": "INVALID_VALUE_TYPE"}`
+envelope; argparse's `choices=` rejects it before `work()` runs, exiting non-zero
+with a `USAGE_ERROR` envelope (per GH-0402) whose stderr usage message names the
+allowed values (number/string/date). That is fine because it is already the error
+surface for every other malformed flag in the skill scripts — missing required
+flags, non-integer ids, and enum flags like `list_documents --order` and
+`scan --group-by` all surface as argparse usage errors. No test or SKILL.md text
+referenced `INVALID_VALUE_TYPE`, and the agent-facing outcome (rejection with a
+message listing the valid types) is preserved.
+
+## No back-compat
+
+Per the repo's no-backwards-compatibility default, `validate_value_type` and its
+import are deleted outright — no shim.
+
+## Touched
+
+- `bartleby/skill_scripts/_tags.py` — `validate_value_type` removed (13 lines).
+- `bartleby/skill_scripts/add_tag.py` — import dropped; `work()` reads
+  `args.value_type` directly.
+
+Net: shrink. Full suite: green.


### PR DESCRIPTION
Part of #447.

**Proof of unreachability.** `validate_value_type`'s only caller in the repo was `add_tag.work()`. `add_tag`'s argparse declaration sets `choices=list(VALUE_TYPES)` on `--value-type` with `default=None`, and `skill_runner.run` calls `parse_args` *before* `work()` (argparse rejects any other value with a non-zero `SystemExit`, surfaced as `USAGE_ERROR` per GH-0402). So `args.value_type` is provably `None` or a member of `VALUE_TYPES` at the call site — the `INVALID_VALUE_TYPE` raise could never fire. The function was a dead identity check.

**Removed.** `validate_value_type` (13 lines) from `_tags.py`; its import from `add_tag.py`; `work()` now reads `args.value_type` directly. `INVALID_VALUE_TYPE` is gone from the vocabulary. No test or SKILL.md referenced it. Ships `docs/decisions/GH-0438-delete-validate-value-type-0001.md`.

**Net:** -14 code lines (decision-log doc is additive prose). Suite: 925 passed.