### PR TITLE
Refresh drifted docs: ARCHITECTURE, README, shipped skill docs, module docstrings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 Bartleby is two surfaces over one SQLite database:
 
-1. **The CLI (`bartleby ...`)** — ingestion (`scribe`), config (`ready`), projects, sessions, embedding, audit logs.
-2. **The skill (`skill/`)** — six Python scripts the agent calls: `list_documents`, `search`, `read_chunks`, `read_document`, `save_summary`, `save_finding`.
+1. **The CLI (`bartleby ...`)** — ingestion (`scribe`), config (the `config` wizard; `ready` installs/refreshes the skill into a harness), `serve`, projects, sessions, embedding, audit logs.
+2. **The skill** — the agent-facing scripts, dispatched via `bartleby skill <name>`. The dispatcher (`bartleby/commands/skill.py`) derives its script set dynamically from the non-underscore modules of `bartleby/skill_scripts/` (about two dozen: `search`, `read_document`, `save_finding`, the tag ops, `extract`, …), so a new script is callable on drop-in. The shipped `skill/` folder holds only `SKILL.md` + `README.md` (the agent-facing guide); the scripts themselves are package-internal.
 
 The database is the contract between them. The CLI writes; the skill reads and writes findings back. Both import from one Python package (`bartleby/`).
 
