### PR TITLE
Stop ensure_provider_env clobbering an exported OLLAMA_API_BASE

### DIFF
--- a/bartleby/config.py
+++ b/bartleby/config.py
@@ -148,6 +148,12 @@ def ensure_provider_env(provider: str | None, config: dict) -> None:
         if config_value and not os.environ.get("GEMINI_API_KEY"):
             os.environ["GEMINI_API_KEY"] = config_value
     elif provider == "ollama":
-        os.environ["OLLAMA_API_BASE"] = config.get(
-            "ollama_base_url", "http://localhost:11434"
-        )
+        # Mirror the api-key branches: only populate the env var when it isn't
+        # already exported, so a user-set ``OLLAMA_API_BASE`` (e.g. a remote GPU
+        # box) survives instead of being clobbered with the config/localhost
+        # default. With nothing exported, the configured ``ollama_base_url``
+        # (else localhost) still applies.
+        if not os.environ.get("OLLAMA_API_BASE"):
+            os.environ["OLLAMA_API_BASE"] = config.get(
+                "ollama_base_url", "http://localhost:11434"
+            )

--- a/docs/decisions/GH-0490-ollama-api-base-no-clobber-0001.md
+++ b/docs/decisions/GH-0490-ollama-api-base-no-clobber-0001.md
@@ -1,0 +1,11 @@
+# `ensure_provider_env` stops clobbering an exported `OLLAMA_API_BASE` (issue #490)
+
+> Source: [#490](https://github.com/jswest/bartleby/issues/490)
+
+The anthropic/openai/wsjpt branches of `ensure_provider_env` honor a pre-set env var (`if config_value and not os.environ.get(env_var)`), matching the docstring's "(without overwriting an existing env var)". The ollama branch was the odd one out: it assigned `os.environ["OLLAMA_API_BASE"]` *unconditionally* — even when no `ollama_base_url` was configured — so an exported `OLLAMA_API_BASE` (e.g. a remote GPU box) was overwritten with the config value, or worse, the `http://localhost:11434` default. `README.md:310` tells users the env var works, but it couldn't whenever `ensure_provider_env` ran first.
+
+**Decision (director, 2026-06-11): take the code fix, not a doc-only line.** The two candidate fixes were (a) edit the env-var branch to mirror its siblings — set `OLLAMA_API_BASE` only when it isn't already present — or (b) leave the clobber and re-document the README/docstring to say "config wins." We took (a). It restores the symmetry the docstring already promises across all four providers, and keeps the precedence the way users (and `OllamaProvider.__init__`, which reads `base_url or OLLAMA_API_BASE or localhost`) already assume: an explicitly-exported env var is the most specific signal of intent and shouldn't be silently discarded. Re-documenting config-wins would have entrenched a surprising special case for the one provider whose base URL users most often point elsewhere.
+
+Resulting precedence for ollama (now identical in spirit to the api-key branches): an exported `OLLAMA_API_BASE` survives untouched; with nothing exported, a configured `ollama_base_url` applies; with neither, the localhost default. `README.md:310` and the `ensure_provider_env` docstring stay accurate **as written** — no edit needed.
+
+Additive, no `SCHEMA_VERSION` bump. Three tests in `tests/test_config.py` pin the contract: exported value survives, configured value applies when unexported, localhost when neither. Out of scope: any change to provider precedence elsewhere or to the other branches.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import os
+
 import yaml
 import pytest
 
 import bartleby.config
 import bartleby.commands.config as config
-from bartleby.config import config_drift, redact_config, save_config
+from bartleby.config import (
+    config_drift,
+    ensure_provider_env,
+    redact_config,
+    save_config,
+)
 
 
 @pytest.fixture
@@ -353,3 +360,25 @@ def test_config_drift_reports_changed_added_and_removed_fields():
 def test_config_drift_identical_is_silent():
     cfg = {"provider": "anthropic", "model": "x"}
     assert config_drift(cfg, dict(cfg)) == []
+
+
+def test_ensure_provider_env_ollama_honors_exported_base(monkeypatch):
+    # No ``ollama_base_url`` configured, but the user exported a remote box:
+    # the exported value must survive, mirroring the api-key branches.
+    monkeypatch.setenv("OLLAMA_API_BASE", "http://gpu-box:11434")
+    ensure_provider_env("ollama", {})
+    assert os.environ["OLLAMA_API_BASE"] == "http://gpu-box:11434"
+
+
+def test_ensure_provider_env_ollama_applies_config_when_unexported(monkeypatch):
+    # Nothing exported: the configured ``ollama_base_url`` still applies.
+    monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
+    ensure_provider_env("ollama", {"ollama_base_url": "http://configured:11434"})
+    assert os.environ["OLLAMA_API_BASE"] == "http://configured:11434"
+
+
+def test_ensure_provider_env_ollama_defaults_localhost_when_neither(monkeypatch):
+    # Neither exported nor configured: fall back to the localhost default.
+    monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
+    ensure_provider_env("ollama", {})
+    assert os.environ["OLLAMA_API_BASE"] == "http://localhost:11434"


### PR DESCRIPTION
Part of #492.

The ollama branch of `ensure_provider_env` set `OLLAMA_API_BASE` unconditionally, clobbering a user-exported value (e.g. a remote GPU box) with the config value or the localhost default. The anthropic/openai/wsjpt branches all honor a pre-set env var, matching the docstring "(without overwriting an existing env var)". This mirrors them for ollama: set `OLLAMA_API_BASE` only when it isn't already present.

Precedence now: exported env var wins; else configured `ollama_base_url`; else localhost. README:310 and the docstring stay accurate as written. Additive, no SCHEMA_VERSION bump.

**How to verify:** `uv run pytest tests/test_config.py` — three new `ensure_provider_env` tests assert (1) an exported `OLLAMA_API_BASE` survives with no config, (2) a configured `ollama_base_url` applies when unexported, (3) localhost default when neither. Full suite green (1009 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)