### PR TITLE
ingestion: #440 pass ParseConfig down parsers.py

### DIFF
--- a/bartleby/ingest/parsers.py
+++ b/bartleby/ingest/parsers.py
@@ -81,11 +81,8 @@ class _ImageRoute:
 
 def _parse_image_routes(
     routes: list[_ImageRoute],
+    config: ParseConfig,
     *,
-    archive_root: Path,
-    vision_enabled: bool,
-    vision_max_dimension: int,
-    vision_min_dimension: int,
     on_warn: Callable[[str], None] | None = None,
 ) -> list[ParsedImage]:
     """Scale + archive each route into a ParsedImage (no VLM, no DB).
@@ -98,7 +95,7 @@ def _parse_image_routes(
     """
     if not routes:
         return []
-    if not vision_enabled:
+    if not config.vision_enabled:
         if on_warn is not None:
             on_warn(
                 f"Skipping {len(routes)} image(s) — no vision provider configured."
@@ -107,19 +104,19 @@ def _parse_image_routes(
     parsed: list[ParsedImage] = []
     for route in routes:
         prepared = image_pipeline.prepare_image(
-            route.bytes_, max_dimension=vision_max_dimension,
+            route.bytes_, max_dimension=config.vision_max_dimension,
         )
         if image_pipeline.is_below_vlm_minimum(
-            prepared, min_dimension=vision_min_dimension
+            prepared, min_dimension=config.vision_min_dimension
         ):
             page_str = f" (page {route.page_number})" if route.page_number else ""
             if on_warn is not None:
                 on_warn(
                     f"Skipping image{page_str} — {prepared.width}x{prepared.height}px "
-                    f"is below the {vision_min_dimension}px vision minimum."
+                    f"is below the {config.vision_min_dimension}px vision minimum."
                 )
             continue
-        archived = image_pipeline.archive_image(prepared, archive_root)
+        archived = image_pipeline.archive_image(prepared, config.archive_root)
         parsed.append(ParsedImage(
             hash=prepared.hash,
             archive_path=archived,
@@ -308,15 +305,10 @@ def _parse_edgar_submission(
 
 def _parse_pdf_pdfplumber(
     archived: Path,
+    config: ParseConfig,
     *,
     file_hash: str,
     file_name: str,
-    archive_root: Path,
-    sparse_text_threshold: int,
-    ocr_min_confidence: int,
-    vision_enabled: bool,
-    vision_max_dimension: int,
-    vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
     on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
@@ -324,8 +316,8 @@ def _parse_pdf_pdfplumber(
         on_stage("extracting")
     result = pdfplumber_pipeline.convert(
         archived,
-        sparse_text_threshold=sparse_text_threshold,
-        ocr_min_confidence=ocr_min_confidence,
+        sparse_text_threshold=config.sparse_text_threshold,
+        ocr_min_confidence=config.ocr_min_confidence,
     )
 
     doc_rows: list[ChunkRow] = []
@@ -363,12 +355,7 @@ def _parse_pdf_pdfplumber(
         embeddings = embed.embed_texts([r.text for r in doc_rows])
         chunks = _build_chunk_inputs(doc_rows, embeddings)
 
-    images = _parse_image_routes(
-        image_routes, archive_root=archive_root, vision_enabled=vision_enabled,
-        vision_max_dimension=vision_max_dimension,
-        vision_min_dimension=vision_min_dimension,
-        on_warn=on_warn,
-    )
+    images = _parse_image_routes(image_routes, config, on_warn=on_warn)
     return ParsedDocument(
         file_hash=file_hash, file_name=file_name, archive_path=archived,
         page_count=result.page_count, token_count=_token_count(result.full_text),
@@ -377,13 +364,10 @@ def _parse_pdf_pdfplumber(
 
 def _parse_pdf_docling(
     archived: Path,
+    config: ParseConfig,
     *,
     file_hash: str,
     file_name: str,
-    archive_root: Path,
-    vision_enabled: bool,
-    vision_max_dimension: int,
-    vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
     on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
@@ -392,7 +376,7 @@ def _parse_pdf_docling(
     if on_stage is not None:
         on_stage("extracting")
     docling_result = docling_pipeline.convert(
-        archived, extract_images=vision_enabled,
+        archived, extract_images=config.vision_enabled,
     )
 
     chunks: list[ChunkInput] = []
@@ -409,7 +393,7 @@ def _parse_pdf_docling(
 
     # Embedded images come out of the same docling pass (no second parse).
     image_routes: list[_ImageRoute] = []
-    if vision_enabled and docling_result.images:
+    if config.vision_enabled and docling_result.images:
         image_routes = [
             _ImageRoute(
                 bytes_=img.png_bytes,
@@ -418,12 +402,7 @@ def _parse_pdf_docling(
             )
             for img in docling_result.images
         ]
-    images = _parse_image_routes(
-        image_routes, archive_root=archive_root, vision_enabled=vision_enabled,
-        vision_max_dimension=vision_max_dimension,
-        vision_min_dimension=vision_min_dimension,
-        on_warn=on_warn,
-    )
+    images = _parse_image_routes(image_routes, config, on_warn=on_warn)
     return ParsedDocument(
         file_hash=file_hash, file_name=file_name, archive_path=archived,
         page_count=docling_result.page_count,
@@ -433,13 +412,10 @@ def _parse_pdf_docling(
 
 def _parse_image_file(
     archived: Path,
+    config: ParseConfig,
     *,
     file_hash: str,
     file_name: str,
-    archive_root: Path,
-    vision_enabled: bool,
-    vision_max_dimension: int,
-    vision_min_dimension: int,
     on_stage: Callable[[str], None] | None = None,
     on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
@@ -452,12 +428,7 @@ def _parse_image_file(
     route = _ImageRoute(
         bytes_=archived.read_bytes(), page_number=None, image_index_on_page=0,
     )
-    images = _parse_image_routes(
-        [route], archive_root=archive_root, vision_enabled=vision_enabled,
-        vision_max_dimension=vision_max_dimension,
-        vision_min_dimension=vision_min_dimension,
-        on_warn=on_warn,
-    )
+    images = _parse_image_routes([route], config, on_warn=on_warn)
     return ParsedDocument(
         file_hash=file_hash, file_name=file_name, archive_path=archived,
         page_count=None, token_count=0, document_chunks=[], images=images,
@@ -466,27 +437,17 @@ def _parse_image_file(
 def _parse_document(
     archived: Path,
     ext: str,
+    config: ParseConfig,
     *,
     file_hash: str,
     file_name: str,
-    pdf_converter: str,
-    html_converter: str,
-    sparse_text_threshold: int,
-    ocr_min_confidence: int,
-    vision_enabled: bool,
-    vision_max_dimension: int,
-    vision_min_dimension: int,
-    archive_root: Path,
     on_stage: Callable[[str], None] | None = None,
     on_warn: Callable[[str], None] | None = None,
 ) -> ParsedDocument:
     """Route an archived file to its converter and return a parsed result."""
     if ext in IMAGE_EXTENSIONS:
         return _parse_image_file(
-            archived, file_hash=file_hash, file_name=file_name,
-            archive_root=archive_root, vision_enabled=vision_enabled,
-            vision_max_dimension=vision_max_dimension,
-            vision_min_dimension=vision_min_dimension,
+            archived, config, file_hash=file_hash, file_name=file_name,
             on_stage=on_stage, on_warn=on_warn,
         )
     if ext in PDF_EXTENSIONS:
@@ -495,22 +456,13 @@ def _parse_document(
         # *without* rerouting them into the HTML pipeline (they carry no
         # document content; ingesting a portal error page pollutes the corpus).
         pdfplumber_pipeline.reject_if_html(archived)
-        if pdf_converter == "docling":
+        if config.pdf_converter == "docling":
             return _parse_pdf_docling(
-                archived, file_hash=file_hash, file_name=file_name,
-                archive_root=archive_root, vision_enabled=vision_enabled,
-                vision_max_dimension=vision_max_dimension,
-                vision_min_dimension=vision_min_dimension,
+                archived, config, file_hash=file_hash, file_name=file_name,
                 on_stage=on_stage, on_warn=on_warn,
             )
         return _parse_pdf_pdfplumber(
-            archived, file_hash=file_hash, file_name=file_name,
-            archive_root=archive_root,
-            sparse_text_threshold=sparse_text_threshold,
-            ocr_min_confidence=ocr_min_confidence,
-            vision_enabled=vision_enabled,
-            vision_max_dimension=vision_max_dimension,
-            vision_min_dimension=vision_min_dimension,
+            archived, config, file_hash=file_hash, file_name=file_name,
             on_stage=on_stage, on_warn=on_warn,
         )
     if edgar_pipeline.detect(archived):
@@ -522,7 +474,7 @@ def _parse_document(
         )
     if (
         ext in HTML_EXTENSIONS
-        and html_converter == "sec2md"
+        and config.html_converter == "sec2md"
         and sec2md_pipeline.is_ixbrl(archived)
     ):
         return _parse_html_sec2md(
@@ -602,14 +554,8 @@ def _parse_request(
     try:
         parsed = _parse_document(
             _archive(request.path, config.archive_root, request.file_hash, request.ext),
-            request.ext, file_hash=request.file_hash, file_name=request.file_name,
-            pdf_converter=config.pdf_converter, html_converter=config.html_converter,
-            sparse_text_threshold=config.sparse_text_threshold,
-            ocr_min_confidence=config.ocr_min_confidence,
-            vision_enabled=config.vision_enabled,
-            vision_max_dimension=config.vision_max_dimension,
-            vision_min_dimension=config.vision_min_dimension,
-            archive_root=config.archive_root,
+            request.ext, config, file_hash=request.file_hash,
+            file_name=request.file_name,
             on_stage=on_stage, on_warn=warnings.append,
         )
     except Exception as e:

--- a/docs/decisions/GH-0440-parseconfig-down-parsers-0001.md
+++ b/docs/decisions/GH-0440-parseconfig-down-parsers-0001.md
@@ -1,0 +1,42 @@
+# Pass ParseConfig down the per-format parse helpers (issue #440)
+
+> Source: [#440](https://github.com/jswest/bartleby/issues/440)
+
+`ParseConfig` — the frozen, picklable dataclass that already crosses the spawn
+boundary into `_parse_request` — was being **exploded into seven scalars**
+(`pdf_converter`, `html_converter`, `sparse_text_threshold`,
+`ocr_min_confidence`, `vision_enabled`, `vision_max_dimension`,
+`vision_min_dimension`, `archive_root`) and re-threaded by hand through
+`_parse_document`, `_parse_pdf_pdfplumber`, `_parse_pdf_docling`,
+`_parse_image_file`, and `_parse_image_routes`. The same keyword block was
+repeated across six signatures and four internal call sites; `_parse_document`
+alone carried a 17-line signature. Every scalar was only ever sourced from the
+one `ParseConfig` instance.
+
+Fix: those five helpers now take the `ParseConfig` object as a positional
+`config` argument (alongside identity fields `file_hash`/`file_name` and the
+`on_stage`/`on_warn` callbacks) and read `config.vision_max_dimension` etc.
+directly. `_parse_request` passes `config` through **unexploded**. No per-format
+helper's signature exceeds `(path, config, identity, callbacks)`.
+
+After this change the per-format parse helpers receive the run-wide
+`ParseConfig` object instead of seven exploded scalars. Nothing is no longer
+handled: every value still originates from the same frozen dataclass that
+already crosses the spawn boundary into `_parse_request`, the helpers remain
+DB-free, and no new pickling surface is created (the config object is already
+present in the worker process when these functions run). The only thing given up
+is that each helper's signature no longer documents exactly which settings it
+consumes — acceptable in a module where five functions threaded the same seven
+parameters and the signature noise now outweighs that documentation value.
+
+**No new dataclass or abstraction.** `ParseConfig` is the existing,
+already-present spawn-boundary payload; this change only stops disassembling it.
+The tests that constructed the scalar block by hand now build a `ParseConfig`
+through a small test-local `_parse_config(...)` factory (defaults for the
+run-wide fields, overrides only for the `archive_root`/`vision_enabled`/
+`vision_min_dimension` that actually vary across sites). Behavior is unchanged;
+`uv run pytest` stays green.
+
+---
+*Filed from the 2026-06-11 dry sweep (dead/wet/bloat audit; every item
+adversarially verified by an independent defender pass).*

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -30,6 +30,18 @@ def _emb(seed: float, n: int) -> list[list[float]]:
     ]
 
 
+def _parse_config(archive_root, *, vision_enabled=False, vision_min_dimension=32):
+    """A ParseConfig with the per-format helpers' run-wide defaults — the scalar
+    block these tests used to thread by hand. Only the fields that actually vary
+    across call sites are overridable."""
+    return parsers.ParseConfig(
+        pdf_converter="pdfplumber", html_converter="docling",
+        sparse_text_threshold=100, ocr_min_confidence=30,
+        vision_enabled=vision_enabled, vision_max_dimension=1024,
+        vision_min_dimension=vision_min_dimension, archive_root=archive_root,
+    )
+
+
 class _StubProvider:
     name = "stub"
 
@@ -217,11 +229,8 @@ def test_persist_parse_reuses_existing_file_hash(
     try:
         writer = scribe_module.Writer(conn)
         parsed = parsers._parse_document(
-            txt, ".txt", file_hash="dup", file_name="doc.txt",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            txt, ".txt", _parse_config(archive_root),
+            file_hash="dup", file_name="doc.txt",
         )
         first = writer.persist_parse(parsed)
         second = writer.persist_parse(parsed)
@@ -245,11 +254,8 @@ def test_parse_document_rejects_html_saved_as_pdf(tmp_path):
     archive_root.mkdir()
     with pytest.raises(NotAPdfError) as exc:
         parsers._parse_document(
-            src, ".pdf", file_hash="h", file_name="ViewDoc.pdf",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            src, ".pdf", _parse_config(archive_root),
+            file_hash="h", file_name="ViewDoc.pdf",
         )
     assert "HTML page" in str(exc.value)
     assert "No /Root object" not in str(exc.value)
@@ -878,11 +884,8 @@ def test_summarize_all_progress_callback_fires_per_document(
     try:
         writer = scribe_module.Writer(conn)
         parsed = parsers._parse_document(
-            txt, ".txt", file_hash="h", file_name="doc.txt",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            txt, ".txt", _parse_config(archive_root),
+            file_hash="h", file_name="doc.txt",
         )
         writer.persist_parse(parsed)
 
@@ -917,11 +920,8 @@ def test_summarize_all_lane_callback_reports_document(
     try:
         writer = scribe_module.Writer(conn)
         parsed = parsers._parse_document(
-            txt, ".txt", file_hash="h", file_name="doc.txt",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            txt, ".txt", _parse_config(archive_root),
+            file_hash="h", file_name="doc.txt",
         )
         writer.persist_parse(parsed)
 
@@ -956,11 +956,8 @@ def test_summarize_all_skips_capped_document(
     try:
         writer = scribe_module.Writer(conn)
         parsed = parsers._parse_document(
-            txt, ".txt", file_hash="caphash", file_name="doc.txt",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            txt, ".txt", _parse_config(archive_root),
+            file_hash="caphash", file_name="doc.txt",
         )
         writer.persist_parse(parsed)
         # Cap the summary stage so the pass must skip rather than retry.
@@ -1143,11 +1140,8 @@ def test_parse_document_stage_callback_fires_extract_then_embed(
 
     stages: list[str] = []
     parsers._parse_document(
-        pdf, ".pdf", file_hash="h", file_name="doc.pdf",
-        pdf_converter="pdfplumber", html_converter="docling",
-        sparse_text_threshold=100, ocr_min_confidence=30,
-        vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-        archive_root=tmp_path / "archive",
+        pdf, ".pdf", _parse_config(tmp_path / "archive"),
+        file_hash="h", file_name="doc.pdf",
         on_stage=stages.append,
     )
 
@@ -1164,11 +1158,8 @@ def test_parse_document_reports_page_count(
     _text_pdf(pdf)
 
     parsed = parsers._parse_document(
-        pdf, ".pdf", file_hash="h", file_name="doc.pdf",
-        pdf_converter="pdfplumber", html_converter="docling",
-        sparse_text_threshold=100, ocr_min_confidence=30,
-        vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=32,
-        archive_root=tmp_path / "archive",
+        pdf, ".pdf", _parse_config(tmp_path / "archive"),
+        file_hash="h", file_name="doc.pdf",
     )
 
     assert parsed.page_count == 1
@@ -1197,8 +1188,8 @@ def test_parse_image_routes_routes_sub_minimum_warning_off_the_console(
         bytes_=_png_bytes(), page_number=3, image_index_on_page=0,
     )
     images = parsers._parse_image_routes(
-        [route], archive_root=tmp_path / "archive", vision_enabled=True,
-        vision_max_dimension=1024, vision_min_dimension=128,
+        [route],
+        _parse_config(tmp_path / "archive", vision_enabled=True, vision_min_dimension=128),
         on_warn=warnings.append,
     )
 
@@ -1221,11 +1212,9 @@ def test_parse_document_threads_on_warn_to_the_leaf(
 
     warnings: list[str] = []
     parsers._parse_document(
-        img, ".png", file_hash="h", file_name="pic.png",
-        pdf_converter="pdfplumber", html_converter="docling",
-        sparse_text_threshold=100, ocr_min_confidence=30,
-        vision_enabled=False, vision_max_dimension=1024, vision_min_dimension=128,
-        archive_root=tmp_path / "archive",
+        img, ".png",
+        _parse_config(tmp_path / "archive", vision_min_dimension=128),
+        file_hash="h", file_name="pic.png",
         on_warn=warnings.append,
     )
 
@@ -1248,11 +1237,8 @@ def test_caption_all_progress_callback_fires_per_image(
     try:
         writer = scribe_module.Writer(conn)
         parsed = parsers._parse_document(
-            pdf, ".pdf", file_hash="h", file_name="img.pdf",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=True, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            pdf, ".pdf", _parse_config(archive_root, vision_enabled=True),
+            file_hash="h", file_name="img.pdf",
         )
         document_id = writer.persist_parse(parsed)
 
@@ -1289,11 +1275,8 @@ def test_caption_all_lane_callback_reports_owning_document(
     try:
         writer = scribe_module.Writer(conn)
         parsed = parsers._parse_document(
-            pdf, ".pdf", file_hash="h", file_name="img.pdf",
-            pdf_converter="pdfplumber", html_converter="docling",
-            sparse_text_threshold=100, ocr_min_confidence=30,
-            vision_enabled=True, vision_max_dimension=1024, vision_min_dimension=32,
-            archive_root=archive_root,
+            pdf, ".pdf", _parse_config(archive_root, vision_enabled=True),
+            file_hash="h", file_name="img.pdf",
         )
         document_id = writer.persist_parse(parsed)
 


### PR DESCRIPTION
Part of #447.

Collapses the seven exploded `ParseConfig` scalars (`pdf_converter`, `html_converter`, `sparse_text_threshold`, `ocr_min_confidence`, `vision_enabled`, `vision_max_dimension`, `vision_min_dimension`, `archive_root`) back into the existing `ParseConfig` object down the per-format parse helpers.

**Helpers changed** (each now takes a positional `config: ParseConfig` alongside identity fields + `on_stage`/`on_warn`):
- `_parse_document`
- `_parse_pdf_pdfplumber`
- `_parse_pdf_docling`
- `_parse_image_file`
- `_parse_image_routes`

`_parse_request` passes `config` through **unexploded**. No helper signature exceeds `(path, config, identity, callbacks)`.

**No new dataclass / abstraction** — `ParseConfig` already existed as the spawn-boundary payload; this only stops disassembling it. Tests build a `ParseConfig` via a small test-local `_parse_config(...)` factory instead of the inline scalar block. Decision-log entry: `docs/decisions/GH-0440-parseconfig-down-parsers-0001.md`.

**Net line delta:** -71 code lines (parsers.py + tests/test_scribe.py); full `uv run pytest` green (925 passed).