@@ -41,7 +41,7 @@ Image chunks carry one of two `content_type` values: `image_ocr` (verbatim trans
 
 ### Summarizer structured-output contract
 
-The summarizer is structured-output only across all three providers (Anthropic / OpenAI / Ollama). Even though we control the prompt, JSON enforcement keeps open-source models from drifting into "Here is your summary:" preambles, thinking tags, or stray markdown fences. The schema is rendered from a Pydantic model (`DocumentSummary`); all three providers consume `model_json_schema()`, so adding fields means one place to change.
+The summarizer is structured-output only across all four providers (Anthropic / OpenAI / Ollama / wsjpt). Even though we control the prompt, JSON enforcement keeps open-source models from drifting into "Here is your summary:" preambles, thinking tags, or stray markdown fences. The schema is a Pydantic model (`DocumentSummary`); the three first-party providers consume its `model_json_schema()` and wsjpt takes the model class directly, so adding fields means one place to change.
 
 Validation failures raise. Don't insert malformed summaries silently.
 
@@ -57,8 +57,8 @@ When a document exceeds `max_summarize_tokens`, the summary's `text` field gets 
 
 - Skill scripts print one JSON object to stdout, exit non-zero on error with `{"error", "code"}`. Prose/progress goes to stderr only.
 - Embedding model: `BAAI/bge-base-en-v1.5` (768 dims, 512 token max). FTS5 tokenizer: `unicode61 remove_diacritics 2`.
-- LLM provider defaults: anthropic `claude-haiku-4-5`, openai `gpt-5-mini`, ollama `qwen3-vl:30b`.
-- VLM provider defaults: anthropic `claude-haiku-4-5`, openai `gpt-5-mini`, ollama `qwen3-vl:30b`.
+- LLM provider defaults (`ALLOWED_PROVIDERS` — four): anthropic `claude-haiku-4-5`, openai `gpt-5-mini`, ollama `qwen3-vl:30b`, wsjpt `fast`.
+- VLM provider defaults: anthropic `claude-haiku-4-5`, openai `gpt-5-mini`, ollama `qwen3-vl:30b`, wsjpt `fast`.
 - PDF converter (config `pdf_converter`, CLI `--pdf-converter`): `pdfplumber` (default — fast text + page-render image extraction) and `docling` (opt-in — better structural extraction at higher cost).
 - HTML converter (config `html_converter`, CLI `--html-converter`): `docling` (default) and `sec2md` (opt-in — routes iXBRL EDGAR filings to sec2md by sniff, non-iXBRL HTML falls back to docling). MD always goes through docling. If you have an HTML/MD corpus, `docling` must be installed; if you set `html_converter=sec2md`, the `sec2md` extra must also be installed.
 - Dependency management: `uv` (not pip/venv). Run with `uv run python`.

--- a/README.md
+++ b/README.md
@@ -292,12 +292,13 @@ Interactive configuration wizard. Asks for:
 | API key | — | Required for Anthropic/OpenAI; can also use env vars |
 | Summary depth | `one-shot` | `none` or `one-shot` |
 | Temperature | 0 | 0 = deterministic, 1 = creative |
+| Reasoning effort | `low` | `minimal`, `low`, `medium`, or `high` — how hard the model reasons before summarizing. Lower = fewer billed reasoning tokens and faster; plenty for summaries. Applies to OpenAI (gpt-5) and effort-capable Anthropic models; Ollama/wsjpt accept and ignore it. Only prompted when summary depth is `one-shot` |
 | Max summarize tokens | 50000 | If a document exceeds this, only the first N tokens are summarized (with a note appended) |
 | Summarize workers | 4 (cloud) / 1 (Ollama) | How many documents summarize in parallel after parsing. The LLM call is network-bound, so it runs as its own stage — raise it for a rate-tolerant cloud provider. A local Ollama provider auto-clamps to 1 and isn't prompted for a count (`OLLAMA_NUM_PARALLEL` defaults to 1, so parallel requests only queue) |
 | PDF converter | `pdfplumber` | `pdfplumber` (fast, default) or `docling` (slower, more structurally aware) |
 | HTML converter | `docling` | `docling` (default; also handles `.md`) or `sec2md` (routes iXBRL EDGAR filings to sec2md, other HTML to docling) |
 | Sparse-text threshold | 100 | Pages with fewer extracted chars are treated as scanned; OCR then VLM fallback |
-| Parse workers | auto | How many documents to parse in parallel. `0` = auto (`min(CPU cores − 2 reserved, free RAM ÷ ~4 GB)`) — the auto-pick leaves a couple of cores for the OS so a long ingest doesn't saturate the machine; a value you set here can use every core. Workers recycle periodically to keep memory bounded. Raise for a faster bulk ingest on a big machine, lower if memory is tight |
+| Parse workers | auto | How many documents to parse in parallel. `0` = auto (`min(CPU cores − 2 reserved, free RAM ÷ ~12 GB)`, the `PER_WORKER_GB` budget measured against peak pdfplumber RSS) — the auto-pick leaves a couple of cores for the OS so a long ingest doesn't saturate the machine; a value you set here can use every core. Workers recycle periodically to keep memory bounded. Raise for a faster bulk ingest on a big machine, lower if memory is tight |
 | Vision provider | (off) | Off by default; opt in during the wizard. If enabled, choose `anthropic`, `openai`, or `ollama` (plus `wsjpt`, WSJ-internal) |
 | Vision model | varies by provider | e.g., `claude-haiku-4-5`, `gpt-5-mini`, `qwen3-vl:30b` |
 | Max image dimension | 768 | Long-edge pixels before sending an image to the VLM |
@@ -362,7 +363,7 @@ bartleby scribe --files <path> [<path> ...] [options]
 
 **Supported file types:** `.pdf`, `.html`/`.htm`, `.md`, `.txt`, image files (`.jpg`/`.jpeg`, `.png`, `.webp`, `.bmp`, `.tiff`/`.tif`). The type is taken from the extension when it is one of these; a missing or unrecognized extension is resolved by sniffing the file's magic bytes instead. A recognized extension is always trusted as-is — content never overrides it — so a `.txt` that happens to hold PDF bytes stays text.
 
-Ingestion runs sequentially. The embedding model is heavy, and small corpora don't benefit enough from parallelism to justify the warmup cost and complexity.
+Ingestion runs in three concurrent phases — parse (a process pool), image caption, and summarize (each its own worker pool, sized by the wizard settings above) — all feeding a single writer that owns the database connection. See [`ARCHITECTURE.md`](./ARCHITECTURE.md) for the single-writer drain and how a run resumes by what's missing.
 
 **Pipeline:**
 
@@ -476,7 +477,7 @@ stores, and provenance — lives in [`benchmarks/README.md`](benchmarks/README.m
 | --- | --- | --- | --- |
 | Anthropic | `claude-haiku-4-5` | `claude-haiku-4-5` | Requires API key. Structured output via tool-use. |
 | OpenAI | `gpt-5-mini` | `gpt-5-mini` | Requires API key. Structured output via the SDK's Pydantic parse helper. |
-| Ollama | `qwen3-vl:30b` | `qwen3-vl:30b` | Local server. Structured output via the chat API's `format=` JSON schema. One MoE model handles both jobs; `gemma4:e2b` is a lighter alternative — see the Ollama-defaults note above. |
+| Ollama | `qwen3-vl:30b` | `qwen3-vl:30b` | Local server. Structured output via the chat API's `format=` JSON schema. One MoE model handles both jobs; `gemma4:e2b` is a lighter alternative (see [Picking models for your hardware](#picking-models-for-your-hardware)). |
 | wsjpt | `fast` | `fast` | Out-of-band install (`uv pip install 'git+ssh://git@github.dowjones.net/data/wsjpt.git'`; not in the locked deps — WSJ-internal git source). Routes Gemini via WSJ's [parsing toolkit](https://github.dowjones.net/data/wsjpt) so model aliases (`fast` / `smart` / `smartest`) resolve centrally — no concrete model names in bartleby config. WSJ-internal install. Set `GEMINI_API_KEY` (or `wsjpt_api_key` in config); without one, wsjpt falls back to Vertex AI via ADC. |
 
 The same provider list is used for both ingest-time summarization (the LLM) and image analysis (the VLM). You can mix providers — e.g. OpenAI for summaries, local Ollama for image analysis — or run the same one for both. Research at the agent layer is governed by whatever model your harness is running the `bartleby` skill against, not by these settings.

--- a/bartleby/ingest/sec2md.py
+++ b/bartleby/ingest/sec2md.py
@@ -1,9 +1,15 @@
 """sec2md wrapper — converter for iXBRL EDGAR filings.
 
-Slots in alongside ``docling`` on the HTML branch. Only opted in when
-``html_converter = sec2md`` in config (or ``--html-converter sec2md`` on the
-CLI), and even then only routed to for files that pass the iXBRL sniff. Other
-HTML/HTM files fall through to Docling. See issue #14 for the full scope.
+Slots in alongside ``docling`` on the HTML branch. For standalone HTML/HTM
+files it's opt-in: only when ``html_converter = sec2md`` in config (or
+``--html-converter sec2md`` on the CLI), and even then only routed to for files
+that pass the iXBRL sniff — other HTML/HTM files fall through to Docling.
+
+The EDGAR full-submission path is the exception: when a ``.txt`` is unwrapped
+as an SEC SGML envelope (see ``ingest/parsers.py``), its inner HTML/iXBRL
+bodies always route through sec2md regardless of ``html_converter`` — it's the
+only converter that reads SEC HTML and the alternative is raw tag soup, so the
+dependency is hard there. See issue #14 for the full scope.
 """
 
 from __future__ import annotations

--- a/bartleby/providers/wsjpt.py
+++ b/bartleby/providers/wsjpt.py
@@ -1,6 +1,10 @@
 """wsjpt provider — routes through WSJ's parsing toolkit (Pydantic-AI under the hood).
 
-Optional install: ``pip install bartleby[wsjpt]``. The provider talks to
+Out-of-band install: there is **no** ``bartleby[wsjpt]`` extra — the git source
+is WSJ-internal and unreachable outside WSJ, so it can't live in the locked
+deps. Inject it into the installed tool's environment with
+``uv tool install '.[...]' --with 'git+ssh://git@github.dowjones.net/data/wsjpt.git' --force``
+(see the README install section). The provider talks to
 Gemini via wsjpt's ``ModelConfig(provider="google", model=<alias>)`` so model
 aliases (``fast`` / ``smart`` / ``smartest``) resolve centrally and bartleby
 doesn't have to track concrete model names. Anthropic/OpenAI/Bedrock are also

--- a/bartleby/skill/README.md
+++ b/bartleby/skill/README.md
@@ -44,7 +44,7 @@ The main [README](../../README.md#install-the-skill) covers refreshing after an 
 
 ## What the skill exposes
 
-The skill ships a `scripts/` directory containing small Python scripts that the agent calls. Each takes arguments, prints JSON to stdout, and exits non-zero on error.
+The agent calls these scripts via `bartleby skill <name>`. They're package-internal (under `bartleby/skill_scripts/`), dispatched by the CLI — the installed bundle itself ships only `SKILL.md` + `README.md`, not a `scripts/` directory. Each script takes arguments, prints JSON to stdout, and exits non-zero on error.
 
 | Script | Purpose |
 | --- | --- |
@@ -60,8 +60,19 @@ The skill ships a `scripts/` directory containing small Python scripts that the 
 | `delete_finding` | Retract a finding outright — its row, body chunks, and citations. Cited document chunks (evidence) are untouched. The curation counterpart to `delete_tag`. |
 | `list_findings` | Browse prior findings (newest first): id, title, description, authoring session, created-at, citation count. Paginated. The enumeration counterpart to `search --findings`. |
 | `read_finding` | Read one whole finding by id — full body, the finding's chunks, and resolved citations. Same shape as `save_finding`. |
+| `edit_finding` | Update an existing finding's title, description, and/or body. Memory-gated like the other finding reads/writes. |
+| `save_date` | Backfill or correct a document's `authored_date` (the date-only counterpart to re-saving a summary; supports `--clear`). |
+| `extract` | Run a value-tag's stored regex over a set of chunks, storing the per-document values it captures. |
+| `read_tags` | List the controlled tag vocabulary — names, descriptions, and document counts. |
+| `add_tag` | Create a new tag in the controlled vocabulary (optionally a value-tag with a `value_type` + regex `pattern`). |
+| `rename_tag` | Rename a tag; assignments preserved. |
+| `delete_tag` | Remove a tag from the vocabulary. The curation counterpart to `delete_finding`. |
+| `merge_tags` | Move all assignments from one tag (`--from`) onto another (`--into`), then delete the source. The tag counterpart to `merge_findings`. |
+| `tag` | Classify documents against the controlled vocabulary (LLM-assisted) — runs the configured summarizer model once per document; `tag --all` requires explicit human confirmation. |
+| `assign_tag` | Attach one tag to one or more documents directly, bypassing the classifier. |
+| `unassign_tag` | Detach one tag from one or more documents. |
 
-The scripts wrap a shared Python library that owns all writes to the chunks table. Source-kind discipline (`document` vs. `summary` vs. `finding`) is enforced both by a `CHECK` constraint at the SQL layer and by typed insert helpers in the library, so agents can't accidentally mislabel chunks.
+The scripts wrap a shared Python library that owns all writes to the chunks table. Source-kind discipline (`document` vs. `summary` vs. `finding` vs. `image`) is enforced both by a `CHECK` constraint at the SQL layer and by typed insert helpers in the library, so agents can't accidentally mislabel chunks.
 
 For full argument-level contracts, see [`SKILL.md`](./SKILL.md) and the script docstrings.
 
@@ -118,11 +129,13 @@ Findings also have a curation path so memory can be tended rather than only grow
 Everything queryable lives in the project's `bartleby.db`:
 
 - `documents` — one row per ingested file
-- `chunks` — polymorphic: documents, summaries, and findings all chunk into here, tagged with `source_kind` and `source_id`
+- `chunks` — polymorphic: documents, summaries, findings, and images all chunk into here, tagged with `source_kind` (`document` / `summary` / `finding` / `image`) and `source_id`
 - `summaries` — one row per document (single-shot, whole-document)
 - `sessions` — one row per agent session
 - `findings` — one row per saved finding, with markdown text
 - `finding_citations` — join table from findings to the chunks they cite
+- `tags` — the controlled tag vocabulary: name, description, and (for value-tags) a `value_type` + capture `pattern`
+- `document_tags` — join table assigning tags to documents (with the captured `value` and source `chunk_id` for value-tags)
 - `audit_logs` — every tool call the agent made, append-only, never read by the agent
 
 No sidecar files. If you want to export a finding to disk, ask the agent to write it.

--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -1,4 +1,4 @@
-"""Shared lifecycle for ``skill/scripts/`` executables.
+"""Shared lifecycle for the ``bartleby/skill_scripts/`` executables.
 
 Each script defines ``parse_args(argv)`` and ``work(*, conn, args, session_id)``
 and calls :func:`run`. The runner:
@@ -66,7 +66,7 @@ def build_arg_parser(
     arguments *and* the response shape. Agents read SKILL.md and ``--help``;
     the JSON contract otherwise lives only in docstrings they never see (issue
     #47). The raw formatter must travel with the docstring, so it lives here
-    rather than at each of the ~18 call sites.
+    rather than at each of the ~two-dozen skill-script call sites.
 
     ``--project`` is declared here too: ``run()`` unconditionally reads
     ``args.project`` to resolve the corpus, so it is part of the runner's

--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -737,8 +737,8 @@ def chunk_locations(
     underlying document's summary row (the same value list_documents and the date
     filters use); it is resolved in the same per-kind join that fetches
     ``file_name``, so it costs no extra query:
-      - document chunks: file_name from the document; page_number parsed from
-        ``section_heading`` (the 'page N' convention pdfplumber writes);
+      - document chunks: file_name from the document; page_number read from the
+        chunk's first-class ``page_number`` column (the page recorded at ingest);
         authored_date from the document's summary (NULL if undated / no summary).
       - summary chunks: file_name from the underlying document; page_number is
         always None (summaries aren't paginated); authored_date off the summary

--- a/bartleby/skill_scripts/describe_corpus.py
+++ b/bartleby/skill_scripts/describe_corpus.py
@@ -24,10 +24,11 @@ on anything that isn't a clean ``YYYY-MM-DD``, so it's frequently absent. The
 date range is reported *alongside* ``undated_document_count`` — a range without
 the null count would imply more temporal coverage than the slice has.
 
-Scope: the same flags ``search`` / ``scan`` / ``list_documents`` accept —
-``--tag`` (repeatable, OR), ``--in-documents``, and the inclusive ``YYYY-MM-DD``
-``--authored-after`` / ``--authored-before`` bounds (``--include-nulls`` keeps
-undated docs). With any of them active, *every* aggregate is computed over that
+Scope: ``--tag`` (repeatable, OR), ``--in-documents``, and the inclusive
+``YYYY-MM-DD`` ``--authored-after`` / ``--authored-before`` bounds
+(``--include-nulls`` keeps undated docs) — the scope flags ``scan`` and
+``list_documents`` also take. (``search`` shares ``--tag`` / ``--in-documents``
+but *not* the date bounds.) With any of them active, *every* aggregate is computed over that
 filtered subset instead of the whole corpus, and a ``filters`` object echoes the
 scope (``{tags, in_documents, authored_after, authored_before, include_nulls,
 excluded_null_dated}``) so the numbers are self-describing. The ``tags`` facet

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -49,10 +49,14 @@ Output (compact by default):
     {
       "query": str,
       "match_mode": "phrase" | "terms",
-      "in_documents": [int, ...] | null,
-      "tags": [str, ...] | null,
       "offset": int, "limit": int, "total": int,
       "preview": int,
+      "filters": {   # present ONLY when a scope filter is active (see below)
+        "tags": [str, ...], "in_documents": [int, ...],
+        "file_like": [str, ...], "heading_like": [str, ...],
+        "authored_after": str, "authored_before": str,
+        "include_nulls": bool, "excluded_null_dated": int
+      },
       "matches": [{
         "document_id": int,
         "file_name": str,

--- a/docs/decisions/GH-0250-unconditional-temperature-drop-opus-47plus-0001.md
+++ b/docs/decisions/GH-0250-unconditional-temperature-drop-opus-47plus-0001.md
@@ -1,0 +1,32 @@
+# GH-0250 — Temperature is dropped on Opus 4.7+ unconditionally, not only on the effort path
+
+**Supersedes [GH-0232](GH-0232-reasoning-effort-knob-0001.md)** on the narrow
+point of *when* the Anthropic provider drops `temperature`.
+
+GH-0232 introduced the `reasoning_effort` knob and, in the course of it,
+described dropping `temperature` "only where it 400s … on the effort path for
+those models" — i.e. it coupled the temperature drop to whether a
+reasoning-effort value was sent. That coupling was wrong in practice: **Opus
+4.7+ rejects `temperature` outright** (a 400), and that rejection is a property
+of the *model*, not of whether the request also carried an `output_config.effort`
+block. A summarize (or classify) call against Opus 4.7/4.8 with effort unset
+would still send `temperature` and still 400.
+
+PR #250 (`fix/anthropic-temp-drop`) made the drop **unconditional**: the
+Anthropic provider removes `temperature` for any model whose name matches the
+no-temperature prefix tuple (`claude-opus-4-7`, `claude-opus-4-8`), independent
+of `reasoning_effort`, warning once when a non-default temperature is thereby
+ignored. The effort knob and the temperature drop are now orthogonal — effort is
+gated by `_supports_effort` (Opus 4.5+/Sonnet 4.6), temperature is gated by
+`_drops_temperature` (Opus 4.7+) — and either can apply without the other. Older
+effort-capable models (Opus 4.5/4.6, Sonnet 4.6) still accept `temperature`, so
+it's kept there for determinism. The same model-keyed drop was later extended to
+`classify()` (#256), which has the same exposure.
+
+Everything else in GH-0232 — the unified `minimal|low|medium|high` enum, the
+modern `output_config.effort` API, sending effort *without* a `thinking` block,
+the model-gated effort allowlist, OpenAI's clean `reasoning_effort` pass-through,
+Ollama/wsjpt accepting-and-ignoring — stands unchanged. Only the
+temperature-drop *condition* is corrected here.
+
+Code-only, no schema change.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -95,6 +95,7 @@ past calls, read on demand.
 - [GH-0246 — describe_corpus reports chunk-length stats (median/p90/max) so the agent self-sizes `--preview` instead of raising the 240-char default (issue #246)](GH-0246-describe-corpus-chunk-length-stats-0001.md)
 - [GH-0234 — Graduate the local-summarizer benchmark into VC: local-only, temp-0.0 parity, blind OpenAI judge, schema-gate leaderboard; defer the real run (issue #234)](GH-0234-graduate-summarize-benchmark-to-vc-0001.md)
 - [GH-0243 — A local Ollama provider auto-clamps the caption/summarize worker pools to 1 (issue #243)](GH-0243-clamp-ollama-worker-pools-0001.md)
+- [GH-0250 — Temperature is dropped on Opus 4.7+ unconditionally (a property of the model, not of whether reasoning effort was sent), not only on the effort path; supersedes GH-0232 on that one point (issue #232 / PR #250)](GH-0250-unconditional-temperature-drop-opus-47plus-0001.md)
 - [GH-0232 — Reasoning effort is a unified enum mapped per-provider, via the modern Anthropic effort API (issue #232)](GH-0232-reasoning-effort-knob-0001.md)
 - [GH-0235 — An HTML page saved as `.pdf` is rejected with a clear reason, never rerouted into the HTML pipeline (issue #235)](GH-0235-reject-html-saved-as-pdf-not-reroute-0001.md)
 - [GH-0236 — PER_WORKER_GB sized against measured pdfplumber peak RSS, not a model-load estimate (issue #236)](GH-0236-tune-per-worker-gb-to-measured-peak-0001.md)


### PR DESCRIPTION
A single coordinated docs refresh — every claim re-verified against current `main`. No behavior change. Closes #485.

### `ARCHITECTURE.md` — current-state claims
- Skill is **~two dozen scripts** dispatched from `bartleby/skill_scripts/` (a pointer, not the stale "six Python scripts in `skill/`"); the shipped `skill/` holds only SKILL.md + README.md.
- CLI line names `config` (wizard), `ready` (skill installer), `serve` correctly + mentions the dispatcher.
- Summarizer structured-output and provider defaults now say **four** providers (`anthropic`/`openai`/`ollama`/`wsjpt`); wsjpt consumes the Pydantic model class directly rather than `model_json_schema()`.
- New **`GH-0250`** decision file records PR #250's unconditional Opus-4.7+ temperature drop, **superseding GH-0232** on that one point. GH-0232 left untouched per the decisions-are-immutable discipline.

### `README.md` — pipeline & config
- Drop self-contradicting "Ingestion runs sequentially" (parallel three-phase pipeline since #165).
- Fix parse-worker auto-formula "free RAM ÷ ~4 GB" → ~12 GB (`PER_WORKER_GB` since #236).
- Add a Reasoning-effort wizard row (#232): `minimal`/`low`/`medium`/`high`, default `low`.
- Point the dangling "Ollama-defaults note above" cross-ref at the real "Picking models for your hardware" section.

### `bartleby/skill/README.md` — shipped skill docs (installed copy restamped)
- Bundle ships SKILL.md + README.md only — not a `scripts/` directory; scripts are package-internal via `bartleby skill <name>`.
- Script table **12 → 23**: add `edit_finding`, `save_date`, `extract`, and the eight tag ops.
- Add `tags` + `document_tags` to the storage overview.
- Add the fourth source-kind `image` (CHECK-constraint sentence + polymorphic-chunks bullet).

### Module docstrings (agent-facing via `--help`, no behavior change)
- `describe_corpus`: `search` shares `--tag`/`--in-documents` but takes **no date bounds**.
- `scan`: scope is echoed under a `filters` object, not top-level `in_documents`/`tags`.
- `_common.chunk_locations`: `page_number` is read from the first-class `chunks.page_number` column.
- `skill_runner`: `bartleby/skill_scripts/`, ~two dozen call sites (was `skill/scripts/`, "~18").
- `sec2md`: the EDGAR full-submission path routes inner HTML through it **unconditionally**.
- `wsjpt`: there is no `bartleby[wsjpt]` extra — it's an out-of-band `--with` install of a WSJ-internal git source.

### Notes
- Two issue claims were themselves stale and corrected: `list_documents` **does** now carry `--in-documents` (only `search`'s date-bound lumping in `describe_corpus` was wrong); the script count is **23**, not "24" — used drift-resistant pointers instead of hardcoding.
- Tests: **1006 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)