### PR TITLE
skill: #439 drop EMPTY_NAME guard subsumed by normalize_name

### DIFF
--- a/bartleby/skill_scripts/add_tag.py
+++ b/bartleby/skill_scripts/add_tag.py
@@ -63,8 +63,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
 def work(*, conn, args, session_id) -> dict:
     name = args.name.strip()
     description = args.description.strip()
-    if not name:
-        raise SkillError("EMPTY_NAME", "Tag name must be non-empty.")
     if not description:
         raise SkillError(
             "EMPTY_DESCRIPTION", "Tag description must be non-empty."

--- a/bartleby/skill_scripts/rename_tag.py
+++ b/bartleby/skill_scripts/rename_tag.py
@@ -29,8 +29,6 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
 
 def work(*, conn, args, session_id) -> dict:
     new_name = args.new.strip()
-    if not new_name:
-        raise SkillError("EMPTY_NAME", "New tag name must be non-empty.")
     if not normalize_name(new_name):
         raise SkillError(
             "EMPTY_NORMALIZED_NAME",

--- a/docs/decisions/GH-0439-drop-empty-name-guard-0001.md
+++ b/docs/decisions/GH-0439-drop-empty-name-guard-0001.md
@@ -1,0 +1,27 @@
+# Drop the `EMPTY_NAME` guard in `add_tag`/`rename_tag` (issue #439)
+
+> Source: [#439](https://github.com/jswest/bartleby/issues/439)
+
+Both `add_tag` and `rename_tag` ran two sequential guards on the same input:
+`if not name: raise EMPTY_NAME` immediately followed by
+`if not normalize_name(name): raise EMPTY_NORMALIZED_NAME`. The name is already
+`.strip()`-ed before either guard, and `normalize_name` deletes every
+non-`[a-z0-9]` character (`_NAME_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")`), so
+an empty or whitespace-only name normalizes to `""` (falsy) and is *always*
+caught by the second guard. The `EMPTY_NAME` branch therefore guarded a state
+the `normalize_name` check already covered — there is no input that fires
+`EMPTY_NAME` where `EMPTY_NORMALIZED_NAME` would not. Dead code by definition.
+
+So the `EMPTY_NAME` branch is removed from both scripts, leaving the single
+`normalize_name` guard. A blank or whitespace-only tag name now reports
+`EMPTY_NORMALIZED_NAME` ("must contain at least one alphanumeric character"),
+which is a truthful description of the blank case too. That is fine because
+nothing in the repo — tests, `SKILL.md`, or other scripts — distinguished the
+two codes (repo-wide grep confirms no surviving reference to `EMPTY_NAME`), and
+the agent's remediation is identical either way: supply a real name. The only
+loss is a marginally more specific message for the all-whitespace sub-case.
+
+`add_tag`'s separate `EMPTY_DESCRIPTION` guard is unrelated and stays. Tests now
+pin the surviving envelope: whitespace-only and punctuation-only names fail with
+the `EMPTY_NORMALIZED_NAME` JSON envelope on both paths. Pure deletion, no schema
+change.

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -168,6 +168,31 @@ def test_add_tag_detects_similar_description(seeded_project, capsys):
     assert out["similar_to"]["similarity"] >= tags_helpers.SIMILARITY_THRESHOLD
 
 
+def test_add_tag_rejects_whitespace_name(seeded_project, capsys):
+    # A whitespace-only name has no alphanumeric content; it falls through to
+    # the normalize_name guard and reports EMPTY_NORMALIZED_NAME.
+    with pytest.raises(SystemExit):
+        add_tag.main([
+            "--project", seeded_project["project"],
+            "--name", "   ", "--description", "a real description",
+        ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_NORMALIZED_NAME"
+
+
+def test_add_tag_rejects_punctuation_only_name(seeded_project, capsys):
+    # A punctuation-only name normalizes to "" — same EMPTY_NORMALIZED_NAME
+    # envelope. (Leading-dash values like "---" are eaten by argparse before
+    # work() runs, so use non-flag punctuation to exercise the normalize guard.)
+    with pytest.raises(SystemExit):
+        add_tag.main([
+            "--project", seeded_project["project"],
+            "--name", "%%%", "--description", "a real description",
+        ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_NORMALIZED_NAME"
+
+
 # ---------- delete_tag / rename_tag / merge_tags ----------
 
 
@@ -258,6 +283,26 @@ def test_rename_tag_allows_case_punctuation_self_rename(seeded_project, capsys):
         ).fetchone()[0] == "NYSEG"
     finally:
         conn.close()
+
+
+def test_rename_tag_rejects_whitespace_new_name(seeded_project, capsys):
+    # A whitespace-only --new normalizes to "" and is refused via the
+    # normalize_name guard's EMPTY_NORMALIZED_NAME envelope.
+    conn = open_db(seeded_project["project"])
+    try:
+        conn.cursor().execute(
+            "INSERT INTO tags (name, description) VALUES ('a', 'd1')"
+        )
+    finally:
+        conn.close()
+
+    with pytest.raises(SystemExit):
+        rename_tag.main([
+            "--project", seeded_project["project"],
+            "--old", "a", "--new", "   ",
+        ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_NORMALIZED_NAME"
 
 
 def test_merge_tags_moves_assignments_and_deletes_source(seeded_project, capsys):


### PR DESCRIPTION
Part of #447.

**Redundancy proof.** Both `add_tag.work` and `rename_tag.work` `.strip()` the name, then ran two sequential guards: `if not name: raise EMPTY_NAME` immediately followed by `if not normalize_name(name): raise EMPTY_NORMALIZED_NAME`. `normalize_name` is `_NAME_NORMALIZE_RE.sub("", name.lower())` with `_NAME_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")`, so any empty / whitespace-only / punctuation-only input normalizes to `""` (falsy). Verified directly: `normalize_name("")`, `normalize_name("   ".strip())`, and `normalize_name("%%%")` all return `""`. There is no input that fires `EMPTY_NAME` where `EMPTY_NORMALIZED_NAME` would not — the first branch was dead code.

**Surviving error shape.** Empty / whitespace / punctuation-only names still fail, now via the single normalize-path envelope: `{"code": "EMPTY_NORMALIZED_NAME", ...}` ("must contain at least one alphanumeric character"). Nothing in the repo (tests, SKILL.md, other scripts) distinguished the two codes; repo-wide grep confirms no surviving `EMPTY_NAME` reference. Tests now pin the survivor: whitespace `add_tag --name`, punctuation-only `add_tag --name`, and whitespace `rename_tag --new` each assert `code == EMPTY_NORMALIZED_NAME`.

**Net lines.** Production code: -4 lines (two guard branches removed from add_tag.py + rename_tag.py). Plus a `docs/decisions/GH-0439-*.md` entry and three pin tests (additive). Full suite green (928 passed). SCHEMA_VERSION unchanged.