### PR TITLE
project publish → S3 (Part of #494)

### DIFF
--- a/bartleby/cli.py
+++ b/bartleby/cli.py
@@ -75,6 +75,15 @@ def main():
         help="Apply additive schema upgrades to bring a project up to date",
     )
     pup.add_argument("name", type=str)
+    ppub = project_sub.add_parser(
+        "publish",
+        help="Publish a findings-free copy of a corpus (+ originals) to S3",
+    )
+    ppub.add_argument("name", type=str)
+    ppub.add_argument(
+        "--to", required=True, metavar="S3_URL",
+        help="Destination S3 URL, e.g. s3://my-bucket/corpora/acme",
+    )
 
     scribe_parser = subparsers.add_parser(
         "scribe",
@@ -376,6 +385,8 @@ def _project(args, parser):
         project_cmd.delete(name=args.name, yes=args.yes)
     elif args.project_command == "upgrade":
         project_cmd.upgrade(name=args.name)
+    elif args.project_command == "publish":
+        project_cmd.publish(name=args.name, to=args.to)
 
 
 def _session(args, parser):

--- a/bartleby/commands/project.py
+++ b/bartleby/commands/project.py
@@ -205,6 +205,30 @@ def upgrade(*, name: str) -> None:
     )
 
 
+def publish(*, name: str, to: str) -> None:
+    """Publish a findings-free copy of a corpus (+ originals) to an S3 URL.
+
+    Writes a ``VACUUM INTO`` snapshot of the corpus DB, strips the session layer
+    on that copy, gathers the original files content-addressed by ``file_hash``,
+    and uploads the ``.db`` + files to ``--to``. The source corpus is never
+    mutated.
+    """
+    from bartleby.share.publish import publish_project
+
+    try:
+        result = publish_project(name, to)
+    except (ValueError, FileNotFoundError) as e:
+        console.error(str(e))
+        sys.exit(1)
+
+    _console.print(
+        f"[bold green]Published '{name}'[/bold green] to "
+        f"[cyan]{result['destination']}[/cyan]"
+    )
+    _console.print(f"Database: [cyan]{result['db_url']}[/cyan]")
+    _console.print(f"Files: {result['file_count']} uploaded (keyed by file_hash)")
+
+
 def delete(*, name: str, yes: bool) -> None:
     if not yes:
         if not Confirm.ask(

--- a/bartleby/db/chunks.py
+++ b/bartleby/db/chunks.py
@@ -129,6 +129,48 @@ def insert_image_chunks(
     return _insert(conn, "image", image_id, chunks, ingest_run_id)
 
 
+def delete_chunks_of_kind(conn: apsw.Connection, source_kind: str) -> list[int]:
+    """Delete every chunk of ``source_kind`` from chunks, chunks_fts, chunks_vec.
+
+    The whole-kind counterpart to :func:`delete_chunks_for` (which keys on a
+    single source). Used by corpus publish to drop all finding chunks at once.
+    Returns the deleted chunk ids so callers can re-point anything that anchored
+    at them (e.g. ``document_tags.chunk_id``).
+    """
+    if source_kind not in ALLOWED_SOURCE_KINDS:
+        raise ValueError(
+            f"invalid source_kind {source_kind!r}; "
+            f"expected one of {ALLOWED_SOURCE_KINDS}"
+        )
+
+    with conn:
+        cur = conn.cursor()
+        ids = [
+            row[0]
+            for row in cur.execute(
+                "SELECT chunk_id FROM chunks WHERE source_kind = ?",
+                (source_kind,),
+            )
+        ]
+        for cid in ids:
+            cur.execute("DELETE FROM chunks_fts WHERE rowid = ?", (cid,))
+            cur.execute("DELETE FROM chunks_vec WHERE rowid = ?", (cid,))
+        cur.execute("DELETE FROM chunks WHERE source_kind = ?", (source_kind,))
+    return ids
+
+
+def rebuild_fts(conn: apsw.Connection) -> None:
+    """Rebuild the external-content ``chunks_fts`` index from ``chunks``.
+
+    The FTS5 ``'rebuild'`` command lives here, in the one module sanctioned to
+    issue raw writes against the chunks shadow tables (the chokepoint guard
+    exempts only this module). Callers that mutate ``chunks`` outside the
+    insert helpers — e.g. publish, which bulk-deletes finding chunks — call this
+    to bring the index back in sync.
+    """
+    conn.cursor().execute("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')")
+
+
 def delete_chunks_for(
     conn: apsw.Connection,
     source_kind: str,

--- a/bartleby/share/__init__.py
+++ b/bartleby/share/__init__.py
@@ -1,0 +1,8 @@
+"""Corpus sharing: publish a findings-free copy of a corpus to S3.
+
+``bartleby project publish <name> --to <s3-url>`` lives here. The package is
+two thin pieces: :mod:`bartleby.share.s3` (a put/get wrapper over a real boto3
+client) and :mod:`bartleby.share.publish` (the VACUUM-INTO copy, the bounded
+session-layer strip on that copy, and the upload of the ``.db`` plus the
+content-addressed original files). The source corpus is never mutated.
+"""

--- a/bartleby/share/publish.py
+++ b/bartleby/share/publish.py
@@ -1,0 +1,175 @@
+"""Publish a findings-free copy of a corpus to S3.
+
+The flow, source-never-mutated throughout:
+
+1. ``VACUUM INTO`` a fresh ``.db`` copy of the corpus (never a live ``cp`` — the
+   corpus runs WAL mode, so a raw byte copy can be torn). VACUUM INTO writes a
+   clean, fully-checkpointed snapshot from a consistent read of the source.
+2. Strip the session layer on the **copy**: delete ``findings``, ``sessions``,
+   ``finding_citations``; delete the ``source_kind='finding'`` chunks and their
+   ``chunks_vec`` rows; rebuild the FTS index; null any ``document_tags.chunk_id``
+   anchor that pointed at a now-stripped chunk (the document-level tag assignment
+   survives).
+3. Gather the original ingested files, content-addressed by ``file_hash``.
+4. Upload the ``.db`` and the files to the S3 URL.
+
+A published corpus is raw material — everyone grows findings locally — so the
+findings-free strip is the permanent rule, not an option.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import apsw
+
+from bartleby.db.chunks import delete_chunks_of_kind, rebuild_fts
+from bartleby.db.connection import _attach, project_db_path
+from bartleby.project import get_project_dir, validate_project_name
+from bartleby.share import s3
+
+
+PUBLISHED_DB_NAME = "bartleby.db"
+
+
+def _vacuum_into(source_db: Path, dest_db: Path) -> None:
+    """Write a clean, consistent ``.db`` snapshot of ``source_db`` to ``dest_db``.
+
+    Opens the source read-only and runs ``VACUUM INTO``. This is the whole-file
+    transport: the entire DB (including the fts5/vec0 shadow tables) is carried,
+    never cherry-picked. The source is only read, never written.
+    """
+    if dest_db.exists():
+        dest_db.unlink()
+    conn = apsw.Connection(str(source_db), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        conn.cursor().execute("VACUUM INTO ?", (str(dest_db),))
+    finally:
+        conn.close()
+
+
+def strip_session_layer(conn: apsw.Connection) -> None:
+    """Strip findings, sessions, and finding chunks from an opened copy.
+
+    Operates on the publish copy only. Drops the finding chunks (and their
+    ``chunks_vec`` rows) via the typed ``delete_chunks_of_kind`` helper, nulls
+    ``document_tags.chunk_id`` anchors that pointed at them (the document-level
+    assignment survives), clears the session layer, and rebuilds the FTS index
+    over the surviving chunks through ``rebuild_fts``.
+    """
+    with conn:
+        cur = conn.cursor()
+
+        # Null any tag anchored at a finding chunk BEFORE the chunk is deleted:
+        # ``document_tags.chunk_id`` references ``chunks`` with no cascade, so a
+        # live anchor would block the delete on a FK violation. The document-level
+        # assignment (document_id, tag_id, value) survives — only the anchor goes.
+        cur.execute(
+            "UPDATE document_tags SET chunk_id = NULL WHERE chunk_id IN "
+            "(SELECT chunk_id FROM chunks WHERE source_kind = 'finding')"
+        )
+
+        delete_chunks_of_kind(conn, "finding")
+
+        # FK chains (finding_citations -> findings -> sessions, all ON DELETE
+        # CASCADE) mean deleting sessions is enough to clear findings and
+        # citations, but we delete each explicitly so the intent reads plainly
+        # and a future FK change can't silently leave rows behind.
+        cur.execute("DELETE FROM finding_citations")
+        cur.execute("DELETE FROM findings")
+        cur.execute("DELETE FROM sessions")
+
+        rebuild_fts(conn)
+
+
+def gather_files(conn: apsw.Connection) -> dict[str, Path]:
+    """Map ``file_hash`` -> on-disk path for every original ingested file.
+
+    Reads from the (stripped) copy's ``documents`` and ``images`` tables. A
+    container row from anchor-splitting holds no file of its own (its sections
+    carry derived hashes pointing back at the same archived original), so rows
+    whose archived path is missing on disk are skipped rather than failing the
+    publish — the content-addressed set still covers every real artifact.
+    """
+    files: dict[str, Path] = {}
+    cur = conn.cursor()
+    for file_hash, file_path in cur.execute(
+        "SELECT file_hash, file_path FROM documents"
+    ):
+        p = Path(file_path)
+        if p.is_file():
+            files[file_hash] = p
+    for file_hash, file_path in cur.execute(
+        "SELECT file_hash, file_path FROM images"
+    ):
+        p = Path(file_path)
+        if p.is_file():
+            files[file_hash] = p
+    return files
+
+
+def publish_project(name: str, to_url: str, *, client=None) -> dict:
+    """Publish project ``name`` to ``to_url`` (an ``s3://bucket/prefix`` URL).
+
+    Returns a summary dict: the destination URL, the uploaded ``.db`` URL, and
+    the per-``file_hash`` file URLs. ``client`` is injectable so tests pass a
+    stubbed boto3 client; production builds a real one.
+
+    The source corpus DB is opened read-only for the VACUUM INTO and is never
+    mutated. All strip writes land on the copy.
+    """
+    validate_project_name(name)
+    source_db = project_db_path(name)
+    if not source_db.exists():
+        raise FileNotFoundError(f"Project '{name}' has no database at {source_db}.")
+
+    target = s3.parse_s3_url(to_url)
+    if client is None:
+        client = s3._client()
+
+    # Build the copy inside the project's own scratch area, then clean it up.
+    work_dir = get_project_dir(name) / ".publish-tmp"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    copy_db = work_dir / PUBLISHED_DB_NAME
+
+    try:
+        _vacuum_into(source_db, copy_db)
+
+        conn = apsw.Connection(str(copy_db))
+        try:
+            _attach(conn)
+            strip_session_layer(conn)
+            files = gather_files(conn)
+        finally:
+            conn.close()
+
+        # Checkpoint + drop WAL so the uploaded .db is a single self-contained
+        # file (the strip ran in WAL mode via _attach).
+        wal = copy_db.with_name(copy_db.name + "-wal")
+        shm = copy_db.with_name(copy_db.name + "-shm")
+        if wal.exists() or shm.exists():
+            ck = apsw.Connection(str(copy_db))
+            try:
+                ck.cursor().execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                ck.cursor().execute("PRAGMA journal_mode = DELETE")
+            finally:
+                ck.close()
+
+        db_url = s3.put_file(client, target, PUBLISHED_DB_NAME, copy_db)
+
+        file_urls: dict[str, str] = {}
+        for file_hash, path in files.items():
+            file_urls[file_hash] = s3.put_file(
+                client, target, f"files/{file_hash}{path.suffix}", path
+            )
+    finally:
+        for leftover in work_dir.glob("*"):
+            leftover.unlink()
+        work_dir.rmdir()
+
+    return {
+        "destination": to_url,
+        "db_url": db_url,
+        "file_count": len(file_urls),
+        "file_urls": file_urls,
+    }

--- a/bartleby/share/publish.py
+++ b/bartleby/share/publish.py
@@ -93,18 +93,13 @@ def gather_files(conn: apsw.Connection) -> dict[str, Path]:
     """
     files: dict[str, Path] = {}
     cur = conn.cursor()
-    for file_hash, file_path in cur.execute(
-        "SELECT file_hash, file_path FROM documents"
-    ):
-        p = Path(file_path)
-        if p.is_file():
-            files[file_hash] = p
-    for file_hash, file_path in cur.execute(
-        "SELECT file_hash, file_path FROM images"
-    ):
-        p = Path(file_path)
-        if p.is_file():
-            files[file_hash] = p
+    for table in ("documents", "images"):
+        for file_hash, file_path in cur.execute(
+            f"SELECT file_hash, file_path FROM {table}"
+        ):
+            p = Path(file_path)
+            if p.is_file():
+                files[file_hash] = p
     return files
 
 

--- a/bartleby/share/s3.py
+++ b/bartleby/share/s3.py
@@ -1,0 +1,65 @@
+"""Thin put/get over a boto3 S3 client.
+
+Deliberately un-abstracted: no pluggable backend, no local-dir mode. In
+production :func:`_client` returns a real ``boto3`` client; tests monkeypatch
+:func:`_client` with an in-memory fake and assert the put round-trips. That is
+the whole transport layer — everything richer (multipart, retries, ACLs) is
+out of scope for this command.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+@dataclass(frozen=True)
+class S3Target:
+    """An ``s3://bucket/prefix`` destination, split into bucket + key prefix."""
+
+    bucket: str
+    prefix: str
+
+    def key_for(self, name: str) -> str:
+        """Join ``name`` onto the prefix as an S3 key (no leading slash)."""
+        if not self.prefix:
+            return name
+        return f"{self.prefix.rstrip('/')}/{name}"
+
+
+def parse_s3_url(url: str) -> S3Target:
+    """Parse ``s3://bucket/prefix/...`` into an :class:`S3Target`.
+
+    Raises ``ValueError`` on a non-``s3`` scheme or a missing bucket so the
+    caller can report a clean user error rather than upload into the void.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise ValueError(
+            f"Not an S3 URL: {url!r}. Expected the form s3://bucket/prefix"
+        )
+    return S3Target(bucket=parsed.netloc, prefix=parsed.path.lstrip("/"))
+
+
+def _client():
+    """Return a boto3 S3 client. Patched out in tests; real in production."""
+    import boto3
+
+    return boto3.client("s3")
+
+
+def put_bytes(client, target: S3Target, name: str, data: bytes) -> str:
+    """Upload ``data`` under ``target``'s prefix as object ``name``.
+
+    Returns the full ``s3://`` URL the object landed at.
+    """
+    key = target.key_for(name)
+    client.put_object(Bucket=target.bucket, Key=key, Body=data)
+    return f"s3://{target.bucket}/{key}"
+
+
+def put_file(client, target: S3Target, name: str, path) -> str:
+    """Read ``path`` and upload it under ``target`` as object ``name``."""
+    from pathlib import Path
+
+    return put_bytes(client, target, name, Path(path).read_bytes())

--- a/docs/decisions/GH-0509-project-publish-s3.md
+++ b/docs/decisions/GH-0509-project-publish-s3.md
@@ -1,0 +1,32 @@
+# `bartleby project publish <name> --to <s3-url>` ships a findings-free corpus copy to S3 (issue #519)
+
+> Source: [#519](https://github.com/jswest/bartleby/issues/519)
+
+`publish` exports a corpus as shareable raw material: a clean copy of the SQLite DB plus the original ingested files, content-addressed by `file_hash`, uploaded to an `s3://bucket/prefix` URL via `boto3`. The new `bartleby/share/` package holds two thin pieces — `s3.py` (put/get over a real boto3 client) and `publish.py` (copy + strip + gather + upload) — wired in through `bartleby/commands/project.py::publish` and the `project publish` parser in `cli.py`. No schema change.
+
+## VACUUM INTO, never a live `cp`
+
+Bartleby opens corpora in WAL mode (`_attach` sets `journal_mode = WAL`), so a raw byte copy of the `.db` file can be torn — it would miss un-checkpointed pages sitting in the `-wal` sidecar and capture a non-atomic mix of committed and in-flight state. `publish` instead opens the **source read-only** (`SQLITE_OPEN_READONLY`) and runs `VACUUM INTO ?`, which writes a fully-checkpointed, self-consistent snapshot from a single consistent read. This is also why the whole DB is carried as one file: we never cherry-pick the fts5/vec0 shadow tables — VACUUM INTO reproduces them faithfully, and the only per-row touches are the bounded sanitize below. After the strip (which runs in WAL on the copy) we `wal_checkpoint(TRUNCATE)` + `journal_mode = DELETE` so the uploaded `.db` is a single standalone file with no sidecars.
+
+## The strip — on the copy only, source never mutated
+
+A published corpus is permanently findings-free: everyone grows findings locally against the shared raw material, so the session layer is not optional to keep. On the copy, `strip_session_layer`:
+
+1. nulls `document_tags.chunk_id` anchors pointing at finding chunks **before** deleting those chunks — `document_tags.chunk_id` references `chunks` with no cascade, so a live anchor would fail the delete on a FK violation. The document-level tag assignment (`document_id, tag_id, value`) survives; only the chunk anchor goes.
+2. deletes the `source_kind='finding'` chunks and their `chunks_vec` rows via the typed `delete_chunks_of_kind` helper;
+3. deletes `finding_citations`, `findings`, `sessions` (explicitly, though the FK cascade would chain from `sessions`, so intent reads plainly and a future FK change can't silently leave rows);
+4. rebuilds the FTS index via `rebuild_fts`.
+
+The source DB is opened read-only and is never written. Proven in `tests/test_share.py` by hashing the source file before and after `publish_project` and asserting byte-equality.
+
+## Chunks discipline forced two helpers into `bartleby/db/chunks.py`
+
+The polymorphic-chunks chokepoint (CLAUDE.md rule + the `test_chunks_chokepoint` static guard) forbids raw `INSERT INTO chunks_fts/chunks_vec/chunks` outside `bartleby/db/chunks.py`, and the guard exempts only the `integrity-check` command form. The FTS `'rebuild'` command and the bulk finding-chunk delete therefore belong in that sanctioned module, not in `share/publish.py`. We added two small maintenance helpers there — `delete_chunks_of_kind` (the whole-kind sibling of the existing `delete_chunks_for`) and `rebuild_fts` — and `publish.py` calls them. This is the one out-of-touches file the discipline required.
+
+## Content-addressing by `file_hash`
+
+Originals live in the project archive at `archive/<file_hash>/<file_hash><ext>` (documents) and `archive/images/<hash>.jpg` (images), with the archived path stored in `documents.file_path` / `images.file_path`. `gather_files` reads those rows off the stripped copy and maps `file_hash -> path`, uploading each as `files/<file_hash><ext>`. Anchor-split container rows whose archived file is absent on disk are skipped — their sections carry derived hashes pointing back at the same original, so the content-addressed set still covers every real artifact.
+
+## Stubbed boto3 — no new test dependency
+
+`s3._client()` returns a real `boto3.client("s3")` in production; `publish_project(..., client=...)` makes the client injectable. Tests pass an in-memory `FakeS3Client` recording every `put_object` and assert the `.db` + per-`file_hash` files round-trip — no `moto`, no pluggable local-dir backend, the transport layer stays thin. `boto3` is a new runtime dependency (added via `uv add boto3`) because `s3.py` imports it even though the client is stubbed under test. Suite green at 1067 passing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.40.0",
     "apsw>=3.51.0.0",
+    "boto3>=1.43.28",
     "filetype>=1.2.0",
     "google-re2>=1.1.20251105",
     "loguru>=0.7.3",

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,0 +1,244 @@
+"""Tests for ``bartleby project publish`` (the bartleby.share package).
+
+S3 is stubbed with an in-memory fake client — no moto, no new test dep. The
+fixtures build a throwaway temp corpus (documents with on-disk originals, a
+session + finding with a body chunk, and a tag anchored at that finding chunk)
+so we can prove: the source DB is byte-identical before/after; the published
+copy is findings-free (no findings/sessions/finding_citations rows, no
+``source_kind='finding'`` chunks or their vec rows); a finding-anchored tag's
+``chunk_id`` is nulled while the document-level assignment survives; and the
+``.db`` plus the originals (keyed by ``file_hash``) all reach the stub.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import apsw
+import pytest
+
+import bartleby.project
+from bartleby.db.chunks import ChunkInput, insert_document_chunks, insert_finding_chunks
+from bartleby.db.connection import open_db, project_db_path
+from bartleby.db.schema import EMBEDDING_DIM
+from bartleby.share import publish as publish_mod
+from bartleby.share.s3 import parse_s3_url, S3Target
+
+
+def _emb(seed: float = 0.0) -> list[float]:
+    return [seed + 0.001 * j for j in range(EMBEDDING_DIM)]
+
+
+class FakeS3Client:
+    """In-memory stand-in for a boto3 S3 client: records every put_object."""
+
+    def __init__(self):
+        self.objects: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes) -> dict:
+        self.objects[(Bucket, Key)] = Body
+        return {}
+
+
+@pytest.fixture
+def published_corpus(tmp_path):
+    """A temp corpus with originals, a finding, and a finding-anchored tag.
+
+    Returns a dict with the project name, the archive paths, the finding chunk
+    id, the document ids, and the surviving-tag bookkeeping the asserts need.
+    """
+    bartleby.project.create_project("pub")
+    archive = bartleby.project.get_project_dir("pub") / "archive"
+
+    # Two original files on disk, content-addressed by sha256.
+    originals = {}
+    for hsh_name, text in (("alpha", b"alpha original bytes"),
+                           ("beta", b"beta original bytes")):
+        file_hash = hashlib.sha256(text).hexdigest()
+        dest_dir = archive / file_hash
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"{file_hash}.pdf"
+        dest.write_bytes(text)
+        originals[hsh_name] = (file_hash, dest)
+
+    conn = open_db("pub")
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, page_count, token_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (originals["alpha"][0], "alpha.pdf", str(originals["alpha"][1]), 3, 500),
+        )
+        doc_a = conn.last_insert_rowid()
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, page_count, token_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (originals["beta"][0], "beta.pdf", str(originals["beta"][1]), 1, 100),
+        )
+        doc_b = conn.last_insert_rowid()
+
+        doc_chunk_ids = insert_document_chunks(conn, doc_a, [
+            ChunkInput(text="alpha chunk zero", embedding=_emb(0.0), chunk_index=0),
+            ChunkInput(text="alpha chunk one", embedding=_emb(0.1), chunk_index=1),
+        ])
+
+        # A session + finding with one body chunk, citing a document chunk.
+        cur.execute(
+            "INSERT INTO sessions (name, memory_enabled) VALUES ('s1', 1)"
+        )
+        session_id = conn.last_insert_rowid()
+        cur.execute(
+            "INSERT INTO findings (session_id, title, description, body) "
+            "VALUES (?, 'F', 'hook', 'finding body')",
+            (session_id,),
+        )
+        finding_id = conn.last_insert_rowid()
+        finding_chunk_ids = insert_finding_chunks(conn, finding_id, [
+            ChunkInput(text="finding body", embedding=_emb(9.0), chunk_index=0),
+        ])
+        finding_chunk_id = finding_chunk_ids[0]
+        cur.execute(
+            "INSERT INTO finding_citations (finding_id, chunk_id) VALUES (?, ?)",
+            (finding_id, doc_chunk_ids[0]),
+        )
+
+        # A tag assigned to doc_a, anchored at the FINDING chunk. The
+        # document-level assignment must survive; only the anchor is nulled.
+        cur.execute(
+            "INSERT INTO tags (name, description) VALUES ('topic', 'a topic tag')"
+        )
+        tag_id = conn.last_insert_rowid()
+        cur.execute(
+            "INSERT INTO document_tags (document_id, tag_id, value, chunk_id) "
+            "VALUES (?, ?, 'climate', ?)",
+            (doc_a, tag_id, finding_chunk_id),
+        )
+    finally:
+        conn.close()
+
+    return {
+        "project": "pub",
+        "doc_a": doc_a,
+        "doc_b": doc_b,
+        "tag_id": tag_id,
+        "finding_chunk_id": finding_chunk_id,
+        "originals": originals,
+    }
+
+
+def _open_copy(db_bytes: bytes, tmp_path: Path) -> apsw.Connection:
+    """Materialize an uploaded .db blob and open it with vec attached."""
+    from bartleby.db.connection import _attach
+
+    out = tmp_path / "downloaded.db"
+    out.write_bytes(db_bytes)
+    conn = apsw.Connection(str(out))
+    _attach(conn)
+    return conn
+
+
+def test_source_db_byte_identical_after_publish(published_corpus):
+    src = project_db_path("pub")
+    before = src.read_bytes()
+    before_digest = hashlib.sha256(before).hexdigest()
+
+    publish_mod.publish_project("pub", "s3://bucket/corpora/pub",
+                                client=FakeS3Client())
+
+    after = src.read_bytes()
+    assert hashlib.sha256(after).hexdigest() == before_digest
+    assert after == before
+
+
+def test_published_copy_is_findings_free(published_corpus, tmp_path):
+    client = FakeS3Client()
+    publish_mod.publish_project("pub", "s3://bucket/p", client=client)
+
+    db_blob = client.objects[("bucket", "p/bartleby.db")]
+    conn = _open_copy(db_blob, tmp_path)
+    try:
+        cur = conn.cursor()
+        assert cur.execute("SELECT COUNT(*) FROM findings").fetchone()[0] == 0
+        assert cur.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0
+        assert cur.execute(
+            "SELECT COUNT(*) FROM finding_citations"
+        ).fetchone()[0] == 0
+        assert cur.execute(
+            "SELECT COUNT(*) FROM chunks WHERE source_kind = 'finding'"
+        ).fetchone()[0] == 0
+
+        # The stripped finding chunk's vec row is gone too.
+        fc = published_corpus["finding_chunk_id"]
+        assert cur.execute(
+            "SELECT COUNT(*) FROM chunks_vec WHERE rowid = ?", (fc,)
+        ).fetchone()[0] == 0
+
+        # Document chunks (and their vec rows) survive untouched.
+        assert cur.execute(
+            "SELECT COUNT(*) FROM chunks WHERE source_kind = 'document'"
+        ).fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_finding_anchored_tag_nulled_assignment_survives(published_corpus, tmp_path):
+    client = FakeS3Client()
+    publish_mod.publish_project("pub", "s3://bucket/p", client=client)
+
+    conn = _open_copy(client.objects[("bucket", "p/bartleby.db")], tmp_path)
+    try:
+        row = conn.cursor().execute(
+            "SELECT value, chunk_id FROM document_tags "
+            "WHERE document_id = ? AND tag_id = ?",
+            (published_corpus["doc_a"], published_corpus["tag_id"]),
+        ).fetchone()
+        assert row is not None, "the document-level tag assignment must survive"
+        value, chunk_id = row
+        assert value == "climate"
+        assert chunk_id is None, "the finding-anchored chunk_id must be nulled"
+    finally:
+        conn.close()
+
+
+def test_files_uploaded_keyed_by_file_hash(published_corpus):
+    client = FakeS3Client()
+    result = publish_mod.publish_project("pub", "s3://bucket/p", client=client)
+
+    assert result["file_count"] == 2
+    for _name, (file_hash, dest) in published_corpus["originals"].items():
+        key = ("bucket", f"p/files/{file_hash}.pdf")
+        assert key in client.objects, f"missing upload for {file_hash}"
+        assert client.objects[key] == dest.read_bytes()
+        assert file_hash in result["file_urls"]
+
+
+def test_stub_received_db_and_files(published_corpus):
+    client = FakeS3Client()
+    publish_mod.publish_project("pub", "s3://bucket/corpora/pub", client=client)
+
+    keys = set(client.objects)
+    assert ("bucket", "corpora/pub/bartleby.db") in keys
+    # one .db + two files
+    assert len(keys) == 3
+    file_keys = {k for k in keys if k[1].startswith("corpora/pub/files/")}
+    assert len(file_keys) == 2
+
+
+def test_publish_missing_project_raises(project_env=None):
+    bartleby.project.create_project("empty")
+    # Remove the db to simulate a project with no corpus.
+    project_db_path("empty").unlink()
+    with pytest.raises(FileNotFoundError):
+        publish_mod.publish_project("empty", "s3://bucket/p", client=FakeS3Client())
+
+
+def test_parse_s3_url():
+    t = parse_s3_url("s3://my-bucket/a/b/c")
+    assert t == S3Target(bucket="my-bucket", prefix="a/b/c")
+    assert t.key_for("x.db") == "a/b/c/x.db"
+    assert parse_s3_url("s3://only-bucket").key_for("x.db") == "x.db"
+    with pytest.raises(ValueError):
+        parse_s3_url("https://example.com/x")
+    with pytest.raises(ValueError):
+        parse_s3_url("s3:///no-bucket")

--- a/uv.lock
+++ b/uv.lock
@@ -171,6 +171,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "apsw" },
+    { name = "boto3" },
     { name = "filetype" },
     { name = "google-re2" },
     { name = "loguru" },
