### PR TITLE
#504: Deny-list older models in Anthropic temperature/effort gates (Part of #508)

### DIFF
--- a/bartleby/providers/anthropic.py
+++ b/bartleby/providers/anthropic.py
@@ -19,19 +19,27 @@ _SUMMARY_TOOL = "save_summary"
 _IMAGE_TOOL = "save_image_description"
 _CLASSIFY_TOOL = "save_classification"
 
-# Reasoning effort is GA via output_config.effort on Opus 4.5+ and Sonnet 4.6;
-# it 400s on Sonnet 4.5 / Haiku 4.5 and earlier, so we only send it for the
-# models below and leave older models on their default behavior. We deliberately
+# Both knobs are deny-lists of the OLDER models, so a current model
+# (claude-fable-5) and any future model take the safe path automatically — an
+# allowlist would silently mis-handle every model released after this code,
+# reintroducing the #250 400 and dropping effort.
+#
+# Effort (output_config.effort) is GA on Opus 4.5+, Sonnet 4.6, Fable 5, and
+# every later model; it 400s only on Sonnet 4.5 / Haiku 4.5 and earlier. So we
+# deny-list the pre-effort models and send effort everywhere else. We deliberately
 # do NOT pair it with a thinking block: Anthropic rejects an enabled-thinking
 # request that also forces a specific tool, and summarize() forces save_summary.
 # Effort alone still lowers reasoning spend, which is the whole point.
-_EFFORT_MODEL_PREFIXES = (
-    "claude-opus-4-5", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8",
-    "claude-sonnet-4-6",
+_NO_EFFORT_PREFIXES = ("claude-sonnet-4-5", "claude-haiku-4-5")
+# temperature is removed on Opus 4.7+, Fable 5, and every later model (400 if
+# sent). The older models that still accept it — Opus 4.5/4.6, Sonnet 4.5/4.6,
+# Haiku 4.5, and earlier — are the deny-list: we keep forwarding temperature
+# there for determinism and drop it everywhere else (current + future models).
+_KEEPS_TEMPERATURE_PREFIXES = (
+    "claude-opus-4-5", "claude-opus-4-6",
+    "claude-sonnet-4-5", "claude-sonnet-4-6",
+    "claude-haiku-4-5",
 )
-# temperature is removed on Opus 4.7+ (400 if sent); on the older effort-capable
-# models it's still accepted, so we keep forwarding it there for determinism.
-_NO_TEMPERATURE_PREFIXES = ("claude-opus-4-7", "claude-opus-4-8")
 # Our unified enum has "minimal" (an OpenAI level); Anthropic's lowest is "low".
 _EFFORT_MAP = {"minimal": "low", "low": "low", "medium": "medium", "high": "high"}
 
@@ -53,11 +61,14 @@ def _map_effort(reasoning_effort: str) -> str:
 
 
 def _supports_effort(model: str) -> bool:
-    return model.startswith(_EFFORT_MODEL_PREFIXES)
+    # Default safe: everything except the pre-effort deny-list takes effort.
+    return not model.startswith(_NO_EFFORT_PREFIXES)
 
 
 def _drops_temperature(model: str) -> bool:
-    return model.startswith(_NO_TEMPERATURE_PREFIXES)
+    # Default safe: drop temperature everywhere except the older models that
+    # still accept it, so a current/future temperature-rejecting model can't 400.
+    return not model.startswith(_KEEPS_TEMPERATURE_PREFIXES)
 
 
 def _warn_dropped_temperature(temperature: float, model: str) -> None:
@@ -100,9 +111,10 @@ class AnthropicProvider:
         )
         if reasoning_effort and _supports_effort(model):
             kwargs["output_config"] = {"effort": _map_effort(reasoning_effort)}
-        # Opus 4.7+ rejects temperature outright — a property of the model, not of
-        # whether we sent effort — so drop it wherever it would 400, independent of
-        # reasoning_effort. The older effort-capable models still accept it.
+        # Current temperature-rejecting models (Opus 4.7+, Fable 5, future) 400 on
+        # temperature outright — a property of the model, not of whether we sent
+        # effort — so drop it wherever it would 400, independent of
+        # reasoning_effort. Only the older deny-listed models still accept it.
         if _drops_temperature(model):
             _warn_dropped_temperature(temperature, model)
             del kwargs["temperature"]
