### PR TITLE
Critic pass 1 fixes: reachable backfill, robust import file-landing (Part of #494)

### DIFF
--- a/bartleby/commands/project.py
+++ b/bartleby/commands/project.py
@@ -178,12 +178,6 @@ def upgrade(*, name: str) -> None:
             console.error("Database has no schema_version. Recreate the project.")
             sys.exit(1)
         current = int(row[0])
-        if current == SCHEMA_VERSION:
-            _console.print(
-                f"Project '{name}' is already at schema v{SCHEMA_VERSION}. "
-                "Nothing to do."
-            )
-            return
         if current > SCHEMA_VERSION:
             console.error(
                 f"Database is at v{current}, newer than code's "
@@ -191,6 +185,12 @@ def upgrade(*, name: str) -> None:
             )
             sys.exit(1)
 
+        # Always call upgrades.upgrade — even when already at SCHEMA_VERSION. The
+        # version-step loop won't run, but the always-runs tail (idempotent
+        # `INSERT OR IGNORE embedding_model` + `upgraded_at`) still does. A v9
+        # corpus created before #517 has no embedding_model key, and this is the
+        # only CLI path that backfills it; skipping the call here (the old bug)
+        # left those corpora forever unable to publish an importable artifact.
         try:
             upgrades_mod.upgrade(conn, current)
         except (RuntimeError, apsw.Error) as e:
@@ -199,10 +199,16 @@ def upgrade(*, name: str) -> None:
     finally:
         conn.close()
 
-    _console.print(
-        f"[bold green]Upgraded '{name}'[/bold green] "
-        f"from v{current} to v{SCHEMA_VERSION}."
-    )
+    if current == SCHEMA_VERSION:
+        _console.print(
+            f"Project '{name}' is already at schema v{SCHEMA_VERSION}; "
+            "ensured metadata is current."
+        )
+    else:
+        _console.print(
+            f"[bold green]Upgraded '{name}'[/bold green] "
+            f"from v{current} to v{SCHEMA_VERSION}."
+        )
 
 
 def publish(*, name: str, to: str) -> None:
@@ -213,12 +219,23 @@ def publish(*, name: str, to: str) -> None:
     and uploads the ``.db`` + files to ``--to``. The source corpus is never
     mutated.
     """
+    from botocore.exceptions import (
+        ClientError,
+        EndpointConnectionError,
+        NoCredentialsError,
+    )
+
     from bartleby.share.publish import publish_project
 
     try:
         result = publish_project(name, to)
     except (ValueError, FileNotFoundError) as e:
         console.error(str(e))
+        sys.exit(1)
+    except (ClientError, NoCredentialsError, EndpointConnectionError) as e:
+        # A bad bucket/URL, missing/expired credentials, or an unreachable
+        # endpoint should be a clean error, not a boto3 traceback.
+        console.error(f"S3 error: {e}")
         sys.exit(1)
 
     _console.print(
@@ -238,12 +255,24 @@ def import_(*, name: str, from_url: str, without_tags: bool) -> None:
     rewrites local file paths by ``file_hash``. ``--without-tags`` drops the
     adopted tag definitions and assignments.
     """
+    from botocore.exceptions import (
+        ClientError,
+        EndpointConnectionError,
+        NoCredentialsError,
+    )
+
     from bartleby.share.import_ import ImportRefused, import_project
 
     try:
         result = import_project(name, from_url, without_tags=without_tags)
     except (ValueError, ImportRefused) as e:
         console.error(str(e))
+        sys.exit(1)
+    except (ClientError, NoCredentialsError, EndpointConnectionError) as e:
+        # A wrong URL, a missing bartleby.db at the prefix, missing/expired
+        # credentials, or an unreachable endpoint should be a clean error, not a
+        # boto3 traceback. import_project already tore down any half-built project.
+        console.error(f"S3 error: {e}")
         sys.exit(1)
 
     _console.print(

--- a/bartleby/share/import_.py
+++ b/bartleby/share/import_.py
@@ -35,6 +35,7 @@ import shutil
 from pathlib import Path
 
 import apsw
+from botocore.exceptions import ClientError
 
 from bartleby.db.connection import _attach, project_db_path
 from bartleby.db.schema import SCHEMA_VERSION
@@ -65,7 +66,12 @@ def _read_meta(db_path: Path, key: str) -> str | None:
             row = conn.cursor().execute(
                 "SELECT value FROM meta WHERE key = ?", (key,)
             ).fetchone()
-        except apsw.SQLError:
+        except apsw.Error:
+            # A garbage / non-SQLite blob raises apsw.NotADBError, which is an
+            # apsw.Error but NOT an apsw.SQLError — catching only the latter let
+            # a corrupt download escape as a traceback instead of the clean
+            # missing-key refusal path. Treat any DB-level error as "no value",
+            # so _verify_compatible refuses it as a non-Bartleby corpus.
             return None
     finally:
         conn.close()
@@ -121,10 +127,21 @@ def _land_files(conn: apsw.Connection, target: s3.S3Target, archive: Path,
     landed path. Idempotent: the landing path depends only on ``file_hash`` (and
     suffix), so a re-import overwrites in place to identical bytes.
 
-    A row whose published object is absent (e.g. an anchor-split container row
-    that publish skipped because it holds no file of its own) is left with its
-    ``file_path`` untouched — its sections carry derived hashes pointing back at
-    the same original. Returns the count of files actually landed.
+    Error handling is deliberately strict: a row whose ``file_path`` is NOT
+    rewritten still points at the *publisher's* absolute path, which is dangling
+    on this machine — and the web view and search trust that column. So:
+
+    * A genuinely-absent object (boto3 ``NoSuchKey``/404 ``ClientError``) is
+      itself a sign of a corrupt artifact: publish only uploads files it
+      actually found on disk, so a published artifact missing a file it
+      advertised is broken. We refuse the whole import rather than silently
+      leave a dangling row.
+    * Any other failure (a transient S3 error, throttling, expired credentials,
+      or a disk-write failure — all brought inside the protected region) aborts
+      the import by re-raising, so the CLI maps it to a non-zero exit and the
+      half-built project is cleaned up.
+
+    Returns the count of files landed (every row, on success).
     """
     landed = 0
     cur = conn.cursor()
@@ -137,23 +154,35 @@ def _land_files(conn: apsw.Connection, target: s3.S3Target, archive: Path,
             name = f"files/{file_hash}{ext}"
             try:
                 data = s3.get_bytes(client, target, name)
-            except Exception:
-                # Object absent (a container row, or a partial publish). Leave
-                # the path as-is rather than fail the whole import.
-                continue
-            if subdir is None:
-                dest_dir = archive / file_hash
-            else:
-                dest_dir = archive / subdir
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            dest = dest_dir / f"{file_hash}{ext}"
-            dest.write_bytes(data)
+                if subdir is None:
+                    dest_dir = archive / file_hash
+                else:
+                    dest_dir = archive / subdir
+                dest_dir.mkdir(parents=True, exist_ok=True)
+                dest = dest_dir / f"{file_hash}{ext}"
+                dest.write_bytes(data)
+            except ClientError as e:
+                if _is_missing_key(e):
+                    raise ImportRefused(
+                        f"Published artifact is missing a file it advertised "
+                        f"(object {name!r} for {table} file_hash {file_hash}). "
+                        "The artifact is corrupt — refusing to import a corpus "
+                        "with dangling file references."
+                    ) from e
+                raise
             cur.execute(
                 f"UPDATE {table} SET file_path = ? WHERE file_hash = ?",
                 (str(dest), file_hash),
             )
             landed += 1
     return landed
+
+
+def _is_missing_key(err: ClientError) -> bool:
+    """True if a boto3 ``ClientError`` is an absent-object (NoSuchKey / 404)."""
+    error = err.response.get("Error", {}) if hasattr(err, "response") else {}
+    code = str(error.get("Code", ""))
+    return code in ("NoSuchKey", "404", "NoSuchBucket")
 
 
 def _drop_tags(conn: apsw.Connection) -> None:
@@ -190,6 +219,11 @@ def import_project(name: str, from_url: str, *, client=None,
         client = s3._client()
 
     project_dir = get_project_dir(name)
+    # Whether this project already existed before the import. A re-import
+    # overwrites in place, so we must NOT delete a pre-existing project if
+    # landing fails; a freshly-created one, however, is cleaned up so an aborted
+    # import never leaves a half-registered project behind.
+    preexisting = project_dir.exists()
 
     # Download + verify in scratch first, so a refused import touches nothing.
     scratch = project_dir.parent / f".import-tmp-{name}"
@@ -218,15 +252,25 @@ def import_project(name: str, from_url: str, *, client=None,
             leftover.unlink()
         scratch.rmdir()
 
-    conn = apsw.Connection(str(dest_db))
+    # Landing can fail (a refused absent-key artifact, a transient S3 error, a
+    # disk-write failure). The DB is registered now, so on ANY landing failure
+    # tear the freshly-created project back down before re-raising — otherwise a
+    # failed import leaves a project whose rows still point at the publisher's
+    # dangling paths.
     try:
-        _attach(conn)
-        if without_tags:
-            _drop_tags(conn)
-        with conn:
-            file_count = _land_files(conn, target, archive, client)
-    finally:
-        conn.close()
+        conn = apsw.Connection(str(dest_db))
+        try:
+            _attach(conn)
+            if without_tags:
+                _drop_tags(conn)
+            with conn:
+                file_count = _land_files(conn, target, archive, client)
+        finally:
+            conn.close()
+    except BaseException:
+        if not preexisting and project_dir.exists():
+            shutil.rmtree(project_dir)
+        raise
 
     set_active_project(name)
 

--- a/bartleby/share/publish.py
+++ b/bartleby/share/publish.py
@@ -32,6 +32,23 @@ from bartleby.share import s3
 PUBLISHED_DB_NAME = "bartleby.db"
 
 
+def _read_source_meta(source_db: Path, key: str) -> str | None:
+    """Read a single ``meta`` value from the source corpus, read-only.
+
+    Opens the source ``.db`` read-only (no vec extension, no mutation — the
+    corpus is never touched by publish) just to pre-flight the embedding-model
+    gate. Returns ``None`` if the key is absent.
+    """
+    conn = apsw.Connection(str(source_db), flags=apsw.SQLITE_OPEN_READONLY)
+    try:
+        row = conn.cursor().execute(
+            "SELECT value FROM meta WHERE key = ?", (key,)
+        ).fetchone()
+    finally:
+        conn.close()
+    return None if row is None else str(row[0])
+
+
 def _vacuum_into(source_db: Path, dest_db: Path) -> None:
     """Write a clean, consistent ``.db`` snapshot of ``source_db`` to ``dest_db``.
 
@@ -117,6 +134,20 @@ def publish_project(name: str, to_url: str, *, client=None) -> dict:
     source_db = project_db_path(name)
     if not source_db.exists():
         raise FileNotFoundError(f"Project '{name}' has no database at {source_db}.")
+
+    # Refuse BEFORE the expensive VACUUM/upload if the source corpus doesn't
+    # record its embedding model. A published artifact lacking meta.embedding_model
+    # is dead on arrival: every importer hard-refuses it (the #520 gate), but only
+    # the importer sees that error — the publisher, the one person who can fix it,
+    # would otherwise get a green "Published". Point them at `project upgrade`,
+    # which backfills the key (and, post-critic-pass-1, is reachable on a v9 corpus).
+    if _read_source_meta(source_db, "embedding_model") is None:
+        raise ValueError(
+            f"Project '{name}' does not record its embedding model "
+            "(meta.embedding_model is absent), so any importer will hard-refuse "
+            f"the published artifact. Run `bartleby project upgrade {name}` to "
+            "backfill it, then publish again. Refusing to publish a dead artifact."
+        )
 
     target = s3.parse_s3_url(to_url)
     if client is None:

--- a/docs/decisions/GH-0511-critic-pass1-fixes.md
+++ b/docs/decisions/GH-0511-critic-pass1-fixes.md
@@ -1,0 +1,137 @@
+# Critic pass 1 fixes for the publish→import contract (omnibus #494)
+
+> Source: omnibus [#494](https://github.com/jswest/bartleby/issues/494) (v0.9.8),
+> critic pass over the three merged sub-issues
+> ([#517](https://github.com/jswest/bartleby/issues/517) embedding-model
+> recording, [#519](https://github.com/jswest/bartleby/issues/519) `project
+> publish`, [#520](https://github.com/jswest/bartleby/issues/520) `project
+> import`).
+
+A critic found four bugs in the merged publish→import seam, all in the same blast
+radius: a corpus that lacks `meta.embedding_model` (every pre-#517 corpus) could
+never become importable, and `import` could report success while leaving dangling
+file references or crash with a boto3/apsw traceback. Additive only —
+`SCHEMA_VERSION` stays at 9, no `--force` anywhere, no schema change.
+
+## FIX 1 — the embedding-model backfill was unreachable for existing v9 corpora
+
+#517 put the `embedding_model` backfill in the **always-runs tail** of
+`bartleby.db.upgrades.upgrade()` (an idempotent `INSERT OR IGNORE`). But the CLI
+wrapper `commands/project.py::upgrade` short-circuited *before* ever calling that
+function: when `current == SCHEMA_VERSION` (9) it printed "already at schema v9.
+Nothing to do." and `return`ed. So every corpus created **before** this omnibus
+is at v9 with no `embedding_model` key and had **no CLI path to acquire it** — it
+would `publish` a `.db` that `import` always hard-refuses, and the publisher (the
+only one who can fix it) saw a green "Published".
+
+The unit tests missed this because they call `upgrades.upgrade(conn, ...)`
+directly, bypassing the CLI guard that contained the bug.
+
+**Fix:** drop the early `return`. When `current == SCHEMA_VERSION` we now still
+call `upgrades.upgrade(conn, current)` — the version-step `while` loop is a no-op
+at that version, but the tail's `INSERT OR IGNORE embedding_model` +
+`upgraded_at` write runs and backfills the key. The `current > SCHEMA_VERSION`
+newer-than-code refusal path is preserved unchanged, and the console message
+distinguishes "already at v9; ensured metadata is current" from a real version
+bump. `upgrades.py` is untouched — its tail was already idempotent and correct;
+only the CLI's reach to it was broken.
+
+**Proof:** `tests/test_project.py::test_upgrade_backfills_embedding_model_on_current_v9`
+goes through the **public command** (`project_cmd.upgrade(name=...)`, not
+`upgrades.upgrade`) to exercise the actual seam that was dead: it deletes the
+`embedding_model` key from a fresh v9 DB, runs the command, asserts the key is
+back and equals `EMBEDDING_MODEL`, and that a second run neither errors nor
+overwrites.
+
+## FIX 2 — `import`'s `_land_files` swallowed real failures into a dangling success
+
+`_land_files` had a bare `except Exception: continue`, and the `dest.write_bytes`
+sat *outside* the try. So a transient S3 error (reset, throttle, expired
+credentials), a `NoSuchKey`, **or** a disk-write failure mid-loop was silently
+swallowed: the import exited 0 and reported success, but that row's
+`documents`/`images` `file_path` still pointed at the **publisher's** absolute
+path — dangling on the importer's machine. The web view (`web/.../queries.js`)
+and `search.py` trust that column.
+
+**Fix — narrow the catch, and abort loudly:**
+
+- `write_bytes` (and the dir creation) is now **inside** the protected region, so
+  a disk-write failure is caught rather than escaping mid-row.
+- Only a genuinely-absent object — a boto3 `ClientError` whose code is
+  `NoSuchKey`/`404`/`NoSuchBucket` (`_is_missing_key`) — is treated specially,
+  and even then we do **not** silently succeed. Per the publish side, every
+  gathered file actually exists in the artifact, so a missing object means the
+  artifact is **corrupt**; we raise `ImportRefused` rather than leave a dangling
+  row. (We chose refuse over collect-and-report: it's simpler and a published
+  artifact missing a file it advertised is unambiguously broken.)
+- **Any other exception** (the transient/credential/disk cases) re-raises, so the
+  CLI maps it to a non-zero exit.
+
+Because the project is *registered* (its directory created, `.db` moved into
+place) before landing runs, a landing failure now tears the **freshly-created**
+project back down before re-raising — mirroring the pre-verification scratch
+cleanup. We track whether the project pre-existed and only `rmtree` one we
+created, so a re-import that fails mid-landing never deletes a user's prior
+project.
+
+**Proof:**
+`tests/test_share.py::test_import_aborts_on_non_missing_get_error_no_dangling_project`
+wraps the in-memory `FakeS3Client` so the first file GET raises a non-`NoSuchKey`
+`ClientError`; the import raises, no project is left registered, and the project
+dir is gone (no row keeps a publisher path). A companion
+`test_import_refuses_artifact_missing_advertised_file` covers the `NoSuchKey`
+→ `ImportRefused` path. boto3 stays stubbed — no moto.
+
+## FIX 3 — `publish` silently uploaded a dead artifact (composes with FIX 1)
+
+A user who never ran `project upgrade` could `publish` a `.db` lacking
+`embedding_model`; every importer hard-refuses it, but only the importer sees the
+error. The publisher got a green "Published".
+
+**Fix:** `publish.publish_project` now pre-flights the **source** corpus `meta`
+for `embedding_model` *before* the expensive VACUUM/upload (via a read-only
+`_read_source_meta` that never mutates the corpus). If the key is absent it
+**refuses** with an actionable `ValueError` pointing at `bartleby project upgrade
+<name>` — which, after FIX 1, actually backfills it. We deliberately do **not**
+mutate the source to add the key; refuse-and-point keeps publish read-only on the
+corpus and routes the user through the one place that owns the backfill.
+
+**Proof:**
+`tests/test_share.py::test_publish_refuses_source_without_embedding_model`
+drops the key from a fresh corpus, asserts `publish_project` raises `ValueError`
+mentioning `project upgrade`, and that **nothing** was uploaded to the stub
+(`client.objects == {}`).
+
+## FIX 4 — corrupt download / boto3 errors crashed instead of refusing cleanly
+
+Two narrow-catch gaps:
+
+- `import_._read_meta` caught only `apsw.SQLError`. A non-DB / garbage blob raises
+  `apsw.NotADBError`, which is an `apsw.Error` but **not** a subclass of
+  `SQLError`, so a corrupt download escaped as a traceback. Widened to
+  `apsw.Error`, which routes a garbage blob through the same clean
+  missing-`schema_version` refusal (`ImportRefused`).
+- The command-layer handlers (`commands/project.py::publish` and `::import_`)
+  caught only `ValueError`/`ImportRefused`, so a boto3 `NoCredentialsError` /
+  `ClientError` / `EndpointConnectionError` (wrong URL, missing `bartleby.db` at
+  the prefix, expired creds, unreachable endpoint) printed a traceback. Both
+  handlers now catch those three botocore exceptions and emit a clean stderr
+  error + non-zero exit. Kept minimal — we don't over-catch (programming errors
+  still surface).
+
+**Proof:** `tests/test_share.py::test_import_refuses_non_sqlite_blob` stores a
+non-SQLite blob as `bartleby.db` and asserts a clean `ImportRefused` with no
+project left behind. `test_publish_command_handler_maps_boto3_error_to_exit`
+makes the handler's `publish_project` raise a `ClientError` and asserts a clean
+`SystemExit(1)`.
+
+## Deferred — surfaced to the maintainer, not fixed here
+
+- **`import` overwriting a same-named existing project without confirmation.** The
+  existing `test_import_rewrites_file_paths_and_is_idempotent` *encodes*
+  overwrite-on-reimport as intended behavior; changing it is a design call. Left
+  exactly as-is (and still passing).
+- **Anchor-split corpora uploading N+1 copies of the same original file**
+  (`gather_files` dedup defeat for #254 EDGAR sections). An efficiency issue that
+  crosses the publish/ingest seam; tracked as a follow-up. `gather_files` is
+  untouched by this pass.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -606,3 +606,56 @@ def test_upgrade_refuses_db_newer_than_code(projects_root):
     with pytest.raises(SystemExit) as exc:
         project_cmd.upgrade(name="alpha")
     assert exc.value.code == 1
+
+
+def test_upgrade_backfills_embedding_model_on_current_v9(projects_root):
+    """`project upgrade` on an already-v9 corpus still backfills embedding_model.
+
+    A corpus created before #517 is at schema v9 but carries no
+    `meta.embedding_model` key, so `project publish` produces an artifact every
+    importer hard-refuses. The CLI `upgrade` handler used to `return` early when
+    `current == SCHEMA_VERSION`, BEFORE calling `upgrades.upgrade()` — so the
+    always-runs backfill tail never ran and those corpora could never be fixed
+    through the CLI. This goes through the public command path (not
+    `upgrades.upgrade` directly, which the unit tests already cover) to prove the
+    seam is reachable, and that a second run is idempotent.
+    """
+    import apsw
+
+    from bartleby.commands import project as project_cmd
+    from bartleby.db.connection import project_db_path
+    from bartleby.lib.consts import EMBEDDING_MODEL
+
+    bartleby.project.create_project("alpha")
+    db_path = project_db_path("alpha")
+
+    # Simulate a pre-#517 v9 corpus: at SCHEMA_VERSION but no embedding_model key.
+    conn = apsw.Connection(str(db_path))
+    try:
+        conn.cursor().execute("DELETE FROM meta WHERE key = 'embedding_model'")
+        meta = dict(conn.cursor().execute("SELECT key, value FROM meta"))
+        assert meta["schema_version"] == str(SCHEMA_VERSION)
+        assert "embedding_model" not in meta
+    finally:
+        conn.close()
+
+    # CLI upgrade on an already-current DB now backfills the key.
+    project_cmd.upgrade(name="alpha")
+
+    conn = apsw.Connection(str(db_path))
+    try:
+        meta = dict(conn.cursor().execute("SELECT key, value FROM meta"))
+        assert meta["embedding_model"] == EMBEDDING_MODEL
+        assert meta["schema_version"] == str(SCHEMA_VERSION)
+        first_upgraded_at = meta.get("upgraded_at")
+    finally:
+        conn.close()
+
+    # Idempotent: a second run neither errors nor overwrites the existing value.
+    project_cmd.upgrade(name="alpha")
+    conn = apsw.Connection(str(db_path))
+    try:
+        meta = dict(conn.cursor().execute("SELECT key, value FROM meta"))
+        assert meta["embedding_model"] == EMBEDDING_MODEL
+    finally:
+        conn.close()

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -408,6 +408,154 @@ def test_import_rewrites_file_paths_and_is_idempotent(published_corpus, tmp_path
     assert landed_state() == first
 
 
+def _meta_lacks_key(client: FakeS3Client, bucket: str, key: str,
+                    meta_key: str, tmp_path: Path) -> None:
+    """Delete ``meta_key`` from the stored ``.db`` blob (simulate a pre-#517 src)."""
+    _rewrite_db_meta(
+        client, bucket, key,
+        lambda cur: cur.execute(
+            "DELETE FROM meta WHERE key = ?", (meta_key,)
+        ),
+        tmp_path,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Critic pass 1 regressions (#494): robust import file-landing, publish
+# pre-flight, and clean refusals on corrupt downloads / boto3 errors.
+# --------------------------------------------------------------------------- #
+
+from botocore.exceptions import ClientError  # noqa: E402
+
+
+def test_import_aborts_on_non_missing_get_error_no_dangling_project(
+    published_corpus, tmp_path
+):
+    """A non-NoSuchKey GET failure mid-landing aborts the import cleanly.
+
+    A transient S3 error (reset, throttle, expired creds) on a file GET used to
+    be swallowed by a bare `except Exception: continue`, so the import "succeeded"
+    while that row's `file_path` still pointed at the PUBLISHER's absolute path —
+    a dangling reference the web view and search trust. The narrowed handler now
+    re-raises any non-absent-key error; the freshly-created project is torn down.
+    """
+    client = _publish_to_stub("pub", "s3://bucket/corpora/pub")
+
+    # Wrap the stub so the FIRST file (not the .db) GET raises an internal error.
+    base_get = client.get_object
+    state = {"file_gets": 0}
+
+    def flaky_get(*, Bucket: str, Key: str):
+        if "/files/" in Key:
+            state["file_gets"] += 1
+            if state["file_gets"] == 1:
+                raise ClientError(
+                    {"Error": {"Code": "InternalError",
+                               "Message": "we encountered an internal error"}},
+                    "GetObject",
+                )
+        return base_get(Bucket=Bucket, Key=Key)
+
+    client.get_object = flaky_get
+
+    with pytest.raises(ClientError):
+        import_mod.import_project("imported", "s3://bucket/corpora/pub",
+                                  client=client)
+
+    # No half-registered project, and no row kept a publisher path (the project
+    # dir is gone entirely).
+    assert "imported" not in {p["name"] for p in bartleby.project.list_projects()}
+    assert not import_mod.get_project_dir("imported").exists()
+
+
+def test_import_refuses_artifact_missing_advertised_file(published_corpus, tmp_path):
+    """A published artifact missing a file it advertised is treated as corrupt.
+
+    Publish only uploads files it found on disk, so an absent object (NoSuchKey)
+    means the artifact is broken. Rather than silently leave a dangling row, the
+    import refuses and tears the fresh project back down.
+    """
+    client = _publish_to_stub("pub", "s3://bucket/corpora/pub")
+
+    base_get = client.get_object
+
+    def absent_first_file(*, Bucket: str, Key: str):
+        if "/files/" in Key:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "no such key"}},
+                "GetObject",
+            )
+        return base_get(Bucket=Bucket, Key=Key)
+
+    client.get_object = absent_first_file
+
+    with pytest.raises(import_mod.ImportRefused):
+        import_mod.import_project("imported", "s3://bucket/corpora/pub",
+                                  client=client)
+    assert not import_mod.get_project_dir("imported").exists()
+
+
+def test_publish_refuses_source_without_embedding_model(tmp_path, capsys):
+    """Publishing a corpus whose meta lacks embedding_model refuses, no upload.
+
+    A pre-#517 corpus would publish a dead artifact (every importer hard-refuses)
+    while the publisher saw a green "Published". Publish now pre-flights the
+    source meta and refuses, pointing at `project upgrade`.
+    """
+    bartleby.project.create_project("nomodel")
+    # Simulate a pre-#517 corpus: drop the embedding_model key from the source.
+    src = project_db_path("nomodel")
+    conn = apsw.Connection(str(src))
+    try:
+        conn.cursor().execute("DELETE FROM meta WHERE key = 'embedding_model'")
+    finally:
+        conn.close()
+
+    client = FakeS3Client()
+    with pytest.raises(ValueError) as exc:
+        publish_mod.publish_project("nomodel", "s3://bucket/p", client=client)
+
+    assert "project upgrade" in str(exc.value)
+    # Nothing was uploaded.
+    assert client.objects == {}
+
+
+def test_import_refuses_non_sqlite_blob(tmp_path):
+    """A garbage (non-SQLite) downloaded blob refuses cleanly, no project.
+
+    `_read_meta` catches only apsw.SQLError before; a non-DB blob raises
+    apsw.NotADBError (an apsw.Error, NOT a SQLError), which used to escape as a
+    traceback. Now it routes through the clean missing-schema refusal.
+    """
+    client = FakeS3Client()
+    target = parse_s3_url("s3://bucket/corpora/pub")
+    # Store a non-SQLite blob where the .db is expected.
+    client.put_object(Bucket="bucket", Key=target.key_for("bartleby.db"),
+                      Body=b"this is definitely not a sqlite database")
+
+    with pytest.raises(import_mod.ImportRefused):
+        import_mod.import_project("imported", "s3://bucket/corpora/pub",
+                                  client=client)
+    assert not import_mod.get_project_dir("imported").exists()
+
+
+def test_publish_command_handler_maps_boto3_error_to_exit(tmp_path, monkeypatch):
+    """The publish command handler turns a boto3 ClientError into a clean exit 1."""
+    from bartleby.commands import project as project_cmd
+
+    bartleby.project.create_project("alpha")
+
+    def boom(name, to):
+        raise ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}}, "PutObject"
+        )
+
+    monkeypatch.setattr("bartleby.share.publish.publish_project", boom)
+    with pytest.raises(SystemExit) as exc:
+        project_cmd.publish(name="alpha", to="s3://bucket/p")
+    assert exc.value.code == 1
+
+
 def test_import_without_tags_drops_tags(published_corpus, tmp_path):
     client = _publish_to_stub("pub", "s3://bucket/corpora/pub")
 


### PR DESCRIPTION
Part of #494. Fixes from the critic pass over the merged publish→import seam (#517/#519/#520):

- **FIX 1 (must-fix):** `project upgrade` on an already-v9 corpus no longer `return`s before calling `upgrades.upgrade()`. The always-runs backfill tail (#517's idempotent `INSERT OR IGNORE embedding_model`) is now reachable through the CLI, so every pre-omnibus v9 corpus can finally acquire the key `import` hard-refuses without. CLI-path regression test (not the direct `upgrades.upgrade` call that missed the bug).
- **FIX 2 (must-fix):** `import`'s `_land_files` no longer swallows real failures into a dangling success. `write_bytes` moved inside the protected region; only a `NoSuchKey`/404 `ClientError` is special-cased (and *refuses* — a published artifact missing a file it advertised is corrupt); any other error aborts. A failed landing tears the freshly-created project back down, so no row keeps a publisher's dangling path.
- **FIX 3:** `publish` pre-flights the source corpus meta for `embedding_model` and refuses (pointing at `bartleby project upgrade <name>`) instead of silently uploading a dead artifact every importer rejects.
- **FIX 4:** `_read_meta` catches `apsw.Error` (covers `NotADBError`) so a garbage/non-SQLite download refuses cleanly; the publish/import command handlers catch botocore `ClientError`/`NoCredentialsError`/`EndpointConnectionError` → clean non-zero exit instead of a traceback.

Deferred, left untouched (maintainer calls): import overwrite-on-reimport (encoded by the idempotency test), and the anchor-split N+1 file dedup in `gather_files`.

Decision doc: `docs/decisions/GH-0511-critic-pass1-fixes.md`. Additive only, SCHEMA_VERSION stays 9, no `--force`. Full suite green (1083 passing), +6 tests, boto3 stays stubbed (no moto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)