### PR TITLE
#506: make vacuous test assertions falsifiable; de-risk embed model load (Part of #508)

### DIFF
--- a/docs/decisions/GH-0506-test-suite-hygiene-0001.md
+++ b/docs/decisions/GH-0506-test-suite-hygiene-0001.md
@@ -1,0 +1,61 @@
+# Vacuous test assertions are made falsifiable and the embed argv test stops loading the real model (issue #506)
+
+> Source: [#506](https://github.com/jswest/bartleby/issues/506)
+
+Several assertions across the suite passed regardless of the behavior they
+claimed to pin, so a real regression would have sailed through them. This bundle
+makes each one able to actually fail, removes the dead imports/params that had
+accumulated around them, closes an `os.environ` leak in `test_quiet.py`, and
+takes the real BAAI embedding-model load out of `test_embed.py`'s default path.
+Purely test-quality work — no production code changed.
+
+**Why these were vacuous, and the fix in each case:**
+
+- **Overlap (`test_ingest_text.py`).** The input was `"abcdefghij" * 100` — a
+  10-char period. `prev[-50:] in curr` then matched on the *pattern's*
+  periodicity, not on bytes the chunker actually copied across the overlap; it
+  held even at zero overlap. Replaced with a monotonic, whitespace-free digit
+  stream (`"".join(f"{i:04d}" for i in range(500))`) where every 50-char window
+  is unique and appears exactly once, so a found tail proves a real overlap. No
+  spaces means the chunker's per-piece `.strip()` can't shift the boundary out
+  from under the slice. Verified the assertion now fails when overlap is forced
+  to 0.
+- **RRF order (`test_skill_search.py`).** `assert ids_in_order[0] in (10, 30)`
+  admitted either of the top two ids, so a tie-reversal regression passed.
+  Pinned the full deterministic order `[10, 30, 20, 50, 40]` from the known
+  two-list input.
+- **Lane callbacks (`test_scribe.py`).** The summarize-lane assertion was
+  `phase.lanes == [(phase.lanes[0][0], "doc.txt", "summarizing")]` — the lane
+  key was read back out of the result and compared to itself, so a regression
+  that dropped or mangled the key passed. With `workers=1` the pass runs inline
+  on the test thread, so the key is a *known* value: both the summarize and the
+  caption lane tests now assert the exact tuple keyed on
+  `threading.get_ident()`.
+- **`os.environ` leak (`test_quiet.py`).** `setup_quiet_third_party` writes the
+  offline flags and the noise-control vars straight into `os.environ`
+  (`setdefault` / `os.environ[...] =`), which monkeypatch does not track. A test
+  that flipped `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` to `"1"` left them set
+  for every later test, so `offline_blocked` could read a stale `"1"` it never
+  set. An autouse module fixture now snapshots and restores `os.environ` around
+  every test in the file, keeping each case hermetic and the offline assertions
+  falsifiable rather than passing on a leaked value.
+- **Real-model load (`test_embed.py`).** `test_embed_command_subprocess_listform`
+  shelled out to `uv run bartleby embed ...`, which loaded the real BAAI model
+  in a subprocess and dominated suite runtime. The property it cared about —
+  list-form argv hands the query to the embedder verbatim, with shell
+  metacharacters inert — is now asserted in-process by monkeypatching
+  `embed_texts` to record exactly what `main` forwards, then checking the
+  adversarial `"hello world; rm -rf /"` arrives un-split. The
+  no-shell-interpretation guarantee of list-form `subprocess.run` is Python's,
+  not ours to re-test on every suite run. Chosen over a `slow` marker because no
+  such marker convention exists in `pyproject.toml`; inventing one was out of
+  scope.
+
+Dead weight removed alongside: four unused `from bartleby.commands import scribe
+as scribe_module` locals in `test_scribe.py`, an unused `ChunkInput,
+insert_image_chunks` import in `test_skill_search.py`, and unused `monkeypatch`
+params in `test_skill_save_finding.py` and `test_quiet.py`.
+
+Tests: full suite green (1037 passed), and the run no longer loads the real
+embedding model — wall time dropped from ~2min (dominated by the subprocess
+test) to ~18s. No schema change.

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 
 import pytest
 
@@ -31,21 +30,32 @@ def test_embed_command_rejects_empty_text(capsys):
     assert "non-empty" in err
 
 
-def test_embed_command_subprocess_listform(monkeypatch):
-    """End-to-end via the installed `bartleby` CLI.
+def test_embed_command_passes_argv_text_through_verbatim(monkeypatch, capsys):
+    """The skill's calling pattern: list-form ``["bartleby", "embed", query]``
+    hands the query to the embedder as ``argv``, so shell metacharacters in it
+    are inert data, never interpreted (SPEC §5.5).
 
-    Verifies the skill's calling pattern works: argv-passed text reaches the
-    embedder without shell interpretation, and the response parses as a
-    correctly-sized JSON array.
+    We assert the property without spawning the real CLI — and so without
+    loading the BAAI model — by monkeypatching ``embed_texts`` to record exactly
+    what ``main`` forwards. A regression that mangled, split, or shell-expanded
+    the argument (e.g. stripping past the ``;``) would change the recorded text
+    and fail here. The cross-process, no-shell-interpretation guarantee of
+    list-form ``subprocess.run`` is Python's, not ours to re-test per run.
     """
-    proc = subprocess.run(
-        ["uv", "run", "bartleby", "embed", "hello world; rm -rf /"],
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    assert proc.returncode == 0, proc.stderr
-    vec = json.loads(proc.stdout)
+    adversarial = "hello world; rm -rf /"
+    seen: list[list[str]] = []
+
+    def _fake(texts):
+        seen.append(texts)
+        return [[0.2] * EMBEDDING_DIM for _ in texts]
+
+    monkeypatch.setattr("bartleby.commands.embed.embed_texts", _fake)
+
+    embed_cmd.main(adversarial)
+
+    # The full argument reached the embedder intact — not split on the ';'.
+    assert seen == [[adversarial]]
+    vec = json.loads(capsys.readouterr().out)
     assert isinstance(vec, list)
     assert len(vec) == EMBEDDING_DIM
     assert all(isinstance(x, float) for x in vec)

--- a/tests/test_ingest_text.py
+++ b/tests/test_ingest_text.py
@@ -18,12 +18,21 @@ def test_chunk_text_empty_input_returns_empty_list():
 
 
 def test_chunk_text_overlap_is_honored():
-    text = "abcdefghij" * 100  # 1000 chars
+    # A non-periodic, whitespace-free body: the digit stream is monotonic, so
+    # every 50-char window is unique and appears exactly once. Finding prev's
+    # tail inside curr therefore proves a real overlap, not a coincidental
+    # repeat. (The old "abcdefghij"*100 input was periodic — prev[-50:]
+    # reappeared all over curr even with zero overlap, so the assertion could
+    # never fail. No spaces means the chunker's per-piece .strip() can't shift
+    # the boundary out from under the slice.)
+    text = "".join(f"{i:04d}" for i in range(500))  # 2000 chars, all distinct
     out = chunk_text(text, chunk_size=200, overlap=50)
     assert len(out) >= 2
-    # consecutive chunks should share their tail/head bytes
+    # With chunk_size=200/overlap=50, curr starts 150 chars into prev, so prev's
+    # last 50 chars are exactly curr's first 50 — present here only because the
+    # chunker copied them over.
     for prev, curr in zip(out, out[1:]):
-        assert prev[-25:] in curr or prev[-50:] in curr
+        assert prev[-50:] in curr
 
 
 def test_chunk_text_rejects_bad_overlap():

--- a/tests/test_quiet.py
+++ b/tests/test_quiet.py
@@ -16,6 +16,27 @@ from bartleby.lib import quiet
 from bartleby.lib.consts import DOCLING_HF_REPOS, EMBEDDING_MODEL
 
 
+@pytest.fixture(autouse=True)
+def _restore_environ():
+    """Snapshot and restore ``os.environ`` around every test in this module.
+
+    ``setup_quiet_third_party`` writes the offline flags and the noise-control
+    vars straight into ``os.environ`` (``setdefault`` / ``os.environ[...] =``),
+    which monkeypatch does not track. Without this, a test that flips
+    ``HF_HUB_OFFLINE``/``TRANSFORMERS_OFFLINE`` to ``"1"`` leaves them set for
+    every later test — ``offline_blocked`` then reads a stale ``"1"`` it never
+    set, and ``_model_cached`` probes can be skewed. Restoring the pre-test
+    environment keeps each case hermetic so the offline assertions stay
+    falsifiable rather than passing on a leaked value.
+    """
+    saved = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
 def _cache_model(root, repo_id: str) -> None:
     """Materialise a non-empty HF-cache snapshot for ``repo_id`` under ``root``."""
     folder = "models--" + repo_id.replace("/", "--")
@@ -41,7 +62,7 @@ def test_model_cached_detects_presence(hf_cache):
     assert quiet._model_cached(EMBEDDING_MODEL) is True
 
 
-def test_offline_not_set_when_required_model_missing(hf_cache, monkeypatch):
+def test_offline_not_set_when_required_model_missing(hf_cache):
     # Only the embedding model is cached; a docling model is still missing.
     _cache_model(hf_cache, EMBEDDING_MODEL)
     required = (EMBEDDING_MODEL, *DOCLING_HF_REPOS)
@@ -49,7 +70,7 @@ def test_offline_not_set_when_required_model_missing(hf_cache, monkeypatch):
     assert "HF_HUB_OFFLINE" not in os.environ
 
 
-def test_offline_set_when_all_required_cached(hf_cache, monkeypatch):
+def test_offline_set_when_all_required_cached(hf_cache):
     required = (EMBEDDING_MODEL, *DOCLING_HF_REPOS)
     for repo in required:
         _cache_model(hf_cache, repo)

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -312,7 +312,6 @@ def test_parse_document_rejects_html_saved_as_pdf(tmp_path):
     """A `.pdf` that is really an HTML error page is rejected at dispatch with a
     clear reason, before either PDF backend touches it (#235). The error rides
     the existing parse-failure path into failed_ingests via _parse_request."""
-    from bartleby.commands import scribe as scribe_module
     from bartleby.ingest.pdfplumber import NotAPdfError
 
     src = tmp_path / "ViewDoc.pdf"
@@ -995,6 +994,8 @@ def test_summarize_all_lane_callback_reports_document(
     isolated_project, tmp_path, mock_embed
 ):
     """phase.lane fires per summarized document with its file name and stage."""
+    import threading
+
     from bartleby.commands import scribe as scribe_module
 
     txt = _write_txt(tmp_path / "doc.txt", "A document body with real words to chunk.")
@@ -1021,7 +1022,11 @@ def test_summarize_all_lane_callback_reports_document(
     finally:
         conn.close()
 
-    assert phase.lanes == [(phase.lanes[0][0], "doc.txt", "summarizing")]
+    # workers=1 runs inline on this thread, so the lane key is this thread's id —
+    # a known value, asserted explicitly. (The old tuple read the key back from
+    # phase.lanes[0][0], comparing it to itself, so a regression that dropped or
+    # mangled the lane key sailed through.)
+    assert phase.lanes == [(threading.get_ident(), "doc.txt", "summarizing")]
 
 
 def test_summarize_all_skips_capped_document(
@@ -1216,8 +1221,6 @@ def test_parse_document_stage_callback_fires_extract_then_embed(
     downstream in the main-process drain and summarize in its own later pass —
     not here; parse runs in a pool worker and only carries the parse-side
     stages.)"""
-    from bartleby.commands import scribe as scribe_module
-
     pdf = tmp_path / "doc.pdf"
     _text_pdf(pdf)
 
@@ -1235,8 +1238,6 @@ def test_parse_document_reports_page_count(
     isolated_project, tmp_path, mock_embed
 ):
     """The parse result carries the converter's page count (issue #85)."""
-    from bartleby.commands import scribe as scribe_module
-
     pdf = tmp_path / "doc.pdf"
     _text_pdf(pdf)
 
@@ -1288,8 +1289,6 @@ def test_parse_document_threads_on_warn_to_the_leaf(
     """on_warn reaches the leaf through the full dispatch chain: a standalone
     image parsed with vision off surfaces the 'no vision provider' notice as a
     routed warning, not a console write."""
-    from bartleby.commands import scribe as scribe_module
-
     img = tmp_path / "pic.png"
     img.write_bytes(_png_bytes())
 
@@ -1346,6 +1345,8 @@ def test_caption_all_lane_callback_reports_owning_document(
 ):
     """phase.lane fires per analyzed image with the owning file and a stage label,
     so the renderer can show which worker is captioning what."""
+    import threading
+
     from bartleby.commands import scribe as scribe_module
     from bartleby.db.connection import open_db
 
@@ -1374,10 +1375,10 @@ def test_caption_all_lane_callback_reports_owning_document(
     finally:
         conn.close()
 
-    assert phase.lanes, "expected a lane update for the one embedded image"
-    assert all(
-        item == "img.pdf" and stage == "captioning" for _, item, stage in phase.lanes
-    )
+    # One image, captioned inline (workers=1) on this thread → the lane key is
+    # this thread's id. Asserting the exact tuple (not just item/stage with the
+    # key thrown away) pins the owning-document + thread-keyed-lane contract.
+    assert phase.lanes == [(threading.get_ident(), "img.pdf", "captioning")]
 
 
 def test_document_id_for_returns_parsed_document(

--- a/tests/test_skill_save_finding.py
+++ b/tests/test_skill_save_finding.py
@@ -154,7 +154,7 @@ def test_save_finding_dedupes_repeated_markers(seeded_project, tmp_path, capsys)
 
 
 def test_save_finding_citations_include_page_number_when_available(
-    seeded_project, tmp_path, capsys, monkeypatch
+    seeded_project, tmp_path, capsys
 ):
     """A first-class page_number on the chunk surfaces in citations."""
     from bartleby.db.connection import open_db

--- a/tests/test_skill_search.py
+++ b/tests/test_skill_search.py
@@ -388,9 +388,12 @@ def test_rrf_unit_known_lists():
     expected_10 = 1.0 / 61 + 1.0 / 62
     assert by_id[30] == pytest.approx(expected_30)
     assert by_id[10] == pytest.approx(expected_10)
-    # Order: highest-score first.
+    # Order: highest-score first, fully deterministic. 10 (1/61 + 1/62) just
+    # edges out 30 (1/63 + 1/61), then 20/40 (a-only) and 50 (b-only) by their
+    # single-list RRF contributions. Asserting the whole order — not just
+    # "0th is 10 or 30" — catches a regression that reverses or reshuffles ties.
     ids_in_order = [cid for cid, _ in scored]
-    assert ids_in_order[0] in (10, 30)
+    assert ids_in_order == [10, 30, 20, 50, 40]
 
 
 def test_fts_query_quotes_each_token():
@@ -738,7 +741,6 @@ def test_search_hits_include_file_name_and_page_number(seeded_project, capsys):
 def test_search_image_source_name_notes_multiple_docs(seeded_project, capsys):
     """An image attached to two documents shows '+1 other docs' in source_name."""
     from tests._skill_fixtures import seed_image
-    from bartleby.db.chunks import ChunkInput, insert_image_chunks
     conn = open_db(seeded_project["project"])
     try:
         image_id = seed_image(


### PR DESCRIPTION
Part of #508. Implements #506.

Makes several vacuous assertions able to fail on a real regression: the overlap test now uses a non-periodic input, the RRF test pins a deterministic order, the lane-callback tests assert explicit `threading.get_ident()` tuples (no more comparing a value to itself), and `test_quiet` restores `os.environ` after every test so offline flags can't leak across cases. `test_embed` no longer loads the real BAAI model — it asserts the argv-passthrough property in-process via a monkeypatched `embed_texts` (no `slow` marker convention exists in pyproject.toml). Dead imports/params removed. Suite green (1037 passed); run time dropped from ~2min to ~16s.

No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)