@@ -129,9 +141,9 @@ class AnthropicProvider:
             }],
             tool_choice={"type": "tool", "name": _CLASSIFY_TOOL},
         )
-        # Opus 4.7+ rejects temperature outright (see summarize) — drop it wherever
-        # it would 400. Tag classification reuses the summarizer's model, so a
-        # 4.7+ config would otherwise 400 on every classify call.
+        # Temperature-rejecting models 400 on temperature (see summarize) — drop it
+        # wherever it would 400. Tag classification reuses the summarizer's model, so
+        # a Fable-5/Opus-4.7+ config would otherwise 400 on every classify call.
         if _drops_temperature(model):
             _warn_dropped_temperature(temperature, model)
             del kwargs["temperature"]
@@ -182,6 +194,14 @@ def _extract_tool_input(response, tool_name, model_cls):
                 raise RuntimeError(
                     f"Anthropic tool {tool_name!r} input failed schema validation: {e}"
                 ) from e
+    # A max_tokens truncation cuts the response off before the forced tool call
+    # lands, so it surfaces here as a missing tool block. Name it instead of the
+    # opaque "no tool use" error — the fix (raise max_tokens) is different.
+    if getattr(response, "stop_reason", None) == "max_tokens":
+        raise RuntimeError(
+            f"Anthropic response was truncated by max_tokens before the "
+            f"{tool_name!r} tool call completed; raise max_tokens and retry."
+        )
     raise RuntimeError(
         f"Anthropic response did not include the {tool_name!r} tool call."
     )