@@ -208,6 +209,7 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "apsw", specifier = ">=3.51.0.0" },
+    { name = "boto3", specifier = ">=1.43.28" },
     { name = "docling", marker = "extra == 'docling'", specifier = ">=2.0.0" },
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "google-re2", specifier = ">=1.1.20251105" },
@@ -248,6 +250,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f2/a976b2a81d8dc7ff675f4b614367a185727061130184a28da0f53f446b97/boto3-1.43.28.tar.gz", hash = "sha256:8391fdcc4d8e1d4e0bf96575a7e5610964a4d401dafa4dccb0a5bade8dd3fbb0", size = 113202, upload-time = "2026-06-11T19:29:01.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/a5/47db150ea6380f11569b87d3ad064e3c929e5abe227a549d472fab6f5f3a/boto3-1.43.28-py3-none-any.whl", hash = "sha256:4fe6df2163aea02b561eca0d685e2f41a059d71f03721a3e79c3b522e79a3b56", size = 140536, upload-time = "2026-06-11T19:29:00.143Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/dc/1b01808003f88f8a328732c979f20cb0456791048b4440fc4abcae08c1a0/botocore-1.43.28.tar.gz", hash = "sha256:9bbad501a68e4ffdbeff76a382507f5d7827abc316f34a218ab76f5293e6c78d", size = 15503514, upload-time = "2026-06-11T19:28:50.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/8c/14916c353ce8a29d14cf6308c2bef842bbb25dde6defc620e26e28063331/botocore-1.43.28-py3-none-any.whl", hash = "sha256:8147adea89b4c9324e842cd8c01ea1a0e17c92cb6ebeaa8cb774f821cb5a7629", size = 15188401, upload-time = "2026-06-11T19:28:47.244Z" },
 ]
 
 [[package]]
