### PR TITLE
ingestion: #442 pass progress phase handle directly, drop _ProgressTally

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -295,18 +295,15 @@ def main(
             )
 
             # ---- Phase 2: caption every uncaptioned image, concurrently ------
-            # _caption_all drives the tally via on_progress (0,total then per
-            # image) and the lanes via on_lane (per worker thread); the phase
-            # adapts the tally contract itself and reveals the caption total the
-            # first time it hears one.
-            cap_phase = progress.phase("caption")
+            # _caption_all drives the phase directly: start() reveals the caption
+            # total, advance() ticks the tally per image, lane() updates a worker
+            # row.
             caption._caption_all(
                 writer, units,
                 vision_provider=vision_provider, vision_model=vision_model,
                 vision_enabled=parse_config.vision_enabled,
                 caption_workers=caption_workers, timings=timings,
-                on_progress=cap_phase.on_progress,
-                on_lane=cap_phase.lane,
+                phase=progress.phase("caption"),
             )
             # A document is caption-incomplete if any image is still uncaptioned
             # (failed / capped / no provider — recomputed from the DB so a shared
@@ -333,15 +330,13 @@ def main(
             if summaries_enabled:
                 pending = writer.documents_needing_summary()
                 if pending:
-                    sum_phase = progress.phase("summarize")
                     owed, summarize_times = summary._summarize_all(
                         writer, pending,
                         llm_provider=llm_provider, llm_model=llm_model,
                         temperature=temperature,
                         max_summarize_tokens=max_summarize_tokens,
                         summarize_workers=summarize_workers, timings=timings,
-                        on_progress=sum_phase.on_progress,
-                        on_lane=sum_phase.lane,
+                        phase=progress.phase("summarize"),
                         reasoning_effort=reasoning_effort,
                     )
                     incomplete_count += owed

--- a/bartleby/ingest/caption.py
+++ b/bartleby/ingest/caption.py
@@ -12,11 +12,10 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Callable
 
 from bartleby.ingest import images as image_pipeline
 from bartleby.ingest.parse import DocUnit
-from bartleby.ingest.progress import _ProgressTally
+from bartleby.ingest.progress import _Phase
 from bartleby.ingest.writer import (
     MAX_INGEST_ATTEMPTS,
     ImageCaption,
@@ -75,8 +74,7 @@ def _caption_all(
     vision_enabled: bool,
     caption_workers: int,
     timings: bool,
-    on_progress: Callable[[int, int], None] | None,
-    on_lane: Callable[[object, str, str], None] | None = None,
+    phase: _Phase | None = None,
 ) -> None:
     """Phase 2: caption every still-uncaptioned image across all parsed units.
 
@@ -113,7 +111,8 @@ def _caption_all(
         )
         return
 
-    progress = _ProgressTally(len(pending), on_progress)
+    if phase is not None:
+        phase.start(len(pending))
 
     # Capped rows (failed MAX_INGEST_ATTEMPTS× already) are skipped, not retried.
     to_caption: dict[int, PendingImage] = {}
@@ -123,7 +122,8 @@ def _caption_all(
                 f"{owner[image_id].file_name}: skipping image — failed "
                 f"{MAX_INGEST_ATTEMPTS}× already; not retrying."
             )
-            progress.advance()
+            if phase is not None:
+                phase.advance()
         else:
             to_caption[image_id] = pi
 
@@ -141,8 +141,8 @@ def _caption_all(
     def _analyze(image_id: int, pi: PendingImage) -> image_pipeline.ImageAnalysis:
         # Claim this thread's lane for the owning document, then run the analysis.
         # Keyed by thread id, so the pool's N threads map to N sticky lanes.
-        if on_lane is not None:
-            on_lane(threading.get_ident(), owner[image_id].file_name, "captioning")
+        if phase is not None:
+            phase.lane(threading.get_ident(), owner[image_id].file_name, "captioning")
         return _analyze_image(
             pi, vision_provider=vision_provider, vision_model=vision_model,
         )
@@ -161,7 +161,8 @@ def _caption_all(
                 unit.stages["caption"] = (
                     unit.stages.get("caption", 0.0) + (time.perf_counter() - t0)
                 )
-            progress.advance()
+            if phase is not None:
+                phase.advance()
         return
 
     with ThreadPoolExecutor(max_workers=caption_workers) as pool:
@@ -175,4 +176,5 @@ def _caption_all(
                 _persist(image_id, fut.result())
             except Exception as e:
                 _fail(image_id, e)
-            progress.advance()
+            if phase is not None:
+                phase.advance()

--- a/bartleby/ingest/progress.py
+++ b/bartleby/ingest/progress.py
@@ -78,26 +78,6 @@ def _fmt_eta(secs: float) -> str:
     return f"{hours}h{mins:02d}m"
 
 
-class _ProgressTally:
-    """Counts completed work units and forwards ``(done, total)`` to a progress
-    callback — the shared meter for the caption (#166) and summarize (#188)
-    stages, which both report identically against a fixed-size work-list."""
-
-    def __init__(
-        self, total: int, on_progress: Callable[[int, int], None] | None
-    ) -> None:
-        self._total = total
-        self._on_progress = on_progress
-        self._done = 0
-        if on_progress is not None:
-            on_progress(0, total)
-
-    def advance(self) -> None:
-        self._done += 1
-        if self._on_progress is not None:
-            self._on_progress(self._done, self._total)
-
-
 class ScribeProgress:
     """Live multi-worker progress for a scribe ingest run (see module docstring).
 
@@ -281,12 +261,6 @@ class ScribeProgress:
         self._clear_lanes()       # new phase, fresh lanes
         self._refresh_overall()
 
-    def _set_completed(self, name: str, done: int) -> None:
-        with self._lock:
-            self._done[name] = done
-            self._recompute_eta(name)
-        self._refresh_overall()
-
     def _advance(self, name: str, n: int = 1) -> None:
         with self._lock:
             self._done[name] += n
@@ -297,7 +271,7 @@ class ScribeProgress:
 class _Phase:
     """A bound view of one phase, handed to the phase's loop so it never touches
     Rich directly. ``start`` reveals the denominator (and grows the overall bar),
-    ``advance``/``set_completed`` move the tally, ``lane`` updates a worker row."""
+    ``advance`` moves the tally, ``lane`` updates a worker row."""
 
     def __init__(self, parent: ScribeProgress, name: str) -> None:
         self._parent = parent
@@ -308,18 +282,6 @@ class _Phase:
 
     def advance(self, n: int = 1) -> None:
         self._parent._advance(self._name, n)
-
-    def set_completed(self, done: int) -> None:
-        self._parent._set_completed(self._name, done)
-
-    def on_progress(self, done: int, total: int) -> None:
-        """Adapt the ``_caption_all``/``_summarize_all`` ``on_progress`` contract
-        — ``(0, total)`` to reveal, then ``(done, total)`` per item — onto this
-        phase, so those passes need no bespoke closure in the caller."""
-        if done == 0:
-            self.start(total)
-        else:
-            self.set_completed(done)
 
     def lane(self, key: object, item: str, stage: str) -> None:
         self._parent._lane_update(key, item, stage)

--- a/bartleby/ingest/summary.py
+++ b/bartleby/ingest/summary.py
@@ -13,13 +13,12 @@ import itertools
 import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
-from typing import Callable
 
 from bartleby.db.chunks import ChunkInput
 from bartleby.ingest import embed
 from bartleby.ingest import parsers
 from bartleby.ingest.chunk import chunk_markdown_string
-from bartleby.ingest.progress import _ProgressTally
+from bartleby.ingest.progress import _Phase
 from bartleby.ingest.summarize import summarize
 from bartleby.ingest.writer import MAX_INGEST_ATTEMPTS, PendingSummary, Writer
 from bartleby.lib import console
@@ -44,8 +43,7 @@ def _summarize_all(
     max_summarize_tokens: int,
     summarize_workers: int,
     timings: bool,
-    on_progress: Callable[[int, int], None] | None,
-    on_lane: Callable[[object, str, str], None] | None = None,
+    phase: _Phase | None = None,
     reasoning_effort: str | None = None,
 ) -> tuple[int, dict[int, tuple[str, float]]]:
     """Phase 3: summarize every document still owing one, concurrently (#188).
@@ -71,7 +69,8 @@ def _summarize_all(
     """
     incomplete = 0
     times: dict[int, tuple[str, float]] = {}
-    progress = _ProgressTally(len(pending), on_progress)
+    if phase is not None:
+        phase.start(len(pending))
 
     # Capped docs (failed MAX_INGEST_ATTEMPTS× already) are surfaced, not retried.
     work: list[PendingSummary] = []
@@ -82,7 +81,8 @@ def _summarize_all(
                 f"{MAX_INGEST_ATTEMPTS}× already; not retrying."
             )
             incomplete += 1
-            progress.advance()
+            if phase is not None:
+                phase.advance()
         else:
             work.append(ps)
 
@@ -100,8 +100,8 @@ def _summarize_all(
     def _summarize(ps: PendingSummary, text: str):
         # Claim the running thread's lane for this document, then make the LLM
         # call — keyed by thread id so the pool's N threads map to N sticky lanes.
-        if on_lane is not None:
-            on_lane(threading.get_ident(), ps.file_name, "summarizing")
+        if phase is not None:
+            phase.lane(threading.get_ident(), ps.file_name, "summarizing")
         return summarize(
             text, provider=llm_provider, model=llm_model,
             temperature=temperature, max_summarize_tokens=max_summarize_tokens,
@@ -119,7 +119,8 @@ def _summarize_all(
                 _fail(ps, e)
             if t0 is not None:
                 times[ps.document_id] = (ps.file_name, time.perf_counter() - t0)
-            progress.advance()
+            if phase is not None:
+                phase.advance()
         return incomplete, times
 
     # Pooled: keep at most ``summarize_workers`` inputs in flight (see docstring) —
@@ -138,7 +139,8 @@ def _summarize_all(
                     _persist(ps, fut.result())
                 except Exception as e:
                     _fail(ps, e)
-                progress.advance()
+                if phase is not None:
+                    phase.advance()
                 nxt = next(it, None)
                 if nxt is not None:
                     in_flight[

--- a/docs/decisions/GH-0442-drop-progress-tally-0001.md
+++ b/docs/decisions/GH-0442-drop-progress-tally-0001.md
@@ -1,0 +1,69 @@
+# Pass the progress phase handle directly to caption/summarize (issue #442)
+
+> Source: [#442](https://github.com/jswest/bartleby/issues/442)
+
+The caption (#166) and summarize (#188) passes drove their progress through a
+double adapter that existed only to translate between two shapes nobody else
+consumed. The chain: `_caption_all`/`_summarize_all` wrapped a `_ProgressTally`
+(in `bartleby/ingest/progress.py`) that converted `advance()` into
+`on_progress(done, total)`; `scribe.py` passed `cap_phase.on_progress` /
+`sum_phase.on_progress`, where `_Phase.on_progress` converted `(done, total)`
+**back** into `start(total)` / `set_completed(done)`; `set_completed` and
+`ScribeProgress._set_completed` existed solely to serve that round-trip. Each
+phase additionally threaded a second separate callback, `on_lane`, which was just
+`phase.lane`. The only production consumer of the `(done, total)` contract was
+`ScribeProgress` itself — `_ProgressTally`, the `on_progress`/`on_lane` parameter
+pairs, and the `_Phase.on_progress` re-adapter appeared nowhere else in
+`bartleby/`, `scripts/`, `benchmarks/`, or `web/`.
+
+Fix: `_caption_all` and `_summarize_all` now take `phase: _Phase | None` instead
+of `on_progress` + `on_lane`. They call `phase.start(len(pending))` once and
+`phase.advance()` per item, guarding every call on `phase is not None` so the
+headless path (tests, and any future caller that wants no display) is a clean
+no-op. `scribe.py` passes `progress.phase("caption")` / `progress.phase(
+"summarize")` directly. Deleted: `_ProgressTally`, `_Phase.on_progress`,
+`_Phase.set_completed`, and `ScribeProgress._set_completed`. The parse phase
+already drove its handle this way (`parse_phase.start`/`advance`), so all three
+phases are now uniform.
+
+**Rendered progress output is unchanged.** The old chain was a pure round-trip
+onto the same three primitives the handle now calls directly:
+
+- The reveal — `_ProgressTally.__init__` fired `on_progress(0, total)`, which
+  `_Phase.on_progress` routed to `start(total)`. Now `phase.start(len(pending))`
+  is called once at the same point, so the denominator is revealed identically
+  (header tally flips from `—` to `0/total`, the overall bar grows by `total`).
+- Per-item ticks — `_ProgressTally.advance()` fired `on_progress(done, total)`
+  with monotonically rising `done`, which `_Phase.on_progress` routed to
+  `set_completed(done)`, i.e. `self._done[name] = done`. Since `done` rose by
+  exactly 1 each tick, that is identical to `_advance(name, 1)`, which the handle
+  now calls. Both paths land on the same `self._done[name]`, run the same
+  `_recompute_eta`, and call the same `_refresh_overall` — so the header tally,
+  the ETA, and the overall bar render bit-for-bit the same frames.
+- Lanes — `on_lane=cap_phase.lane` became `phase.lane(...)`; same method, same
+  arguments, same call sites.
+
+## What is no longer handled
+
+The caption and summarize phases no longer expose a renderer-agnostic numeric
+progress contract (a bare `Callable[[int, int], None]` plus a bare lane callable)
+that an alternate consumer could plug into; they now take the `ScribeProgress`
+phase handle (or `None`). That is fine because in the code's entire history only
+`ScribeProgress` ever consumed these callbacks — the `(0, total)`-reveal
+convention, the `_ProgressTally` "shared meter", and the `on_progress`/`on_lane`
+parameter pairs existed purely to adapt between the phases and that one renderer,
+and the parse phase already used the handle directly. If a second progress
+consumer ever appears, the callback seam is trivially re-introduced at that point;
+carrying a two-way adapter today is speculative generality the repo's culture
+explicitly rejects.
+
+**No new abstraction.** This deletes an adapter and points the callers at a handle
+that already existed; no layer is introduced. `uv run pytest` stays green — the
+direct-call tests in `tests/test_scribe.py` now pass a small `_StubPhase` (records
+`start`/`advance`/`lane`) and assert against it instead of against the reconstructed
+`(done, total)` tuples; `tests/test_progress.py` exercises the overall bar via
+`advance()` rather than the deleted `set_completed`.
+
+---
+*Filed from the 2026-06-11 dry sweep (dead/wet/bloat audit; every item
+adversarially verified by an independent defender pass).*

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -56,7 +56,8 @@ def test_overall_total_grows_as_each_phase_reveals_its_denominator():
     cap = sp.phase("caption")
     cap.start(5)
     assert _overall(sp) == (2, 8)              # caption's 5 join the total
-    cap.set_completed(5)
+    for _ in range(5):
+        cap.advance()
     assert _overall(sp) == (7, 8)
 
     summ = sp.phase("summarize")

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -118,6 +118,25 @@ class _StubVisionProvider:
         return self.description
 
 
+class _StubPhase:
+    """Records the _Phase calls the caption/summarize passes make, so a test can
+    assert the total was revealed once and the tally advanced per work item."""
+
+    def __init__(self):
+        self.started: list[int] = []
+        self.advances = 0
+        self.lanes: list[tuple[object, str, str]] = []
+
+    def start(self, total: int) -> None:
+        self.started.append(total)
+
+    def advance(self, n: int = 1) -> None:
+        self.advances += n
+
+    def lane(self, key: object, item: str, stage: str) -> None:
+        self.lanes.append((key, item, stage))
+
+
 def _png_bytes(width=100, height=100, color=(20, 200, 50)) -> bytes:
     im = Image.new("RGB", (width, height), color=color)
     buf = io.BytesIO()
@@ -892,7 +911,8 @@ def test_resolve_summarize_workers_tracks_provider_override():
 def test_summarize_all_progress_callback_fires_per_document(
     isolated_project, tmp_path, mock_embed
 ):
-    """The summarize pass invokes on_progress(0, N) then once per document."""
+    """The summarize pass reveals the total once via phase.start, then advances
+    the tally once per document."""
     from bartleby.commands import scribe as scribe_module
 
     txt = _write_txt(tmp_path / "doc.txt", "A document body with real words to chunk.")
@@ -908,27 +928,26 @@ def test_summarize_all_progress_callback_fires_per_document(
         writer.persist_parse(parsed)
 
         pending = writer.documents_needing_summary()
-        seen: list[tuple[int, int]] = []
+        phase = _StubPhase()
         owed, _times = summary._summarize_all(
             writer, pending,
             llm_provider=_StubProvider(), llm_model="m",
             temperature=0.0, max_summarize_tokens=1000,
             summarize_workers=1, timings=False,
-            on_progress=lambda done, total: seen.append((done, total)),
+            phase=phase,
         )
     finally:
         conn.close()
 
-    assert seen, "expected at least one progress callback for one document"
-    assert seen[0] == (0, 1)
-    assert seen[-1] == (1, 1)
+    assert phase.started == [1]          # total revealed once
+    assert phase.advances == 1           # advanced once for the one document
     assert owed == 0
 
 
 def test_summarize_all_lane_callback_reports_document(
     isolated_project, tmp_path, mock_embed
 ):
-    """on_lane fires per summarized document with its file name and stage."""
+    """phase.lane fires per summarized document with its file name and stage."""
     from bartleby.commands import scribe as scribe_module
 
     txt = _write_txt(tmp_path / "doc.txt", "A document body with real words to chunk.")
@@ -944,19 +963,18 @@ def test_summarize_all_lane_callback_reports_document(
         writer.persist_parse(parsed)
 
         pending = writer.documents_needing_summary()
-        lanes: list[tuple[object, str, str]] = []
+        phase = _StubPhase()
         summary._summarize_all(
             writer, pending,
             llm_provider=_StubProvider(), llm_model="m",
             temperature=0.0, max_summarize_tokens=1000,
             summarize_workers=1, timings=False,
-            on_progress=None,
-            on_lane=lambda key, item, stage: lanes.append((key, item, stage)),
+            phase=phase,
         )
     finally:
         conn.close()
 
-    assert lanes == [(lanes[0][0], "doc.txt", "summarizing")]
+    assert phase.lanes == [(phase.lanes[0][0], "doc.txt", "summarizing")]
 
 
 def test_summarize_all_skips_capped_document(
@@ -987,7 +1005,7 @@ def test_summarize_all_skips_capped_document(
             writer, writer.documents_needing_summary(),
             llm_provider=stub, llm_model="m",
             temperature=0.0, max_summarize_tokens=1000,
-            summarize_workers=2, timings=False, on_progress=None,
+            summarize_workers=2, timings=False,
         )
     finally:
         conn.close()
@@ -1242,7 +1260,8 @@ def test_parse_document_threads_on_warn_to_the_leaf(
 def test_caption_all_progress_callback_fires_per_image(
     isolated_project, tmp_path, mock_embed
 ):
-    """The caption phase invokes on_progress(0, N) then once per image."""
+    """The caption pass reveals the total once via phase.start, then advances the
+    tally once per image."""
     from bartleby.commands import scribe as scribe_module
     from bartleby.db.connection import open_db
 
@@ -1260,26 +1279,25 @@ def test_caption_all_progress_callback_fires_per_image(
         )
         document_id = writer.persist_parse(parsed)
 
-        seen: list[tuple[int, int]] = []
+        phase = _StubPhase()
         caption._caption_all(
             writer,
             [parse.DocUnit(document_id, "img.pdf", "h")],
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",
             vision_enabled=True, caption_workers=1, timings=False,
-            on_progress=lambda done, total: seen.append((done, total)),
+            phase=phase,
         )
     finally:
         conn.close()
 
-    assert seen, "expected at least one progress callback for one embedded image"
-    assert seen[0] == (0, 1)
-    assert seen[-1] == (1, 1)
+    assert phase.started == [1]          # total revealed once
+    assert phase.advances == 1           # advanced once for the one image
 
 
 def test_caption_all_lane_callback_reports_owning_document(
     isolated_project, tmp_path, mock_embed
 ):
-    """on_lane fires per analyzed image with the owning file and a stage label,
+    """phase.lane fires per analyzed image with the owning file and a stage label,
     so the renderer can show which worker is captioning what."""
     from bartleby.commands import scribe as scribe_module
     from bartleby.db.connection import open_db
@@ -1298,20 +1316,21 @@ def test_caption_all_lane_callback_reports_owning_document(
         )
         document_id = writer.persist_parse(parsed)
 
-        lanes: list[tuple[object, str, str]] = []
+        phase = _StubPhase()
         caption._caption_all(
             writer,
             [parse.DocUnit(document_id, "img.pdf", "h")],
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",
             vision_enabled=True, caption_workers=1, timings=False,
-            on_progress=None,
-            on_lane=lambda key, item, stage: lanes.append((key, item, stage)),
+            phase=phase,
         )
     finally:
         conn.close()
 
-    assert lanes, "expected a lane update for the one embedded image"
-    assert all(item == "img.pdf" and stage == "captioning" for _, item, stage in lanes)
+    assert phase.lanes, "expected a lane update for the one embedded image"
+    assert all(
+        item == "img.pdf" and stage == "captioning" for _, item, stage in phase.lanes
+    )
 
 
 def test_document_id_for_returns_parsed_document(


### PR DESCRIPTION
Part of #447.

`_caption_all`/`_summarize_all` now take `phase: _Phase | None` and call `phase.start`/`advance`/`lane` directly (no-op when `None`, for headless tests), instead of routing through a `_ProgressTally` and a `(done, total)` adapter round-trip.

**Deleted:** `_ProgressTally`, `_Phase.on_progress`, `_Phase.set_completed`, and `ScribeProgress._set_completed`. `scribe.py` now passes `progress.phase("caption")` / `progress.phase("summarize")` directly, so all three phases drive the handle uniformly (parse already did).

**Rendered progress output is unchanged.** The old chain was a pure round-trip onto the same `start`/`advance`/`lane` primitives the handle now calls: the reveal `on_progress(0, total)` → `start(total)`; each `on_progress(done, total)` with `done` rising by 1 → `set_completed(done)`, i.e. `self._done[name] = done`, which is identical to `_advance(name, 1)`. Both paths land on the same counter, run the same `_recompute_eta`, and call the same `_refresh_overall`. Lanes are the same method, same args.

**Net:** -19 code lines (bartleby/ + tests/); a `docs/decisions/GH-0442-*` entry lands per tier-2.

`uv run pytest` green (928 passed).