### PR TITLE
#507: bless `bartleby skill` as the sanctioned human curation path (Part of #508)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ The core tables (see [`bartleby/db/schema.py`](./bartleby/db/schema.py) for the 
 | `tags`, `document_tags` | A controlled vocabulary the user curates, with LLM-assisted assignment. Lets the agent slice the corpus by category (`search --tag ch`, `list_documents --tag nyseg --tag conedison`). |
 | `meta` | Schema version + embedding model fingerprint; the skill refuses to start against an incompatible DB. |
 
+Tag and finding curation lives on the skill surface, not the CLI: `bartleby skill <name>` (e.g. `bartleby skill add_tag`, `bartleby skill assign_tag`, `bartleby skill save_finding`) is the sanctioned human path for managing the vocabulary and the findings stored above.
+
 The `chunks` table is polymorphic on purpose: documents, summaries, findings, and images all produce searchable text, and folding them into one indexed table means one search query covers all of it. The trade-off is that `chunks.source_id` isn't a foreign key to any specific table — discipline lives in the typed insert helpers in [`bartleby/db/chunks.py`](./bartleby/db/chunks.py).
 
 ---

--- a/docs/decisions/GH-0507-bless-skill-curation-0001.md
+++ b/docs/decisions/GH-0507-bless-skill-curation-0001.md
@@ -1,0 +1,7 @@
+# Bless `bartleby skill …` as the sanctioned human path for tag/finding curation, with one README sentence rather than a new CLI alias (issue #507)
+
+> Source: [#507](https://github.com/jswest/bartleby/issues/507)
+
+The README's schema table calls `tags` "a controlled vocabulary the user curates" and `findings` agent-authored notes, but never told the human *how* to curate them — and the `bartleby` CLI deliberately surfaces no `tag`/`finding` command, because that work lives on the skill surface (`bartleby skill add_tag`, `assign_tag`, `save_finding`, etc.). The docs promised human curation the CLI doesn't carry. This adds one sentence under the schema table stating plainly that `bartleby skill <name>` *is* that path. No behavior change, no code, no new command, no `SCHEMA_VERSION` bump — a docs-only reconciliation of the promise with reality.
+
+We chose the sentence over the obvious alternative — a `bartleby tag …` CLI alias that would make the promise literally true from the user's primary surface. That was considered and rejected for this bundle: curation already has a complete, tested home on the skill surface, and a parallel CLI alias would duplicate that surface, double the maintenance, and blur the CLI-writes / skill-romps split the README's two-pieces framing rests on. The honest fix is to point the human at the existing path, not grow a second one. `SKILL.md` needed no reconciling: it already invokes everything as `bartleby skill <name>` and says "humans drive tag creation," implying no CLI path that doesn't exist. Suite green at 1037 passing.


### PR DESCRIPTION
Part of #508. Implements #507.

The README's schema table promised human curation of tags/findings the CLI doesn't surface (curation lives on the skill surface — `bartleby skill add_tag`, `assign_tag`, `save_finding`, …). This adds one sentence under the schema table blessing `bartleby skill <name>` as the sanctioned human path. SKILL.md needed no reconciling — it already invokes everything as `bartleby skill <name>`.

Docs-only: no behavior change, no new command. No schema change. Suite green (1037 passing).