--- a/docs/decisions/GH-0504-anthropic-denylist-sampling-params-0001.md
+++ b/docs/decisions/GH-0504-anthropic-denylist-sampling-params-0001.md
@@ -1,0 +1,41 @@
+# GH-0504 — The Anthropic temperature/effort gates are deny-lists of the older models, so current and future models default to the safe path
+
+> Source: [#504](https://github.com/jswest/bartleby/issues/504) (part of #508)
+
+**Supersedes [GH-0250](GH-0250-unconditional-temperature-drop-opus-47plus-0001.md)**
+on the narrow point of *how* the temperature/effort gates are keyed.
+
+GH-0250 dropped `temperature` for an **allowlist** of no-temperature prefixes
+(`claude-opus-4-7`, `claude-opus-4-8`) and sent `output_config.effort` for an
+**allowlist** of effort-capable prefixes (Opus 4.5–4.8, Sonnet 4.6). Both tuples
+were closed: a model released *after* that code — `claude-fable-5` is the live
+example — matched neither list, so it kept its `temperature` (a 400 on Fable 5,
+the exact #250 regression) and silently lost its effort knob. An allowlist is
+fail-unsafe for new models by construction; every Anthropic release would have
+to touch this file or reproduce the bug.
+
+This inverts both gates to **deny-list the older models** and default everything
+else (current + future) to the safe path. `_KEEPS_TEMPERATURE_PREFIXES` is the
+set of older models that still *accept* `temperature` (Opus 4.5/4.6, Sonnet
+4.5/4.6, Haiku 4.5, and earlier); `_drops_temperature` is the negation, so any
+model off that list — Fable 5, a hypothetical Opus 5 — gets `temperature`
+dropped and won't 400. `_NO_EFFORT_PREFIXES` is the set of pre-effort models that
+*400 on* `output_config.effort` (Sonnet 4.5, Haiku 4.5); `_supports_effort` is
+the negation, so current/future models get effort. The older models' observable
+behavior is preserved exactly — Opus 4.5/4.6 and Sonnet 4.6 still take effort and
+keep temperature; Sonnet 4.5/Haiku 4.5 still keep temperature and skip effort.
+The old allowlist tuples are deleted, not left dormant alongside the new ones.
+
+We deliberately did **not** introduce a `model → params` table or any new
+abstraction — that was triaged out as over-engineering for three providers. Two
+prefix tuples plus their negations are the smallest fix that flips the default
+from fail-unsafe (allowlist) to fail-safe (deny-list).
+
+Separately, `_extract_tool_input` now checks `response.stop_reason`. A
+`max_tokens` truncation cuts the response off before the forced tool block lands,
+which previously surfaced as the opaque "did not include the tool call" error —
+the same message a genuinely tool-less response produces, but with a different
+fix (raise `max_tokens`, not retry/debug the prompt). The check raises a
+`RuntimeError` that names the `max_tokens` truncation so the cause is legible.
+
+Code-only, no schema change (`SCHEMA_VERSION` stays 9).

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -27,8 +27,9 @@ _VLM_INPUT = {"description": "A cat sitting.", "notes": ""}
 
 
 class _FakeAnthropicResponse:
-    def __init__(self, blocks):
+    def __init__(self, blocks, stop_reason="tool_use"):
         self.content = blocks
+        self.stop_reason = stop_reason
 
 
 def _block(type_, name=None, input_=None):
@@ -133,6 +134,32 @@ def test_anthropic_minimal_effort_maps_to_low(monkeypatch):
     assert fake.last_call["output_config"] == {"effort": "low"}
 
 
+def test_anthropic_current_model_drops_temperature_and_uses_effort(monkeypatch):
+    # Deny-list inversion: a current model not on either older deny-list
+    # (claude-fable-5) must default SAFE — no temperature sent (it would 400, the
+    # #250 regression), effort applied. An allowlist that predates this model
+    # would have done the opposite.
+    fake = _summarize_with_effort(monkeypatch, model="claude-fable-5", effort="high")
+    assert "temperature" not in fake.last_call
+    assert fake.last_call["output_config"] == {"effort": "high"}
+
+
+def test_anthropic_future_model_defaults_safe(monkeypatch):
+    # Any model released after this code (here a stand-in unknown id) is off both
+    # deny-lists, so it inherits the safe path: temperature dropped, effort sent.
+    fake = _summarize_with_effort(monkeypatch, model="claude-opus-5-0", effort="medium")
+    assert "temperature" not in fake.last_call
+    assert fake.last_call["output_config"] == {"effort": "medium"}
+
+
+def test_anthropic_denylisted_older_model_keeps_temperature_no_effort(monkeypatch):
+    # The pre-effort, temperature-accepting deny-list (Sonnet 4.5 here) must keep
+    # its existing behavior exactly: temperature forwarded, no effort knob sent.
+    fake = _summarize_with_effort(monkeypatch, model="claude-sonnet-4-5", effort="high")
+    assert fake.last_call["temperature"] == 0.0
+    assert "output_config" not in fake.last_call
+
+
 def _classify_on(monkeypatch, model):
     class _Schema(BaseModel):
         ok: bool
@@ -188,6 +215,20 @@ def test_anthropic_missing_tool_use_raises(monkeypatch):
     p = AnthropicProvider()
     with pytest.raises(RuntimeError, match="did not include"):
         p.analyze_image(b"\x00", model="m")
+
+
+def test_anthropic_max_tokens_truncation_raises_named_error(monkeypatch):
+    # A max_tokens truncation cuts the response off before the forced tool block
+    # lands, so the tool call is missing. The error must NAME the max_tokens
+    # truncation rather than the opaque "did not include" message — the fix
+    # (raise max_tokens) is different from a genuinely tool-less response.
+    response = _FakeAnthropicResponse([_block("text")], stop_reason="max_tokens")
+    _install_anthropic(monkeypatch, response)
+    from bartleby.providers.anthropic import AnthropicProvider
+    p = AnthropicProvider()
+    with pytest.raises(RuntimeError, match="max_tokens") as exc:
+        p.analyze_image(b"\x00", model="m")
+    assert "did not include" not in str(exc.value)
 
 
 def test_anthropic_invalid_tool_input_raises(monkeypatch):


### PR DESCRIPTION
Part of #508. Implements #504.

Inverts the Anthropic provider's temperature-drop and effort gates from closed allowlists to deny-lists of the older models, so a current temperature-rejecting model (claude-fable-5) no longer 400s on a parameter bartleby added and future models default safe. Older models' behavior is preserved exactly; no model->params table. `_extract_tool_input` now checks `response.stop_reason` so a max_tokens truncation raises an error that names itself instead of the opaque "did not include the tool call" message.

No schema change.