### PR TITLE
Validate reasoning_effort at load/use (hard-fail, no bare KeyError)

### DIFF
--- a/bartleby/commands/config.py
+++ b/bartleby/commands/config.py
@@ -9,11 +9,13 @@ from bartleby.lib.consts import (
     ALLOWED_HTML_CONVERTERS,
     ALLOWED_PDF_CONVERTERS,
     ALLOWED_PROVIDERS,
+    ALLOWED_REASONING_EFFORTS,
     DEFAULT_CAPTION_WORKERS,
     DEFAULT_HTML_CONVERTER,
     DEFAULT_MAX_SUMMARIZE_TOKENS,
     DEFAULT_OCR_MIN_CONFIDENCE,
     DEFAULT_PDF_CONVERTER,
+    DEFAULT_REASONING_EFFORT,
     DEFAULT_SPARSE_TEXT_THRESHOLD,
     DEFAULT_SUMMARIZE_WORKERS,
     DEFAULT_TEMPERATURE,
@@ -22,10 +24,6 @@ from bartleby.lib.consts import (
 )
 
 ALLOWED_SUMMARY_DEPTHS = ["none", "one-shot"]
-# Unified reasoning-effort enum mapped per-provider (OpenAI reasoning_effort,
-# Anthropic output_config.effort). Cheap by default — summarization is a
-# mechanical task where minimal/low reasoning is almost always enough.
-ALLOWED_REASONING_EFFORTS = ["minimal", "low", "medium", "high"]
 
 PROVIDER_DEFAULT_MODEL = {
     "anthropic": "claude-haiku-4-5",
@@ -35,7 +33,6 @@ PROVIDER_DEFAULT_MODEL = {
 }
 
 DEFAULT_SUMMARY_DEPTH = "one-shot"
-DEFAULT_REASONING_EFFORT = "low"
 DEFAULT_MAX_READ_TOKENS = 50_000
 DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
 

--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -53,6 +53,7 @@ from bartleby.lib import timing
 from bartleby.lib.consts import (
     ALLOWED_HTML_CONVERTERS,
     ALLOWED_PDF_CONVERTERS,
+    ALLOWED_REASONING_EFFORTS,
     DEFAULT_CAPTION_WORKERS,
     DEFAULT_HTML_CONVERTER,
     DEFAULT_MAX_SUMMARIZE_TOKENS,
@@ -199,7 +200,19 @@ def main(
         timings=timings,
     )
     temperature = float(config.get("temperature", DEFAULT_TEMPERATURE))
+    # Validate the configured reasoning_effort once, here, before any summarize
+    # call reaches a provider. The wizard constrains this value, but a config can
+    # be hand-edited — an out-of-enum effort would otherwise crash mid-ingest with
+    # a bare KeyError on the anthropic _EFFORT_MAP lookup (and be forwarded verbatim
+    # to OpenAI). Reject it cleanly instead: named field + allowed values, exit 1
+    # on stderr, no traceback. Hard-fail — never silently fall back to a default.
     reasoning_effort = config.get("reasoning_effort")
+    if reasoning_effort is not None and reasoning_effort not in ALLOWED_REASONING_EFFORTS:
+        console.error(
+            f"Unknown reasoning_effort {reasoning_effort!r} in config; "
+            f"expected one of {', '.join(ALLOWED_REASONING_EFFORTS)}."
+        )
+        sys.exit(1)
     max_summarize_tokens = int(
         config.get("max_summarize_tokens", DEFAULT_MAX_SUMMARIZE_TOKENS)
     )

--- a/bartleby/lib/consts.py
+++ b/bartleby/lib/consts.py
@@ -32,6 +32,13 @@ DOCLING_HF_REPOS = (
 ALLOWED_PROVIDERS = ("anthropic", "openai", "ollama", "wsjpt")
 ALLOWED_PDF_CONVERTERS = ["pdfplumber", "docling"]
 ALLOWED_HTML_CONVERTERS = ["docling", "sec2md"]
+# Unified reasoning-effort enum mapped per-provider (OpenAI reasoning_effort,
+# Anthropic output_config.effort). Lives here — not in the wizard — so scribe can
+# reject a hand-edited config value before any provider call, in lockstep with
+# the wizard's choices. Cheap by default: summarization is mechanical work where
+# minimal/low reasoning is almost always enough.
+ALLOWED_REASONING_EFFORTS = ["minimal", "low", "medium", "high"]
+DEFAULT_REASONING_EFFORT = "low"
 DEFAULT_PDF_CONVERTER = "pdfplumber"
 DEFAULT_HTML_CONVERTER = "docling"
 DEFAULT_TEMPERATURE = 0.0

--- a/bartleby/providers/anthropic.py
+++ b/bartleby/providers/anthropic.py
@@ -38,6 +38,20 @@ _EFFORT_MAP = {"minimal": "low", "low": "low", "medium": "medium", "high": "high
 _temperature_warned = False
 
 
+def _map_effort(reasoning_effort: str) -> str:
+    """Map a unified reasoning_effort to Anthropic's ``output_config.effort``,
+    raising a named ``ValueError`` on an out-of-enum value (backstop — scribe
+    validates first; this beats the bare ``KeyError`` a raw dict lookup raises).
+    """
+    mapped = _EFFORT_MAP.get(reasoning_effort)
+    if mapped is None:
+        raise ValueError(
+            f"Unknown reasoning_effort {reasoning_effort!r}; "
+            f"expected one of {', '.join(_EFFORT_MAP)}."
+        )
+    return mapped
+
+
 def _supports_effort(model: str) -> bool:
     return model.startswith(_EFFORT_MODEL_PREFIXES)
 
@@ -85,7 +99,7 @@ class AnthropicProvider:
             tool_choice={"type": "tool", "name": _SUMMARY_TOOL},
         )
         if reasoning_effort and _supports_effort(model):
-            kwargs["output_config"] = {"effort": _EFFORT_MAP[reasoning_effort]}
+            kwargs["output_config"] = {"effort": _map_effort(reasoning_effort)}
         # Opus 4.7+ rejects temperature outright — a property of the model, not of
         # whether we sent effort — so drop it wherever it would 400, independent of
         # reasoning_effort. The older effort-capable models still accept it.

--- a/docs/decisions/GH-0489-validate-reasoning-effort-0001.md
+++ b/docs/decisions/GH-0489-validate-reasoning-effort-0001.md
@@ -1,0 +1,50 @@
+# reasoning_effort is validated at the scribe chokepoint — hard-fail, no bare KeyError (issue #489)
+
+> Source: [#489](https://github.com/jswest/bartleby/issues/489)
+
+`_EFFORT_MAP[reasoning_effort]` was a bare dict lookup on a value read straight
+from `yaml.safe_load` with no validation outside the interactive wizard. A
+hand-edited config with e.g. `reasoning_effort: xhigh` crashed mid-ingest with a
+raw `KeyError` on the anthropic provider, and was forwarded verbatim to OpenAI.
+Neither failure named the offending config field.
+
+**Director decision (2026-06-11): HARD-FAIL.** An out-of-enum value is rejected,
+not silently coerced to the default effort. This bundle's theme is "expected
+error → clean exit (1) on stderr, never a traceback," and a silent fall-back
+would mask a config typo the user meant to act on.
+
+Fix is a single seam where scribe reads the config, reached **before any
+provider call** — so it protects every provider (anthropic's `_EFFORT_MAP`
+lookup *and* the OpenAI/wsjpt/ollama forwards) at once, not just the anthropic
+path. `scribe.main()` already reads `config.get("reasoning_effort")`; a check
+right there rejects an out-of-enum value via `console.error(...)` + `sys.exit(1)`
+— the same clean exit-1-on-stderr pattern used by the sibling expected-errors in
+`commands/project.py`, `embed.py`, `ready.py`, and `serve.py`. The message names
+the field, the bad value, and the allowed set
+(`minimal, low, medium, high`). No traceback.
+
+The allowed enum (`ALLOWED_REASONING_EFFORTS`) and its default
+(`DEFAULT_REASONING_EFFORT`) moved from `commands/config.py` into
+`bartleby/lib/consts.py`, where the other shared `ALLOWED_*` lists already live.
+That module imports nothing, so scribe and the wizard now both source the enum
+from one place — the values scribe rejects can never drift from the ones the
+wizard offers. The wizard keeps constraining the value at input time as before;
+this gate covers the hand-edited path it can't see.
+
+Defense in depth: the anthropic provider's raw `_EFFORT_MAP[...]` lookup became
+`_map_effort(...)`, a `.get` that raises a `ValueError` naming the field instead
+of a bare `KeyError`. scribe rejects bad values before the provider is ever
+reached, so this is a backstop for a caller that drives the provider directly —
+the issue's suggested `_EFFORT_MAP.get(...)` form, kept as a second layer rather
+than the primary gate.
+
+Deliberately **not** done: no global try/except added to `cli.py` (the existing
+converter-validation `ValueError`s in `scribe.main()` predate this and aren't in
+scope); no schema change (the value lives in `config.yaml`, not the DB); no new
+abstraction beyond the one `_map_effort` helper.
+
+Tests: `tests/test_scribe.py` asserts an out-of-enum `reasoning_effort` exits 1
+with the field named on stderr (captured via the repo's `console.error`
+monkeypatch idiom, since the shared Rich Console binds its stream at import
+time), plus a positive control that a valid value ingests. `tests/test_providers.py`
+covers the anthropic `_map_effort` `ValueError` backstop. No schema change.

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -101,6 +101,17 @@ def test_anthropic_effort_keeps_temperature_on_older_capable_model(monkeypatch):
     assert fake.last_call["temperature"] == 0.0
 
 
+def test_anthropic_out_of_enum_effort_raises_named_valueerror(monkeypatch):
+    # Backstop for the scribe-level gate (#489): a caller reaching the provider
+    # directly with an out-of-enum effort gets a ValueError naming the field —
+    # not the bare KeyError a raw _EFFORT_MAP[...] lookup would raise.
+    with pytest.raises(ValueError) as exc:
+        _summarize_with_effort(monkeypatch, model="claude-opus-4-8", effort="xhigh")
+    msg = str(exc.value)
+    assert "reasoning_effort" in msg
+    assert "xhigh" in msg
+
+
 def test_anthropic_effort_skipped_for_uncapable_model(monkeypatch):
     # Haiku 4.5 would 400 on output_config.effort → never sent; temperature stays.
     fake = _summarize_with_effort(monkeypatch, model="claude-haiku-4-5", effort="high")

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -204,6 +204,53 @@ def test_scribe_ingests_txt_without_llm(isolated_project, tmp_path, mock_embed):
         conn.close()
 
 
+def test_scribe_rejects_out_of_enum_reasoning_effort(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """A hand-edited config with an out-of-enum reasoning_effort exits 1 with the
+    field named on stderr — never a bare KeyError on the provider, and never a
+    silent fall-back to the default effort (#489, hard-fail).
+
+    The error routes through ``console.error`` (stderr); capture it directly
+    rather than through capsys/capfd, since the shared Rich Console binds its
+    stream at import time — the repo's idiom for asserting on status output."""
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.load_config",
+        lambda: {"reasoning_effort": "xhigh"},
+    )
+    errors: list[str] = []
+    monkeypatch.setattr(scribe.console, "error", lambda m: errors.append(m))
+    src = _write_txt(tmp_path / "doc.txt", "Some text to ingest.")
+    with pytest.raises(SystemExit) as exc:
+        scribe.main(project="test_proj", files=str(src))
+    assert exc.value.code == 1
+    assert len(errors) == 1
+    msg = errors[0]
+    assert "reasoning_effort" in msg          # the offending field is named
+    assert "xhigh" in msg                     # ...along with the bad value
+    assert "minimal, low, medium, high" in msg  # ...and the allowed set
+
+
+def test_scribe_accepts_valid_reasoning_effort(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """Positive control: a valid enum value sails through validation and ingests
+    (no provider configured, so summarization is simply skipped)."""
+    monkeypatch.setattr(
+        "bartleby.commands.scribe.load_config",
+        lambda: {"reasoning_effort": "high"},
+    )
+    src = _write_txt(tmp_path / "doc.txt", "Some text to ingest.")
+    scribe.main(project="test_proj", files=str(src))
+
+    conn = open_db("test_proj")
+    try:
+        n = conn.cursor().execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+        assert n == 1
+    finally:
+        conn.close()
+
+
 def test_scribe_dedupes_identical_files(isolated_project, tmp_path, mock_embed):
     src = _write_txt(tmp_path / "doc.txt", "Same content")
     scribe.main(project="test_proj", files=str(src))


### PR DESCRIPTION
Part of #492.

An out-of-enum `reasoning_effort` (e.g. a hand-edited `reasoning_effort: xhigh`) used to crash mid-ingest with a raw `KeyError` on the anthropic `_EFFORT_MAP` lookup, and was forwarded verbatim to OpenAI — neither failure naming the field.

## What changed
- **Single chokepoint**: `scribe.main()` validates `reasoning_effort` where it reads the config, *before any provider call*, so every provider (anthropic / openai / wsjpt / ollama) is covered. An out-of-enum value now exits 1 on stderr naming the field + allowed set (`minimal, low, medium, high`) via the sibling `console.error` + `sys.exit(1)` pattern — **no traceback**, and a **hard-fail** rather than a silent fall-back to the default effort (director decision 2026-06-11).
- The allowed enum + default move from `commands/config.py` into the import-light `lib/consts.py`, so scribe and the wizard source one truth.
- Backstop: the anthropic provider's raw `_EFFORT_MAP[...]` becomes `_map_effort`, a `.get` raising a named `ValueError` for a caller that drives the provider directly.

No schema change.

## How to verify
- `uv run pytest` — 1017 pass.
- New tests: `tests/test_scribe.py::test_scribe_rejects_out_of_enum_reasoning_effort` (exits 1, field named on stderr) + positive control `test_scribe_accepts_valid_reasoning_effort`; `tests/test_providers.py::test_anthropic_out_of_enum_effort_raises_named_valueerror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)