### PR TITLE
#502: gate ready --dest rmtree on the .bartleby-skill marker (Part of #508)

### DIFF
--- a/bartleby/commands/ready.py
+++ b/bartleby/commands/ready.py
@@ -67,9 +67,14 @@ def _read_marker(dest: Path) -> dict:
         return {}
 
 
-def _looks_like_skill_dir(dest: Path) -> bool:
-    """A guard against ``rmtree``-ing an unrelated directory passed as --dest."""
-    return (dest / "SKILL.md").is_file() or (dest / MARKER_NAME).is_file()
+def _is_ours(dest: Path) -> bool:
+    """Whether ``dest`` is one of our installs, by the ``.bartleby-skill`` marker.
+
+    A bare ``SKILL.md`` is *not* enough: a foreign skill (another tool's
+    ``~/.claude/skills/<name>``) carries one too, and we must never ``rmtree``
+    over it. Only the marker we stamp at install time proves ownership.
+    """
+    return (dest / MARKER_NAME).is_file()
 
 
 def _write_marker(dest: Path, src_hash: str) -> None:
@@ -135,10 +140,11 @@ def main(*, dest: Path | None = None, check: bool = False, force: bool = False) 
             console.complete(f"Skill already up to date (v{__version__}) at {dest}.")
         return
 
-    if dest.exists() and any(dest.iterdir()) and not _looks_like_skill_dir(dest):
+    if dest.exists() and any(dest.iterdir()) and not _is_ours(dest):
         console.error(
-            f"{dest} exists and doesn't look like a skill directory (no SKILL.md). "
-            "Refusing to overwrite it — pass a different --dest."
+            f"{dest} is non-empty and not ours (no {MARKER_NAME} marker — a stray "
+            "SKILL.md alone doesn't make it ours). Refusing to delete it; pass a "
+            "different --dest."
         )
         sys.exit(1)
 

--- a/docs/decisions/GH-0502-ready-dest-rmtree-marker-only-guard-0001.md
+++ b/docs/decisions/GH-0502-ready-dest-rmtree-marker-only-guard-0001.md
@@ -1,0 +1,7 @@
+# `ready --dest` rmtrees only dirs carrying our `.bartleby-skill` marker, not any with a SKILL.md (issue #502)
+
+> Source: [#502](https://github.com/jswest/bartleby/issues/502)
+
+`bartleby ready` wipes its destination (`shutil.rmtree`) before copying the packaged skill in, guarded by `_looks_like_skill_dir`, which accepted *either* a `SKILL.md` **or** the `.bartleby-skill` marker. But `SKILL.md` is the universal filename for *any* Claude skill: pointing `--dest` at a foreign skill (another tool's `~/.claude/skills/<name>`) sailed past the guard and silently deleted it. The marker is the only thing that actually proves an install is ours — `_install` stamps it via `_write_marker` on every copy — so the bare-`SKILL.md` arm of the guard was never a real ownership signal, just a footgun.
+
+So `_looks_like_skill_dir` becomes `_is_ours`, keyed solely on the `.bartleby-skill` marker. The refusal is hard (no `--force` override), matching how the guard already ignored `force` before — a non-empty `--dest` without our marker refuses outright, and the message now says it's "not ours" and names the marker, explicitly noting that a stray `SKILL.md` alone doesn't make it ours. Empty dirs and our own marked dirs still install/refresh as before (`force` still governs the up-to-date no-op, not this safety check). No schema change.

--- a/tests/test_ready.py
+++ b/tests/test_ready.py
@@ -144,3 +144,47 @@ def test_refuses_to_overwrite_unrelated_directory(dest):
         ready.main(dest=dest)
     assert exc.value.code == 1
     assert bystander.exists()  # left untouched
+
+
+def test_refuses_foreign_skill_dir_without_marker(dest, monkeypatch):
+    # Another tool's skill: it has a SKILL.md but no .bartleby-skill marker.
+    # A bare SKILL.md must not be enough to make us rmtree it.
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_text("a different tool's skill")
+    bystander = dest / "data.json"
+    bystander.write_text("someone else's files")
+
+    errors = []
+    monkeypatch.setattr(ready.console, "error", lambda m: errors.append(m))
+
+    with pytest.raises(SystemExit) as exc:
+        ready.main(dest=dest)
+
+    assert exc.value.code == 1
+    assert bystander.exists()  # not deleted
+    assert (dest / "SKILL.md").read_text() == "a different tool's skill"
+    assert ready.MARKER_NAME in errors[0]  # message names the marker, says not ours
+
+
+def test_refreshes_dir_we_own(dest, monkeypatch):
+    # A dir with our marker is ours; a plain rerun after drift refreshes it.
+    ready.main(dest=dest)
+    (dest / "SKILL.md").write_text("hand-edited, now stale")
+    assert ready._is_ours(dest)
+
+    calls = []
+    real_install = ready._install
+    monkeypatch.setattr(
+        ready, "_install", lambda *a, **k: (calls.append(1), real_install(*a, **k))[1]
+    )
+    ready.main(dest=dest)
+
+    assert calls == [1]  # reinstalled over our own dir
+    assert ready._hash_dir(dest) == ready._hash_dir(ready._source_dir())
+
+
+def test_empty_dest_dir_installs(dest):
+    dest.mkdir(parents=True)  # pre-existing but empty
+    ready.main(dest=dest)
+    assert (dest / "SKILL.md").is_file()
+    assert (dest / ready.MARKER_NAME).is_file()


### PR DESCRIPTION
Part of #508. Implements #502.

`ready --dest` wiped its destination before copying in the skill, guarded by a check that accepted any directory containing a `SKILL.md` — the universal filename for any Claude skill — so pointing `--dest` at a foreign skill silently rmtree'd it. The guard (now `_is_ours`) keys solely on the `.bartleby-skill` marker we stamp on every install: a non-empty `--dest` without the marker refuses outright and the message says it's "not ours". Empty and marker-owned dirs install/refresh as before.

No schema change. Suite green (1040 passed).