### PR TITLE
#466 — pin scan/describe_corpus finding-chunk exclusion

### DIFF
--- a/tests/test_skill_describe_corpus.py
+++ b/tests/test_skill_describe_corpus.py
@@ -7,7 +7,9 @@ import json
 from bartleby.db.connection import open_db
 from bartleby.skill_scripts import describe_corpus
 from tests._skill_fixtures import (  # noqa: F401
+    mock_embed,
     project_env,
+    seed_finding,
     seed_image,
     seeded_project,
 )
@@ -67,6 +69,42 @@ def test_describe_corpus_happy_path(seeded_project, capsys):
         "title": "Alpha", "token_count": 1000,
     }
     assert out["largest_documents"][1]["title"] is None  # beta has no summary
+
+
+def test_describe_corpus_excludes_summary_and_finding_chunks(seeded_project, capsys):
+    """chunk_count and content_mix count only document chunks. Adding more
+    summary chunks and a finding chunk leaves both aggregates at the baseline —
+    findings/summaries are polymorphic chunks but never corpus content."""
+    project = seeded_project["project"]
+    conn = open_db(project)
+    try:
+        cur = conn.cursor()
+        # Another summary, this one on beta, with its own chunk.
+        from bartleby.db.chunks import ChunkInput, insert_summary_chunks
+        from tests._skill_fixtures import _emb
+        cur.execute(
+            "INSERT INTO summaries (document_id, title, description, text, model) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (seeded_project["doc_b"], "Beta", "desc", "summary body", "test"),
+        )
+        summary_b = conn.last_insert_rowid()
+        insert_summary_chunks(conn, summary_b, [
+            ChunkInput(text="beta summary chunk zero", embedding=_emb(4.0),
+                       chunk_index=0),
+        ])
+        # A prior-session finding with a body chunk.
+        cur.execute("INSERT INTO sessions (name) VALUES (?)", ("prior",))
+        session_id = conn.last_insert_rowid()
+        seed_finding(conn, session_id, title="Prior finding",
+                     body="A finding note about the corpus.")
+    finally:
+        conn.close()
+
+    out = _run(project, capsys)
+    # Unchanged from test_describe_corpus_happy_path's baseline.
+    assert out["chunk_count"] == 6
+    mix = {row["content_type"]: row["chunk_count"] for row in out["content_mix"]}
+    assert mix == {"text": 4, None: 2}
 
 
 def test_describe_corpus_enriched(seeded_project, capsys):
@@ -222,6 +260,30 @@ def test_describe_corpus_date_bound_reports_excluded_nulls(seeded_project, capsy
     # beta is undated → dropped by the bound, surfaced honestly.
     assert out["filters"]["excluded_null_dated"] == 1
     assert out["filters"]["authored_after"] == "2024-01-01"
+
+
+def test_describe_corpus_date_bound_include_nulls_keeps_undated(seeded_project, capsys):
+    """--include-nulls keeps undated documents under a date bound: beta rides
+    along, both docs count, and nothing is reported as excluded."""
+    project = seeded_project["project"]
+    conn = open_db(project)
+    try:
+        conn.cursor().execute(
+            "UPDATE summaries SET authored_date = '2024-03-01' WHERE document_id = ?",
+            (seeded_project["doc_a"],),
+        )
+    finally:
+        conn.close()
+
+    out = _run(project, capsys,
+               extra=["--authored-after", "2024-01-01", "--include-nulls"])
+    assert out["document_count"] == 2   # dated alpha + undated beta both survive
+    assert out["authored_date"] == {
+        "min": "2024-03-01", "max": "2024-03-01",
+        "dated_document_count": 1, "undated_document_count": 1,
+    }
+    assert out["filters"]["include_nulls"] is True
+    assert out["filters"]["excluded_null_dated"] == 0
 
 
 def test_describe_corpus_scoped_content_mix_reaches_images(seeded_project, capsys):

--- a/tests/test_skill_scan.py
+++ b/tests/test_skill_scan.py
@@ -9,7 +9,7 @@ import pytest
 from bartleby.db.chunks import ChunkInput, insert_document_chunks, insert_summary_chunks
 from bartleby.db.connection import open_db
 from bartleby.skill_scripts import scan
-from tests._skill_fixtures import _emb, project_env  # noqa: F401
+from tests._skill_fixtures import _emb, mock_embed, project_env, seed_finding  # noqa: F401
 
 
 MARKER = "I will divest my interests in"
@@ -77,6 +77,23 @@ def scan_corpus(project_env):  # noqa: F811
             ChunkInput(text="Summary: " + MARKER + " ACME CORP.", embedding=_emb(3.0),
                        chunk_index=0),
         ])