@@ -956,6 +986,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
     { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
     { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2585,6 +2624,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
     { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
     { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #494.

Adds `bartleby project publish <name> --to <s3-url>`: writes a `VACUUM INTO` snapshot of the corpus DB (never a live `cp` — Bartleby runs WAL mode), strips the session layer on the copy, gathers the original files content-addressed by `file_hash`, and uploads the `.db` + files to S3 via `boto3`. **The source corpus is never mutated.**

The strip (on the copy only): null `document_tags.chunk_id` anchors pointing at finding chunks, delete `source_kind='finding'` chunks + their `chunks_vec` rows, delete `finding_citations`/`findings`/`sessions`, rebuild `chunks_fts`.

**What changed**
- new `bartleby/share/` package: `s3.py` (thin put/get over a real boto3 client, stubbed in tests) + `publish.py` (copy + strip + gather + upload)
- wired `project publish` into `commands/project.py` + the `cli.py` parser
- added `delete_chunks_of_kind` + `rebuild_fts` to `db/chunks.py` — the chunks chokepoint guard forbids raw chunk-table SQL elsewhere, so these are the sanctioned maintenance helpers publish needs (one out-of-touches file, required by the discipline)
- `boto3` added as a runtime dependency (`uv add boto3`)
- `tests/test_share.py` with an in-memory `FakeS3Client` (no moto)

**Tests**: full suite green, 1067 passing. New tests prove source byte-identical before/after, copy findings-free, finding-anchored tag nulled while assignment survives, files keyed by `file_hash`, stub received `.db` + files.

No schema change. Decision doc: `docs/decisions/GH-0509-project-publish-s3.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)