### PR TITLE
#421 — also write skill errors to stderr

### DIFF
--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -14,7 +14,10 @@ and calls :func:`run`. The runner:
   session to attribute the call to, so it surfaces only in the error envelope;
   the DB connection is still closed on every path where it was opened.
 - Prints either the worker's dict result, or
-  ``{"error": ..., "code": ...}`` on failure, to stdout.
+  ``{"error": ..., "code": ...}`` on failure, to stdout. On failure the error
+  is *also* echoed as ``code: message`` to stderr (issue #421) so a stdout-only
+  consumer can distinguish a tool error from an empty result; the stdout JSON
+  envelope is unchanged.
 - Exits 0 on success and 1 on failure.
 
 A script that mutates the DB passes ``mutates=True`` to :func:`run`; the runner
@@ -84,6 +87,22 @@ def _print_json(payload: Any) -> None:
     sys.stdout.write("\n")
 
 
+def _emit_error(envelope: dict) -> None:
+    """Emit an error envelope on BOTH channels, then exit non-zero.
+
+    The stdout JSON envelope is the machine contract and stays byte-for-byte
+    unchanged. We *also* echo ``code: message`` to stderr (issue #421): today a
+    stdout-only consumer can't tell a tool error from an empty result, and an
+    error is prose — it belongs on stderr alongside the existing
+    progress/prose-to-stderr split. This is the single error-emission point so
+    the two channels never drift; individual scripts never write stderr
+    themselves.
+    """
+    _print_json(envelope)
+    sys.stderr.write(f"{envelope['code']}: {envelope['error']}\n")
+    sys.exit(1)
+
+
 def run(
     *,
     tool_name: str,
@@ -130,11 +149,10 @@ def run(
     except SystemExit as e:
         if not e.code:  # None or 0 → clean exit (e.g. --help); re-raise untouched
             raise
-        _print_json({
+        _emit_error({
             "error": "Invalid arguments. See --help for usage.",
             "code": "USAGE_ERROR",
         })
-        sys.exit(1)
 
     try:
         args_dict = {k: v for k, v in vars(args).items() if v is not None}
@@ -202,7 +220,6 @@ def run(
         conn.close()
 
     if error_envelope is not None:
-        _print_json(error_envelope)
-        sys.exit(1)
+        _emit_error(error_envelope)
 
     _print_json(result)

--- a/tests/test_skill_runner.py
+++ b/tests/test_skill_runner.py
@@ -288,6 +288,54 @@ def test_no_active_project_emits_envelope_without_opening_db(capsys, monkeypatch
     assert "error" in out
 
 
+def test_error_is_echoed_to_stderr_without_changing_stdout_envelope(
+    seeded_project, capsys
+):
+    """On failure the error lands on BOTH channels (issue #421): the stdout JSON
+    envelope is unchanged (the machine contract) with a non-zero exit, and stderr
+    now carries a human-readable ``code: message`` line so a stdout-only consumer
+    can tell a tool error from an empty result."""
+    project = seeded_project["project"]
+
+    def work(*, conn, args, session_id) -> dict:
+        raise RuntimeError("boom in work")
+
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="both_channels_probe",
+            parse_args=_parse_args,
+            work=work,
+            argv=["--project", project],
+        )
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+
+    # stdout: the JSON envelope, unchanged — whole stdout is one JSON object.
+    out = json.loads(captured.out)
+    assert out["code"] == "INTERNAL_ERROR"
+    assert out["error"] == "RuntimeError: boom in work"
+
+    # stderr: now non-empty, carrying the code and the message.
+    assert captured.err.strip() == "INTERNAL_ERROR: RuntimeError: boom in work"
+
+
+def test_usage_error_is_echoed_to_stderr(capsys):
+    """The USAGE_ERROR path shares the same dual-channel emission: stdout keeps
+    the envelope, stderr gets the ``code: message`` echo (issue #421)."""
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="probe",
+            parse_args=_parse_args,
+            work=_never,
+            argv=["--bogus-flag"],
+        )
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    out = json.loads(captured.out)
+    assert out["code"] == "USAGE_ERROR"
+    assert "USAGE_ERROR:" in captured.err
+
+
 def test_help_still_exits_zero(capsys):
     """``--help`` keeps argparse's clean exit-0 behavior — the envelope arm
     only swallows non-zero usage errors."""


### PR DESCRIPTION
Part of #472.

The shared skill error path now **also** echoes the error to stderr (as `code: message`), in addition to the unchanged stdout JSON envelope and the non-zero exit. This aligns errors with the existing prose/progress-to-stderr split: today a stdout-only consumer can't distinguish a tool error from an empty result.

## What changed
- `bartleby/skill_runner.py`: new `_emit_error` helper consolidates the two error-emission sites (USAGE_ERROR + the main `error_envelope` path). It prints the stdout JSON envelope first (unchanged), then writes `code: message` to stderr, then exits 1.
- The **stdout JSON envelope is byte-for-byte unchanged** (the machine contract) and the exit code is unchanged — additive only, no schema change.

## Tests
- `test_error_is_echoed_to_stderr_without_changing_stdout_envelope`: a raising `work()` yields the unchanged INTERNAL_ERROR envelope on stdout + exit 1, and stderr now carries `INTERNAL_ERROR: ...`.
- `test_usage_error_is_echoed_to_stderr`: the USAGE_ERROR path also writes to both channels.
- Full suite green (989 passed).