+
+        # A finding chunk that also contains the marker — scan is docs-only, so
+        # this prior-session finding must never surface as a scan match either.
+        cur.execute("INSERT INTO sessions (name) VALUES (?)", ("prior",))
+        session_id = conn.last_insert_rowid()
+        _, finding_chunk_ids = seed_finding(
+            conn, session_id,
+            title="Prior finding",
+            body="Finding note: " + MARKER + " ACME CORP per the record.",
+        )
+
+        # A tag carried by d2 alone, so --tag can prove it narrows the slice.
+        cur.execute("INSERT INTO tags (name, description) VALUES (?, ?)",
+                    ("senate", "senate filings"))
+        tag_id = conn.last_insert_rowid()
+        cur.execute("INSERT INTO document_tags (document_id, tag_id) VALUES (?, ?)",
+                    (d2, tag_id))
     finally:
         conn.close()
 
@@ -86,6 +103,7 @@ def scan_corpus(project_env):  # noqa: F811
         "long_chunk_id": d1_ids[1],
         "distractor_chunk_id": d2_ids[1],
         "summary_chunk_id": summary_ids[0],
+        "finding_chunk_id": finding_chunk_ids[0],
     }
 
 
@@ -173,6 +191,15 @@ def test_scan_in_documents_scope(scan_corpus, capsys):
     _run(scan_corpus, [MARKER, "--in-documents", str(scan_corpus["d2"])])
     out = json.loads(capsys.readouterr().out)
     assert out["filters"]["in_documents"] == [scan_corpus["d2"]]
+    assert out["total"] == 1
+    assert all(m["document_id"] == scan_corpus["d2"] for m in out["matches"])
+
+
+def test_scan_tag_scope(scan_corpus, capsys):
+    # Only d2 carries the 'senate' tag, so --tag narrows the slice to its hit.
+    _run(scan_corpus, [MARKER, "--tag", "senate"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["filters"]["tags"] == ["senate"]
     assert out["total"] == 1
     assert all(m["document_id"] == scan_corpus["d2"] for m in out["matches"])
 
@@ -388,6 +415,16 @@ def test_scan_excludes_summary_chunks(scan_corpus, capsys):
     out = json.loads(capsys.readouterr().out)
     ids = {m["chunk_id"] for m in out["matches"]}
     assert scan_corpus["summary_chunk_id"] not in ids
+    assert out["total"] == 3
+
+
+def test_scan_excludes_finding_chunks(scan_corpus, capsys):
+    """A prior-session finding chunk carries the marker, but scan is docs-only:
+    its chunk never rides along and the total stays at the 3 document hits."""
+    _run(scan_corpus, [MARKER])
+    out = json.loads(capsys.readouterr().out)
+    ids = {m["chunk_id"] for m in out["matches"]}
+    assert scan_corpus["finding_chunk_id"] not in ids
     assert out["total"] == 3
 
 


### PR DESCRIPTION
Part of #472. Tests-only coverage pinning the polymorphic-chunks boundary at two skill surfaces — no production code changed.

**scan (docs-only):** extends the `scan_corpus` fixture to seed a marker-bearing finding chunk (via the typed `seed_finding`/`insert_finding_chunks` helper) and a `senate` tag on d2.
- `test_scan_excludes_finding_chunks` — a finding chunk carrying the marker never surfaces; `total` stays at the 3 document hits.
- `test_scan_tag_scope` — `--tag senate` narrows the slice to the tagged document.

**describe_corpus (content aggregates count only document chunks):**
- `test_describe_corpus_excludes_summary_and_finding_chunks` — adding an extra summary chunk and a finding chunk leaves `chunk_count`/`content_mix` at the happy-path baseline.
- `test_describe_corpus_date_bound_include_nulls_keeps_undated` — `--include-nulls` keeps undated documents under a date bound.

Full suite: `uv run pytest` → 998 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)