### PR TITLE
#471 — cover untested skill error codes

### DIFF
--- a/tests/test_skill_edit_finding.py
+++ b/tests/test_skill_edit_finding.py
@@ -480,3 +480,16 @@ def test_edit_finding_rejects_empty_title(seeded_project, tmp_path, capsys):
     assert exc.value.code == 1
     out = json.loads(capsys.readouterr().out)
     assert out["code"] == "EMPTY_TITLE"
+
+
+def test_edit_finding_rejects_empty_description(seeded_project, tmp_path, capsys):
+    saved = _seed_finding(seeded_project, tmp_path, capsys)
+    with pytest.raises(SystemExit) as exc:
+        edit_finding.main([
+            "--project", seeded_project["project"],
+            "--finding", str(saved["finding_id"]),
+            "--description", "   ",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_DESCRIPTION"

--- a/tests/test_skill_merge_findings.py
+++ b/tests/test_skill_merge_findings.py
@@ -305,6 +305,131 @@ def test_merge_rejects_citation_to_involved_finding_chunk(
         conn.close()
 
 
+def test_merge_rejects_malformed_citation(seeded_project, tmp_path, capsys):
+    """A merged body with bare ``[N]`` markers (missing the caret) is refused
+    upfront via load_finding_body's MALFORMED_CITATION guard; nothing mutates."""
+    project = seeded_project["project"]
+    chunks = _doc_chunk_ids(project, seeded_project["doc_a"])
+    target = _save(project, tmp_path, capsys, name="t", title="Target", cite=chunks[0])
+    src = _save(project, tmp_path, capsys, name="s", title="Source", cite=chunks[1])
+
+    merged_file = tmp_path / "m.md"
+    merged_file.write_text(
+        f"Real[^{chunks[0]}] but typoed[3] and again[42].", encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        merge_findings.main([
+            "--project", project,
+            "--from", str(src),
+            "--into", str(target),
+            "--body-file", str(merged_file),
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "MALFORMED_CITATION"
+    assert out["malformed_markers"] == ["[3]", "[42]"]
+
+    # Both findings survive — the merge aborted before any deletion.
+    conn = open_db(project)
+    try:
+        assert conn.cursor().execute(
+            "SELECT COUNT(*) FROM findings WHERE finding_id IN (?, ?)",
+            (target, src),
+        ).fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_merge_rejects_unknown_citation(seeded_project, tmp_path, capsys):
+    """A merged body citing a chunk_id that doesn't exist is refused with
+    UNKNOWN_CITATIONS naming the offending id."""
+    project = seeded_project["project"]
+    chunks = _doc_chunk_ids(project, seeded_project["doc_a"])
+    target = _save(project, tmp_path, capsys, name="t", title="Target", cite=chunks[0])
+    src = _save(project, tmp_path, capsys, name="s", title="Source", cite=chunks[1])
+
+    merged_file = tmp_path / "m.md"
+    merged_file.write_text(f"Real[^{chunks[0]}] plus garbage[^999999].",
+                           encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        merge_findings.main([
+            "--project", project,
+            "--from", str(src),
+            "--into", str(target),
+            "--body-file", str(merged_file),
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "UNKNOWN_CITATIONS"
+    assert out["unknown_chunk_ids"] == [999999]
+
+
+def test_merge_rejects_empty_body(seeded_project, tmp_path, capsys):
+    """A whitespace-only body file is refused via load_finding_body's EMPTY_BODY
+    guard; nothing mutates."""
+    project = seeded_project["project"]
+    chunks = _doc_chunk_ids(project, seeded_project["doc_a"])
+    target = _save(project, tmp_path, capsys, name="t", title="Target", cite=chunks[0])
+    src = _save(project, tmp_path, capsys, name="s", title="Source", cite=chunks[1])
+
+    merged_file = tmp_path / "empty.md"
+    merged_file.write_text("   \n\n  ", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        merge_findings.main([
+            "--project", project,
+            "--from", str(src),
+            "--into", str(target),
+            "--body-file", str(merged_file),
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_BODY"
+
+    conn = open_db(project)
+    try:
+        assert conn.cursor().execute(
+            "SELECT COUNT(*) FROM findings WHERE finding_id IN (?, ?)",
+            (target, src),
+        ).fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_merge_dedups_repeated_from_ids(seeded_project, tmp_path, capsys):
+    """A source id repeated in --from is deduped (first-appearance order): it is
+    folded in once and reported once in merged_from, not twice."""
+    project = seeded_project["project"]
+    chunks = _doc_chunk_ids(project, seeded_project["doc_a"])
+    c0, c1 = chunks[0], chunks[1]
+
+    target = _save(project, tmp_path, capsys, name="t", title="Keep", cite=c0)
+    src = _save(project, tmp_path, capsys, name="s", title="Dup", cite=c1)
+
+    merged_file = tmp_path / "merged.md"
+    merged_file.write_text(f"# C\n\nTogether[^{c0}][^{c1}].", encoding="utf-8")
+
+    merge_findings.main([
+        "--project", project,
+        "--from", f"{src},{src}",
+        "--into", str(target),
+        "--body-file", str(merged_file),
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["merged_from"] == [src]  # deduped, not [src, src]
+
+    # The source is folded in exactly once and gone.
+    conn = open_db(project)
+    try:
+        assert conn.cursor().execute(
+            "SELECT COUNT(*) FROM findings WHERE finding_id = ?", (src,),
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_merge_memory_off_foreign_source_rejected(seeded_project, tmp_path, capsys):
     """A memory-off session cannot consume a foreign session's finding, and the
     gate fires before any deletion — both findings survive."""

--- a/tests/test_skill_read_document.py
+++ b/tests/test_skill_read_document.py
@@ -76,6 +76,43 @@ def test_read_document_force_bypasses_gate(seeded_project, capsys, monkeypatch):
     assert out["full_text"]
 
 
+def test_read_document_unknown_document(seeded_project, capsys):
+    with pytest.raises(SystemExit) as exc:
+        read_document.main([
+            "--project", seeded_project["project"], "--document", "999999",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "DOCUMENT_NOT_FOUND"
+
+
+def test_read_document_summary_null_when_undocumented(seeded_project, capsys):
+    # doc_b has no summary row; --summary returns the documented success shape
+    # with summary == null (not an error).
+    read_document.main([
+        "--project", seeded_project["project"],
+        "--document", str(seeded_project["doc_b"]),
+        "--summary",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["document"]["file_name"] == "beta.txt"
+    assert out["summary"] is None
+    assert out["full_text"] is None
+
+
+def test_read_document_summary_and_full_mutually_exclusive(seeded_project, capsys):
+    # --summary and --full are an argparse mutually-exclusive group; passing
+    # both fails with the JSON usage envelope before any query runs.
+    with pytest.raises(SystemExit) as exc:
+        read_document.main([
+            "--project", seeded_project["project"],
+            "--document", str(seeded_project["doc_a"]),
+            "--summary", "--full",
+        ])
+    assert exc.value.code == 1
+    assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"
+
+
 @pytest.mark.parametrize("bad", ["0", "-1"])
 def test_read_document_non_positive_id_rejected(seeded_project, capsys, bad):
     # The --document id flag uses the shared positive_int validator (issue #403):

--- a/tests/test_skill_save_summary.py
+++ b/tests/test_skill_save_summary.py
@@ -253,3 +253,46 @@ def test_save_summary_unknown_document(seeded_project, capsys):
     assert exc.value.code == 1
     out = json.loads(capsys.readouterr().out)
     assert out["code"] == "DOCUMENT_NOT_FOUND"
+
+
+def test_save_summary_rejects_empty_title(seeded_project, capsys):
+    # A whitespace-only title is refused before any document lookup or write.
+    with pytest.raises(SystemExit) as exc:
+        save_summary.main([
+            "--project", seeded_project["project"],
+            "--document", str(seeded_project["doc_b"]),
+            "--title", "   ",
+            "--description", "A real description.",
+            "--text", "A real body.",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_TITLE"
+
+
+def test_save_summary_rejects_empty_description(seeded_project, capsys):
+    with pytest.raises(SystemExit) as exc:
+        save_summary.main([
+            "--project", seeded_project["project"],
+            "--document", str(seeded_project["doc_b"]),
+            "--title", "A real title",
+            "--description", "   ",
+            "--text", "A real body.",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_DESCRIPTION"
+
+
+def test_save_summary_rejects_empty_text(seeded_project, capsys):
+    with pytest.raises(SystemExit) as exc:
+        save_summary.main([
+            "--project", seeded_project["project"],
+            "--document", str(seeded_project["doc_b"]),
+            "--title", "A real title",
+            "--description", "A real description.",
+            "--text", "   ",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "EMPTY_TEXT"

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -219,6 +219,16 @@ def test_delete_tag_cascades_assignments(seeded_project, capsys):
     assert out["removed_assignments"] == 1
 
 
+def test_delete_tag_unknown_tag(seeded_project, capsys):
+    with pytest.raises(SystemExit) as exc:
+        delete_tag.main([
+            "--project", seeded_project["project"], "--tag", "nonexistent",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "TAG_NOT_FOUND"
+
+
 def test_rename_tag_renames_and_preserves_assignment(seeded_project, capsys):
     # The happy path: a fresh-named target renames in place. The tag_id and the
     # document_tags row both survive (rename only touches tags.name), and the
@@ -452,6 +462,31 @@ def test_merge_tags_full_overlap_reports_none_inserted(seeded_project, capsys):
     out = json.loads(capsys.readouterr().out)
     assert out["inserted"] == 0
     assert out["already_present"] == 2
+
+
+def test_merge_tags_self_merge_rejected(seeded_project, capsys):
+    # --from == --into is refused before any tag lookup or mutation.
+    with pytest.raises(SystemExit) as exc:
+        merge_tags.main([
+            "--project", seeded_project["project"],
+            "--from", "a", "--into", "a",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "SELF_MERGE"
+
+
+def test_merge_tags_unknown_source_tag(seeded_project, capsys):
+    # The destination exists but the source doesn't → TAG_NOT_FOUND.
+    _seed_tag(seeded_project["project"], name="dst", description="d")
+    with pytest.raises(SystemExit) as exc:
+        merge_tags.main([
+            "--project", seeded_project["project"],
+            "--from", "nope", "--into", "dst",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "TAG_NOT_FOUND"
 
 
 def _fail_on_sql(monkeypatch, needle: str) -> None:


### PR DESCRIPTION
Part of #472.

Tests-only coverage for still-extant untested skill error codes. Each error-code test asserts exit 1 and the exact JSON envelope `code`; edge cases assert the documented success shape. No production code changed.

- **save_summary**: EMPTY_TITLE / EMPTY_DESCRIPTION / EMPTY_TEXT
- **delete_tag**: TAG_NOT_FOUND
- **merge_tags**: SELF_MERGE / TAG_NOT_FOUND (happy-path moved-assignments already covered)
- **read_document**: DOCUMENT_NOT_FOUND, the summary:null edge case (undocumented doc), and the --summary/--full mutual-exclusion USAGE_ERROR
- **edit_finding**: EMPTY_DESCRIPTION
- **merge_findings**: MALFORMED_CITATION / UNKNOWN_CITATIONS (shared load_finding_body path), EMPTY_BODY, and duplicate --from dedup

Re-scoped out per the issue: add_tag EMPTY_NAME / EMPTY_NORMALIZED_NAME — #439 (v0.9.3) deleted those guards (confirmed absent in the current code).

`uv run pytest`: 971 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)