### PR TITLE
Record embedding model in meta (Part of #494)

### DIFF
--- a/bartleby/db/upgrades.py
+++ b/bartleby/db/upgrades.py
@@ -26,6 +26,7 @@ from typing import Callable
 import apsw
 
 from bartleby.db.schema import SCHEMA_VERSION
+from bartleby.lib.consts import EMBEDDING_MODEL
 
 
 def _upgrade_v4_to_v5(conn: apsw.Connection) -> None:
@@ -188,6 +189,16 @@ def upgrade(conn: apsw.Connection, current_version: int) -> None:
         v += 1
 
     with conn:
+        # Backfill the pinned embedding model for corpora created before init_db
+        # started recording it (#517). INSERT OR IGNORE makes this idempotent and
+        # additive: it never overwrites a value a corpus already carries, so it's
+        # safe to re-run and needs no SCHEMA_VERSION bump. Import-side
+        # verification of the recorded value lives in #520, not here.
+        conn.cursor().execute(
+            "INSERT OR IGNORE INTO meta (key, value) "
+            "VALUES ('embedding_model', ?)",
+            (EMBEDDING_MODEL,),
+        )
         conn.cursor().execute(
             "INSERT OR REPLACE INTO meta (key, value) VALUES ('upgraded_at', ?)",
             (datetime.now(timezone.utc).isoformat(),),

--- a/docs/decisions/GH-0508-record-embedding-model.md
+++ b/docs/decisions/GH-0508-record-embedding-model.md
@@ -1,0 +1,73 @@
+# Record the pinned embedding model in `meta` — backfill without a schema bump (issue #517)
+
+> Source: [#517](https://github.com/jswest/bartleby/issues/517) — part of omnibus
+> [#494](https://github.com/jswest/bartleby/issues/494) (v0.9.8).
+
+A corpus's chunk embeddings are produced by the model pinned in
+`bartleby/lib/consts.py::EMBEDDING_MODEL` (`BAAI/bge-base-en-v1.5`). Until now the
+DB carried `meta.embedding_dim` but not *which* model produced those vectors, so a
+query embedded with a different model than the corpus could silently retrieve
+garbage. Recording the model name is the foundation; the import-side
+*verification* that compares a corpus's recorded model against the running pin is
+[#520](https://github.com/jswest/bartleby/issues/520), not this issue.
+
+Two populations to cover:
+
+- **New corpora.** `init_db` already writes `('embedding_model', EMBEDDING_MODEL)`
+  into `meta` alongside `embedding_dim` and the other init rows — this predates
+  #517 (it landed with the v1 migration). Nothing to add; a regression test now
+  pins it to `EMBEDDING_MODEL` verbatim rather than the looser truthiness check.
+- **Existing corpora.** A corpus created before that init row existed has no key.
+  It gets the *current pinned* value backfilled when the user runs
+  `bartleby project upgrade <name>`.
+
+## The stays-at-9 mechanism (and why no version step)
+
+This omnibus is explicitly additive with `SCHEMA_VERSION` pinned at **9** — the
+release is `v0.<SCHEMA_VERSION>.<patch>` = v0.9.8. A literal `_upgrade_v9_to_v10`
+chain entry would only ever fire if `SCHEMA_VERSION` became 10, which the omnibus
+forbids; adding one would be dead code at best and a forced re-ingest signal at
+worst. So the backfill must run *without* a version bump.
+
+`upgrades.py::upgrade()` already has the right seam: a tail block that runs on
+**every** `project upgrade`, even when zero version steps fire (it stamps
+`upgraded_at`). The backfill is a single idempotent statement added there:
+
+```sql
+INSERT OR IGNORE INTO meta (key, value) VALUES ('embedding_model', <pinned>)
+```
+
+`INSERT OR IGNORE` is what makes this safe to attach to an unconditional,
+already-at-v9 path:
+
+- A corpus **missing** the key gets the current pinned value.
+- A corpus that **already carries** a value keeps it — the backfill never
+  overwrites, so a corpus built on a different model is not silently relabelled
+  (that mismatch is #520's job to *detect*, not this code's to paper over).
+- Re-running `project upgrade` is a no-op — no churn, no version movement.
+
+No `schema_version` is touched by this statement; the column-walk loop above is
+untouched. The DB-newer-than-code guard still raises *before* the tail block, so
+the backfill never runs on a DB this code can't reason about
+(`test_upgrade_refuses_db_newer_than_code` still asserts the tail never fired).
+
+## Rejected alternative
+
+Adding `_upgrade_v9_to_v10` + bumping `SCHEMA_VERSION` to 10. This is the
+mechanically "canonical" upgrade-chain shape, but it turns v0.9.8 into v0.10.0 — a
+minor/schema bump that is the maintainer's release call, not an in-omnibus
+detail — and it would mark every existing v9 corpus as out-of-date for a purely
+additive metadata write. Rejected: the idempotent tail backfill achieves the same
+result with zero version movement.
+
+## Tests (in `tests/test_db.py`)
+
+- `test_init_records_pinned_embedding_model` — fresh DB's `meta.embedding_model`
+  equals `EMBEDDING_MODEL`.
+- `test_upgrade_backfills_embedding_model_idempotently` — delete the key to
+  simulate a pre-#517 corpus, run `upgrade(conn, SCHEMA_VERSION)` (no version step
+  fires; only the tail runs), assert the pinned value lands, and assert a second
+  pass leaves exactly one unchanged row.
+- `test_upgrade_does_not_overwrite_existing_embedding_model` — a pre-existing
+  non-default value survives an upgrade (INSERT OR IGNORE semantics).
+- `test_schema_version_pinned_at_nine` — guards the omnibus's additive contract.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -16,6 +16,8 @@ from bartleby.db.chunks import (
 )
 from bartleby.db.connection import init_db, open_db
 from bartleby.db.schema import EMBEDDING_DIM, SCHEMA_VERSION
+from bartleby.db.upgrades import upgrade
+from bartleby.lib.consts import EMBEDDING_MODEL
 
 
 class _BoomDatetime:
@@ -57,6 +59,61 @@ def test_meta_populated_on_init(conn):
     assert rows["sqlite_vec_version"]
     assert rows["bartleby_version"]
     assert rows["created_at"]
+
+
+def test_init_records_pinned_embedding_model(conn):
+    # A freshly-initialized DB records the pinned embedding model verbatim, so
+    # the import side (#520) can verify a corpus was built with the model it
+    # expects.
+    value = conn.cursor().execute(
+        "SELECT value FROM meta WHERE key = 'embedding_model'"
+    ).fetchone()[0]
+    assert value == EMBEDDING_MODEL
+
+
+def test_upgrade_backfills_embedding_model_idempotently(conn):
+    # Simulate a pre-#517 corpus that never recorded the key, then confirm the
+    # upgrade tail backfills the pinned value — and that re-running is a no-op
+    # rather than a churning rewrite. The DB is already at SCHEMA_VERSION, so no
+    # version step fires; only the unconditional tail block runs.
+    cur = conn.cursor()
+    cur.execute("DELETE FROM meta WHERE key = 'embedding_model'")
+    assert cur.execute(
+        "SELECT COUNT(*) FROM meta WHERE key = 'embedding_model'"
+    ).fetchone()[0] == 0
+
+    upgrade(conn, SCHEMA_VERSION)
+    value = cur.execute(
+        "SELECT value FROM meta WHERE key = 'embedding_model'"
+    ).fetchone()[0]
+    assert value == EMBEDDING_MODEL
+
+    # Idempotent: a second pass leaves exactly one row, unchanged.
+    upgrade(conn, SCHEMA_VERSION)
+    rows = cur.execute(
+        "SELECT value FROM meta WHERE key = 'embedding_model'"
+    ).fetchall()
+    assert rows == [(EMBEDDING_MODEL,)]
+
+
+def test_upgrade_does_not_overwrite_existing_embedding_model(conn):
+    # The backfill is INSERT OR IGNORE: a corpus that already carries a value
+    # (e.g. one built on a different pinned model) keeps it through an upgrade.
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE meta SET value = ? WHERE key = 'embedding_model'",
+        ("some/other-model",),
+    )
+    upgrade(conn, SCHEMA_VERSION)
+    value = cur.execute(
+        "SELECT value FROM meta WHERE key = 'embedding_model'"
+    ).fetchone()[0]
+    assert value == "some/other-model"
+
+
+def test_schema_version_pinned_at_nine():
+    # The v0.9.x line is pinned at schema 9; this whole omnibus is additive.
+    assert SCHEMA_VERSION == 9
 
 
 def test_attach_disables_load_extension(conn):


### PR DESCRIPTION
Part of #494.

Records the pinned embedding model (`EMBEDDING_MODEL`, currently `BAAI/bge-base-en-v1.5`) in `meta.embedding_model` so a later import-side check (#520) can verify a corpus was built with the model it's being queried under.

- **New corpora:** `init_db` already writes the key at create time (pre-existing). A regression test now pins it to `EMBEDDING_MODEL` verbatim.
- **Existing corpora:** backfilled on `bartleby project upgrade` via an idempotent `INSERT OR IGNORE INTO meta` in the unconditional tail of `upgrades.upgrade()`. Additive, never overwrites a value the corpus already carries, safe to re-run.

**SCHEMA_VERSION stays 9** — no `_upgrade_v9_to_v10` entry, no version bump. The backfill rides the always-runs tail block (the same place that stamps `upgraded_at`), so it lands on existing v9 corpora with no schema movement.

Tests: full suite green (1064 passed). Added in `tests/test_db.py`: fresh-init records the pinned value; upgrade backfills missing key idempotently; upgrade never overwrites an existing value; `SCHEMA_VERSION == 9` guard.

Decision doc: `docs/decisions/GH-0508-record-embedding-model.md`.