### PR TITLE
ingestion: #441 merge caption/summarize worker resolvers

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -53,11 +53,13 @@ from bartleby.lib import timing
 from bartleby.lib.consts import (
     ALLOWED_HTML_CONVERTERS,
     ALLOWED_PDF_CONVERTERS,
+    DEFAULT_CAPTION_WORKERS,
     DEFAULT_HTML_CONVERTER,
     DEFAULT_MAX_SUMMARIZE_TOKENS,
     DEFAULT_OCR_MIN_CONFIDENCE,
     DEFAULT_PDF_CONVERTER,
     DEFAULT_SPARSE_TEXT_THRESHOLD,
+    DEFAULT_SUMMARIZE_WORKERS,
     DEFAULT_TEMPERATURE,
     DEFAULT_VISION_MAX_DIMENSION,
     DEFAULT_VISION_MIN_DIMENSION,
@@ -242,9 +244,15 @@ def main(
         max_workers = (
             resolve._resolve_max_workers(config, timings=timings) if to_parse else 1
         )
-        caption_workers = resolve._resolve_caption_workers(config, timings=timings)
-        summarize_workers = resolve._resolve_summarize_workers(
-            config, effective_provider=effective_provider, timings=timings
+        caption_workers = resolve._resolve_io_workers(
+            config, key="caption_workers", default=DEFAULT_CAPTION_WORKERS,
+            provider=config.get("vision_provider"),
+            verb="captions", unit="captioning one image", timings=timings,
+        )
+        summarize_workers = resolve._resolve_io_workers(
+            config, key="summarize_workers", default=DEFAULT_SUMMARIZE_WORKERS,
+            provider=effective_provider,
+            verb="summarizes", unit="summarizing one document", timings=timings,
         )
         if len(to_parse) > 1 and max_workers > 1:
             console.info(

--- a/bartleby/ingest/resolve.py
+++ b/bartleby/ingest/resolve.py
@@ -91,76 +91,47 @@ def _resolve_max_workers(config: dict, *, timings: bool) -> int:
     return n
 
 
-def _resolve_caption_workers(config: dict, *, timings: bool) -> int:
-    """Resolve how many images caption concurrently in the post-parse stage.
-
-    Unlike parse workers (RAM-bound, auto-sized), captioning is network/IO-bound,
-    so this is a plain configured count defaulting to ``DEFAULT_CAPTION_WORKERS``.
-    ``--timings`` forces 1: the per-stage breakdown is a sequential baseline,
-    meaningless once captions overlap (same rationale as ``max_workers``).
-
-    A local Ollama vision provider clamps to 1 regardless (#243): Ollama's
-    ``OLLAMA_NUM_PARALLEL`` defaults to 1, so a single model serializes requests
-    and parallel workers only queue. An explicit ``caption_workers`` > 1 is
-    ignored (with a warning) rather than honored — the clamp is the point.
-    """
-    configured = int(config.get("caption_workers") or DEFAULT_CAPTION_WORKERS)
-    if timings:
-        if configured > 1:
-            console.warn(
-                "--timings captions sequentially (caption_workers=1) for a "
-                "clean baseline."
-            )
-        return 1
-    if config.get("vision_provider") == "ollama":
-        # Re-read the raw value (not `configured`, which has the default folded
-        # in) so the warning fires only on an explicit count, not the default.
-        if int(config.get("caption_workers") or 0) > 1:
-            console.warn(
-                "caption_workers > 1 ignored — Ollama serializes requests "
-                "(OLLAMA_NUM_PARALLEL defaults to 1); captioning one image at a time."
-            )
-        return 1
-    return max(1, configured)
-
-
-def _resolve_summarize_workers(
-    config: dict, *, effective_provider: str | None, timings: bool
+def _resolve_io_workers(
+    config: dict,
+    *,
+    key: str,
+    default: int,
+    provider: str | None,
+    verb: str,
+    unit: str,
+    timings: bool,
 ) -> int:
-    """Resolve how many documents summarize concurrently in the post-parse pass.
+    """Resolve the worker count for a network/IO-bound post-parse stage.
 
-    Like captioning (and unlike RAM-bound parse workers), summarization is
-    network/IO-bound, so this is a plain configured count defaulting to
-    ``DEFAULT_SUMMARIZE_WORKERS``. ``--timings`` forces 1 for a clean per-document
-    baseline, meaningless once summaries overlap (same rationale as the others).
+    Captioning and summarization share this resolver (#441): unlike RAM-bound
+    parse workers (auto-sized), both are a plain configured count (``config[key]``)
+    defaulting to ``default``. ``--timings`` forces 1 for a sequential baseline,
+    meaningless once the stage's work overlaps (same rationale as ``max_workers``).
 
-    A local Ollama LLM provider clamps to 1 regardless (#243): Ollama's
-    ``OLLAMA_NUM_PARALLEL`` defaults to 1, so a single model serializes requests
-    and parallel workers only queue. An explicit ``summarize_workers`` > 1 is
-    ignored (with a warning) rather than honored — the clamp is the point.
+    A local Ollama ``provider`` clamps to 1 regardless (#243): with
+    ``OLLAMA_NUM_PARALLEL`` defaulting to 1 a single model serializes requests, so
+    an explicit ``config[key]`` > 1 is ignored (with a warning), not honored.
 
-    ``effective_provider`` is the provider summaries *actually* run against —
-    ``--provider`` override folded in, not bare ``config['provider']`` (#314).
-    Clamping on the config alone bypasses the clamp when ``--provider ollama``
-    overrides a cloud config, and falsely clamps a cloud override over an Ollama
-    config; the caller computes the effective name and threads it in.
+    ``provider`` is the provider the stage *actually* runs against — the caller
+    threads in the already-resolved name (``config['vision_provider']`` for
+    captions; the ``--provider`` override folded in for summaries, not bare
+    ``config['provider']`` (#314)) so the clamp keys off the real backend.
+    ``verb``/``unit`` only shape the warning strings.
     """
-    configured = int(config.get("summarize_workers") or DEFAULT_SUMMARIZE_WORKERS)
+    configured = int(config.get(key) or default)
     if timings:
         if configured > 1:
             console.warn(
-                "--timings summarizes sequentially (summarize_workers=1) for a "
-                "clean baseline."
+                f"--timings {verb} sequentially ({key}=1) for a clean baseline."
             )
         return 1
-    if effective_provider == "ollama":
+    if provider == "ollama":
         # Re-read the raw value (not `configured`, which has the default folded
         # in) so the warning fires only on an explicit count, not the default.
-        if int(config.get("summarize_workers") or 0) > 1:
+        if int(config.get(key) or 0) > 1:
             console.warn(
-                "summarize_workers > 1 ignored — Ollama serializes requests "
-                "(OLLAMA_NUM_PARALLEL defaults to 1); summarizing one document "
-                "at a time."
+                f"{key} > 1 ignored — Ollama serializes requests "
+                f"(OLLAMA_NUM_PARALLEL defaults to 1); {unit} at a time."
             )
         return 1
     return max(1, configured)

--- a/docs/decisions/GH-0441-merge-worker-resolvers-0001.md
+++ b/docs/decisions/GH-0441-merge-worker-resolvers-0001.md
@@ -1,0 +1,49 @@
+# Merge the caption/summarize worker resolvers into one (issue #441)
+
+> Source: [#441](https://github.com/jswest/bartleby/issues/441)
+
+`_resolve_caption_workers` and `_resolve_summarize_workers` in
+`bartleby/ingest/resolve.py` were two near-identical functions (~71 lines with
+docstrings) implementing the **same algorithm**: read a configured count with a
+default, let `--timings` force 1 (warning only when the configured value exceeds
+1), clamp an Ollama provider to 1 (warning only on an explicit, non-default count
+— the #243 serialization clamp), else return `max(1, configured)`. They differed
+only in config key (`caption_workers` vs `summarize_workers`), default constant,
+provider source (`config['vision_provider']` vs the #314 effective-provider
+argument), and the nouns in two warning strings. They had moved in lockstep
+through #243 and #314, and their docstrings even cross-referenced each other.
+
+Fix: one parameterized helper,
+`_resolve_io_workers(config, *, key, default, provider, verb, unit, timings)`.
+`scribe` calls it twice — passing `config.get('vision_provider')` for captions
+and the already-computed effective provider for summaries — so each stage threads
+in the provider it has already resolved. `verb`/`unit` only shape the two warning
+strings, which are now f-string templates that reproduce the prior text exactly.
+
+Nothing functional is no longer handled. The three load-bearing behaviors are
+preserved byte-for-byte:
+
+- **`--timings` clamp** — forces 1, warning only when the configured value
+  exceeds 1.
+- **Ollama explicit-value clamp (#243)** — clamps to 1; the warning re-reads the
+  raw `config[key]` (not the default-folded value) so it fires only on an
+  explicit count > 1, never on the default.
+- **`max(1, n)` floor** — unchanged for the non-clamped path.
+
+The #314 distinction (summaries clamp off the override-folded *effective*
+provider, not bare `config['provider']`) is preserved structurally: it now lives
+in the call site, which passes the effective name it already computes, rather
+than in a per-function branch.
+
+**No new abstraction.** This is a plain helper that collapses two copies of one
+algorithm — not a worker-resolution layer. If a future stage ever needs a
+divergent clamping rule it can fork back out; an acceptable bet given the two
+functions have changed in lockstep through every revision so far. The direct-call
+tests in `tests/test_scribe.py` now route through small test-local
+`_caption_workers`/`_summarize_workers` wrappers that fix the per-stage
+parameters; the assertions (defaults, `--timings`, the Ollama clamp, and the
+#314 effective-provider override) are unchanged. `uv run pytest` stays green.
+
+---
+*Filed from the 2026-06-11 dry sweep (dead/wet/bloat audit; every item
+adversarially verified by an independent defender pass).*

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -20,6 +20,7 @@ from bartleby.ingest import parse
 from bartleby.ingest import summary
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
+from bartleby.lib.consts import DEFAULT_CAPTION_WORKERS, DEFAULT_SUMMARIZE_WORKERS
 from bartleby.ingest.chunk import resolve_extension
 from bartleby.providers.base import DocumentSummary, VlmDescription
 
@@ -670,23 +671,32 @@ def test_scribe_one_caption_failure_does_not_block_the_rest(
         conn.close()
 
 
-def test_resolve_caption_workers_defaults_and_timings():
+def _caption_workers(config, *, timings):
+    """Call the merged resolver with the caption-stage parameters scribe uses."""
     from bartleby.ingest import resolve as scribe_module
-    from bartleby.lib.consts import DEFAULT_CAPTION_WORKERS
 
+    return scribe_module._resolve_io_workers(
+        config,
+        key="caption_workers",
+        default=DEFAULT_CAPTION_WORKERS,
+        provider=config.get("vision_provider"),
+        verb="captions",
+        unit="captioning one image",
+        timings=timings,
+    )
+
+
+def test_resolve_caption_workers_defaults_and_timings():
     # Default when unset or zero; explicit value respected.
-    assert scribe_module._resolve_caption_workers(
-        {}, timings=False) == DEFAULT_CAPTION_WORKERS
-    assert scribe_module._resolve_caption_workers(
+    assert _caption_workers({}, timings=False) == DEFAULT_CAPTION_WORKERS
+    assert _caption_workers(
         {"caption_workers": 0}, timings=False) == DEFAULT_CAPTION_WORKERS
-    assert scribe_module._resolve_caption_workers(
-        {"caption_workers": 9}, timings=False) == 9
+    assert _caption_workers({"caption_workers": 9}, timings=False) == 9
     # A cloud vision provider keeps the configured/default count.
-    assert scribe_module._resolve_caption_workers(
+    assert _caption_workers(
         {"vision_provider": "anthropic"}, timings=False) == DEFAULT_CAPTION_WORKERS
     # --timings forces a sequential baseline regardless of config.
-    assert scribe_module._resolve_caption_workers(
-        {"caption_workers": 9}, timings=True) == 1
+    assert _caption_workers({"caption_workers": 9}, timings=True) == 1
 
 
 def test_resolve_caption_workers_clamps_ollama(monkeypatch):
@@ -696,11 +706,10 @@ def test_resolve_caption_workers_clamps_ollama(monkeypatch):
     monkeypatch.setattr(scribe_module.console, "warn", warnings.append)
 
     # Ollama serializes (OLLAMA_NUM_PARALLEL=1): clamp to 1, silent at default.
-    assert scribe_module._resolve_caption_workers(
-        {"vision_provider": "ollama"}, timings=False) == 1
+    assert _caption_workers({"vision_provider": "ollama"}, timings=False) == 1
     assert warnings == []
     # An explicit count > 1 is ignored (still 1) and warns.
-    assert scribe_module._resolve_caption_workers(
+    assert _caption_workers(
         {"vision_provider": "ollama", "caption_workers": 8}, timings=False) == 1
     assert any("caption_workers > 1 ignored" in w for w in warnings)
 
@@ -822,20 +831,32 @@ def test_scribe_one_summary_failure_does_not_block_the_rest(
         conn.close()
 
 
-def test_resolve_summarize_workers_defaults_and_timings():
+def _summarize_workers(config, *, effective_provider, timings):
+    """Call the merged resolver with the summarize-stage parameters scribe uses."""
     from bartleby.ingest import resolve as scribe_module
-    from bartleby.lib.consts import DEFAULT_SUMMARIZE_WORKERS
 
+    return scribe_module._resolve_io_workers(
+        config,
+        key="summarize_workers",
+        default=DEFAULT_SUMMARIZE_WORKERS,
+        provider=effective_provider,
+        verb="summarizes",
+        unit="summarizing one document",
+        timings=timings,
+    )
+
+
+def test_resolve_summarize_workers_defaults_and_timings():
     # Default when unset or zero; explicit value respected.
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {}, effective_provider="openai", timings=False) == DEFAULT_SUMMARIZE_WORKERS
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {"summarize_workers": 0}, effective_provider="openai", timings=False
     ) == DEFAULT_SUMMARIZE_WORKERS
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {"summarize_workers": 9}, effective_provider="openai", timings=False) == 9
     # --timings forces a sequential baseline regardless of config.
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {"summarize_workers": 9}, effective_provider="openai", timings=True) == 1
 
 
@@ -846,27 +867,24 @@ def test_resolve_summarize_workers_clamps_ollama(monkeypatch):
     monkeypatch.setattr(scribe_module.console, "warn", warnings.append)
 
     # Ollama serializes (OLLAMA_NUM_PARALLEL=1): clamp to 1, silent at default.
-    assert scribe_module._resolve_summarize_workers(
-        {}, effective_provider="ollama", timings=False) == 1
+    assert _summarize_workers({}, effective_provider="ollama", timings=False) == 1
     assert warnings == []
     # An explicit count > 1 is ignored (still 1) and warns.
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {"summarize_workers": 8}, effective_provider="ollama", timings=False) == 1
     assert any("summarize_workers > 1 ignored" in w for w in warnings)
 
 
 def test_resolve_summarize_workers_tracks_provider_override():
     """The clamp keys off the effective provider, not config['provider'] (#314)."""
-    from bartleby.ingest import resolve as scribe_module
-
     # --provider ollama over a cloud config clamps to 1 (the clamp must not be
     # bypassed just because config['provider'] is a cloud backend).
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {"provider": "openai", "summarize_workers": 4},
         effective_provider="ollama", timings=False) == 1
     # --provider anthropic over an ollama config keeps the configured count
     # (no spurious clamp when the run isn't actually against Ollama).
-    assert scribe_module._resolve_summarize_workers(
+    assert _summarize_workers(
         {"provider": "ollama", "summarize_workers": 4},
         effective_provider="anthropic", timings=False) == 4
 


### PR DESCRIPTION
Part of #447.

Collapses the two lockstep resolvers `_resolve_caption_workers` and `_resolve_summarize_workers` into one parameterized `_resolve_io_workers(config, *, key, default, provider, verb, unit, timings)`. `scribe` passes the per-stage provider it already computes (`config['vision_provider']` for captions, the #314 effective provider for summaries).

**Three clamps preserved exactly** (warning strings verified byte-for-byte against the originals):
- `--timings` forces 1, warning only when the configured value exceeds 1.
- Ollama explicit-value clamp (#243): re-reads the raw `config[key]` (not the default-folded value), so it warns only on an explicit count > 1, never the default; clamps to 1 either way.
- `max(1, n)` floor for the non-clamped path.

The #314 effective-provider distinction is preserved by threading the provider in from each call site rather than a per-function branch.

Decision-log entry: `docs/decisions/GH-0441-merge-worker-resolvers-0001.md`.

**Net code delta: -3 lines** (86 added / 89 deleted across `bartleby/` + `tests/`; the +49 decision-log file is an expected omnibus net-add). `uv run pytest` green — 925 passed.