### PR TITLE
#465 — guard search source_name lookup against deleted sources

### DIFF
--- a/bartleby/skill_scripts/search.py
+++ b/bartleby/skill_scripts/search.py
@@ -467,6 +467,11 @@ def work(*, conn, args, session_id) -> dict:
     results = []
     for rank, (chunk_id, score) in enumerate(scored, start=1):
         _, source_kind, source_id, chunk_index, section_heading, content_type, text = rows[chunk_id]
+        # Resolve the display name once. An unresolvable pair (source row deleted
+        # by a concurrent session between chunk fetch and name resolution) is
+        # absent from ``names`` — degrade to "" rather than KeyError-aborting the
+        # whole search (issue #465; matches read_chunks' "absent pair" contract).
+        source_name = names.get((source_kind, source_id), "")
         loc = locations.get(
             chunk_id,
             {"file_name": None, "page_number": None, "authored_date": None},
@@ -482,7 +487,7 @@ def work(*, conn, args, session_id) -> dict:
                 "document_id": source_id if source_kind == "document" else None,
                 "source_kind": source_kind,
                 "source_id": source_id,
-                "source_name": names[(source_kind, source_id)],
+                "source_name": source_name,
                 "file_name": loc["file_name"],
                 "page_number": loc["page_number"],
                 "authored_date": loc["authored_date"],
@@ -501,7 +506,7 @@ def work(*, conn, args, session_id) -> dict:
             results.append({
                 "chunk_id": chunk_id,
                 "source_kind": source_kind,
-                "source_name": names[(source_kind, source_id)],
+                "source_name": source_name,
                 "page_number": loc["page_number"],
                 "authored_date": loc["authored_date"],
                 "rank": rank,
@@ -513,7 +518,7 @@ def work(*, conn, args, session_id) -> dict:
             "chunk_id": chunk_id,
             "source_kind": source_kind,
             "source_id": source_id,
-            "source_name": names[(source_kind, source_id)],
+            "source_name": source_name,
             "file_name": loc["file_name"],
             "page_number": loc["page_number"],
             "authored_date": loc["authored_date"],

--- a/tests/test_skill_search.py
+++ b/tests/test_skill_search.py
@@ -793,6 +793,43 @@ def test_search_returning_unknown_field_errors(seeded_project, capsys):
     assert "document_id" in out["valid_fields"]
 
 
+def test_search_completes_when_source_deleted_underneath(seeded_project, capsys):
+    """A chunk whose (source_kind, source_id) pair no longer resolves — its
+    source row deleted by a concurrent session between fetch and name resolution
+    — must degrade that one hit's source_name to "" rather than aborting the
+    whole search with KeyError → INTERNAL_ERROR (issue #465)."""
+    from bartleby.db.chunks import ChunkInput, insert_document_chunks
+    conn = open_db(seeded_project["project"])
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, "
+            "page_count, token_count) VALUES (?, ?, ?, ?, ?)",
+            ("h-ghost", "ghost.txt", "/tmp/ghost.txt", None, 0),
+        )
+        ghost_doc = conn.last_insert_rowid()
+        emb = [0.01 * i for i in range(EMBEDDING_DIM)]
+        insert_document_chunks(conn, ghost_doc, [
+            ChunkInput(text="ghostword chunk", embedding=emb, chunk_index=0),
+        ])
+        # Drop the document row out from under its still-indexed chunk, so the
+        # (document, ghost_doc) pair is absent from source_names' result.
+        cur.execute("DELETE FROM documents WHERE document_id = ?", (ghost_doc,))
+    finally:
+        conn.close()
+
+    # Default, brief, and --returning all read source_name — each must survive.
+    for extra in ([], ["--brief"], ["--returning", "chunk_id,source_name"]):
+        _run([
+            "--project", seeded_project["project"],
+            "--full-text", "ghostword", *extra,
+        ])
+        out = json.loads(capsys.readouterr().out)
+        assert "error" not in out, f"search aborted with {extra}: {out}"
+        hit = next(r for r in out["results"] if r["chunk_id"])
+        assert hit["source_name"] == ""
+
+
 def test_search_default_projection_unchanged_without_returning(seeded_project, capsys):
     _run([
         "--project", seeded_project["project"], "--full-text", "alpha",


### PR DESCRIPTION
Part of #472.

search indexed the `source_names` map directly (`names[(kind, id)]`) at every projection site, so a source row deleted by a concurrent session between chunk fetch and name resolution raised `KeyError` → the whole search aborted as `INTERNAL_ERROR`.

This resolves the display name once per hit with `names.get((kind, id), "")`, so an unresolvable ("absent") pair degrades that one hit's `source_name` to `""` rather than aborting the search. Matches `read_chunks`' `.get(...)` pattern and the `source_names` helper's documented "absent pair" contract.

**Test:** `test_search_completes_when_source_deleted_underneath` seeds a still-indexed chunk whose document row is deleted underneath it, then asserts search completes (default / `--brief` / `--returning`) with `source_name == ""`. Full suite: 959 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)