### PR TITLE
Part of #539: scribe backfill-dates + honest stub summaries

### DIFF
--- a/bartleby/cli.py
+++ b/bartleby/cli.py
@@ -107,8 +107,36 @@ def main():
         "scribe",
         help="Ingest PDF, HTML, MD, TXT, and image files into a project",
     )
+    # Bare `scribe` ingests; `scribe backfill-dates ...` is a sibling admin op
+    # (#536). The ingest flags stay on the top parser (so `bartleby scribe
+    # --files ...` is unchanged); the subcommand is optional, and `--files` is
+    # validated in dispatch for the bare form rather than via argparse
+    # `required=True` (which would also fire under a subcommand).
+    scribe_sub = scribe_parser.add_subparsers(dest="scribe_command")
+    bfd = scribe_sub.add_parser(
+        "backfill-dates",
+        help="Bulk-set authored_date from a filename regex (human-run admin op)",
+    )
+    bfd.add_argument("project", type=str, nargs="?", default=None)
+    bfd.add_argument(
+        "--from-filename", required=True, dest="from_filename", metavar="REGEX",
+        help=r"Regex with a named group 'date' matched against each file_name, "
+             r"e.g. '(?P<date>\d{4}-\d{2}-\d{2})'.",
+    )
+    bfd.add_argument(
+        "--match-path", action="store_true",
+        help="Match the regex against the full file_path, not just the basename.",
+    )
+    bfd.add_argument(
+        "--overwrite", action="store_true",
+        help="Replace an existing authored_date (default fills only NULLs).",
+    )
+    bfd.add_argument(
+        "--dry-run", action="store_true",
+        help="Report counts + sample matches; write nothing.",
+    )
     scribe_parser.add_argument(
-        "--files", required=True, type=str, nargs="+", metavar="PATH",
+        "--files", type=str, nargs="+", metavar="PATH",
         help="One or more files and/or directories to ingest. Directories are "
              "walked recursively; a file reachable from more than one path is "
              "ingested once.",
@@ -334,10 +362,31 @@ def _ready(args):
 
 
 def _scribe(args):
-    from bartleby.commands.scribe import main as scribe_main
     from bartleby.lib import console
 
+    if getattr(args, "scribe_command", None) == "backfill-dates":
+        from bartleby.commands.backfill import main as backfill_main
+
+        console.splash()
+        try:
+            backfill_main(
+                project=args.project,
+                from_filename=args.from_filename,
+                match_path=args.match_path,
+                overwrite=args.overwrite,
+                dry_run=args.dry_run,
+            )
+        except (ValueError, RuntimeError) as e:
+            console.error(str(e))
+            sys.exit(1)
+        return
+
+    from bartleby.commands.scribe import main as scribe_main
+
     console.splash()
+    if not args.files:
+        console.error("scribe requires --files (or use a subcommand, e.g. backfill-dates).")
+        sys.exit(1)
     # Scribe's expected failure modes — no active project (RuntimeError), an
     # invalid configured converter or a typo'd --only (ValueError), a missing
     # path (FileNotFoundError) — are user errors, not bugs. Surface them as a

--- a/bartleby/commands/backfill.py
+++ b/bartleby/commands/backfill.py
@@ -1,0 +1,128 @@
+"""`bartleby scribe backfill-dates` — bulk-populate ``authored_date`` from a
+filename regex.
+
+A **human-run admin op**, deliberately not a skill script: it's a bulk write
+over a whole corpus (the press-release corpus has 174k docs with zero
+summarizer-set dates but a date in every filename), kept off the agent surface
+alongside ``scribe`` ingest and ``project upgrade``.
+
+Per document, the regex's named ``date`` group is matched against ``file_name``
+(basename) or, under ``--match-path``, the full ``file_path``. The captured raw
+value is normalized via :func:`normalize_authored_date`; a match that fails
+normalization is **counted and reported, never silently written as NULL**.
+
+For a document that already has a summary row, this UPDATEs ``authored_date``
+(only where it IS NULL, unless ``--overwrite``). For a document with no summary,
+it INSERTs a date-only **stub**: ``model='backfill'``, empty title/description/
+text, and **no summary chunks** (empty text is not chunked/embedded). Section
+rows (#254) share their parent's ``file_name`` and so match the same regex and
+inherit the parent's date — desired, so chunk/section-level date filtering
+works; a stub is created for them too.
+
+``--dry-run`` mutates nothing and prints the same counts plus a few sample
+``file_name → date`` pairs. Idempotent / re-runnable.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from bartleby.db.connection import open_db, resolve_project_name
+from bartleby.ingest.summarize import (
+    FilenameDateError,
+    compile_filename_date_regex,
+    extract_filename_date,
+    normalize_authored_date,
+)
+from bartleby.lib import console
+from bartleby.lib.consts import BACKFILL_MODEL
+
+_SAMPLE_LIMIT = 10
+
+
+def main(
+    *,
+    project: str | None,
+    from_filename: str,
+    match_path: bool = False,
+    overwrite: bool = False,
+    dry_run: bool = False,
+) -> None:
+    try:
+        compiled = compile_filename_date_regex(from_filename)
+    except FilenameDateError as e:
+        console.error(str(e))
+        sys.exit(1)
+
+    project_name = resolve_project_name(project)
+    conn = open_db(project_name)
+    try:
+        cur = conn.cursor()
+        # file_name + file_path + whether a (non-stub-or-not) summary row exists,
+        # and its current authored_date, for every document. One pass.
+        rows = cur.execute(
+            "SELECT d.document_id, d.file_name, d.file_path, "
+            "       s.summary_id, s.authored_date "
+            "FROM documents d LEFT JOIN summaries s USING (document_id)"
+        ).fetchall()
+
+        matched = unmatched = invalid = 0
+        to_update: list[tuple[int, str]] = []          # (summary_id, date)
+        to_insert: list[tuple[int, str]] = []          # (document_id, date)
+        samples: list[tuple[str, str]] = []            # (file_name, date)
+
+        for document_id, file_name, file_path, summary_id, current_date in rows:
+            subject = file_path if match_path else file_name
+            raw = extract_filename_date(compiled, subject or "")
+            if raw is None:
+                unmatched += 1
+                continue
+            matched += 1
+            value = normalize_authored_date(raw)
+            if value is None:
+                invalid += 1
+                continue
+            if len(samples) < _SAMPLE_LIMIT:
+                samples.append((file_name, value))
+            if summary_id is None:
+                to_insert.append((document_id, value))
+            elif current_date is None or overwrite:
+                to_update.append((summary_id, value))
+            # else: a dated summary row, no --overwrite → leave it (idempotent).
+
+        if not dry_run:
+            with conn:
+                if to_update:
+                    cur.executemany(
+                        "UPDATE summaries SET authored_date = ? WHERE summary_id = ?",
+                        [(value, sid) for sid, value in to_update],
+                    )
+                if to_insert:
+                    # Stub: empty title/description/text, model='backfill', the
+                    # date. NO summary chunks — empty text is not chunked, so the
+                    # typed chunk helpers are correctly never called here.
+                    cur.executemany(
+                        "INSERT INTO summaries "
+                        "(document_id, title, description, text, model, authored_date) "
+                        "VALUES (?, '', '', '', ?, ?)",
+                        [(document_id, BACKFILL_MODEL, value)
+                         for document_id, value in to_insert],
+                    )
+    finally:
+        conn.close()
+
+    verb = "would " if dry_run else ""
+    console.big(
+        f"backfill-dates {'(dry run) ' if dry_run else ''}on '{project_name}'"
+    )
+    console.info(f"  matched:           {matched}")
+    console.info(f"  unmatched:         {unmatched}")
+    console.info(f"  invalid date:      {invalid}")
+    console.info(f"  {verb}insert stub:  {len(to_insert)}")
+    console.info(f"  {verb}update date:  {len(to_update)}")
+    if samples:
+        console.info("  samples:")
+        for name, value in samples:
+            console.info(f"    {name} → {value}")
+    if not dry_run:
+        console.complete("Done.")

--- a/bartleby/ingest/summarize.py
+++ b/bartleby/ingest/summarize.py
@@ -38,6 +38,45 @@ def normalize_authored_date(raw: str | None) -> str | None:
     return raw
 
 
+class FilenameDateError(ValueError):
+    """A `--from-filename` regex that can't extract dates (no `date` group / bad
+    pattern). A *usage* error — distinct from a per-document non-match, which is
+    just a count. Raised once, up front, before any document is examined."""
+
+
+def compile_filename_date_regex(pattern: str) -> "re.Pattern[str]":
+    """Compile a `--from-filename` regex, requiring a named ``date`` group.
+
+    Colocated with :func:`normalize_authored_date` so a later metadata sub-issue
+    (#48 seeds) can reuse this named-capture mechanism for non-date facets.
+    Raises :class:`FilenameDateError` on a malformed pattern or a pattern with no
+    ``date`` group — both are operator mistakes worth refusing before a 174k-doc
+    scan rather than silently matching nothing.
+    """
+    try:
+        compiled = re.compile(pattern)
+    except re.error as e:
+        raise FilenameDateError(f"Invalid regex {pattern!r}: {e}") from e
+    if "date" not in compiled.groupindex:
+        raise FilenameDateError(
+            f"Regex {pattern!r} has no named group 'date'; "
+            r"use e.g. '(?P<date>\d{4}-\d{2}-\d{2})'."
+        )
+    return compiled
+
+
+def extract_filename_date(compiled: "re.Pattern[str]", name: str) -> str | None:
+    """Return the raw substring captured by the ``date`` group, or None if the
+    regex doesn't match ``name``. The raw value is *not* normalized here — the
+    caller runs it through :func:`normalize_authored_date` so a match that
+    captures a non-date is counted as invalid, never silently stored as NULL.
+    """
+    m = compiled.search(name)
+    if m is None:
+        return None
+    return m.group("date")
+
+
 @dataclass
 class SummaryResult:
     title: str

--- a/bartleby/lib/consts.py
+++ b/bartleby/lib/consts.py
@@ -9,6 +9,15 @@ CHUNK_OVERLAP = 100
 
 EMBEDDING_MODEL = "BAAI/bge-base-en-v1.5"
 
+# Sentinel `summaries.model` value for date-only stub rows written by
+# `bartleby scribe backfill-dates` (#536). A stub carries a real `authored_date`
+# but empty title/description/text and NO summary chunks — it exists solely to
+# hang a backfilled date off a document the summarizer never ran on. The read
+# side keys off this value so a stub never inflates summary coverage or reads as
+# a real summary (`describe_corpus`, `list_documents.has_summary`,
+# `read_document --summary`).
+BACKFILL_MODEL = "backfill"
+
 # Hugging Face repos Docling lazily fetches for its default PDF/HTML pipeline:
 # the layout model (analysed on every page) and the TableFormer model (pages
 # with tables). Both download on demand, the layout model not until the first

--- a/bartleby/skill_scripts/describe_corpus.py
+++ b/bartleby/skill_scripts/describe_corpus.py
@@ -63,6 +63,7 @@ from __future__ import annotations
 import argparse
 import math
 
+from bartleby.lib.consts import BACKFILL_MODEL
 from bartleby.skill_runner import build_arg_parser, run
 from bartleby.skill_scripts._common import (
     add_date_filter_args, comma_int_list, positive_int,
@@ -234,9 +235,14 @@ def work(*, conn, args, session_id) -> dict:
             )
         ]
 
+    # summary_coverage counts *real* summaries only: a backfill stub (#536)
+    # carries a date but empty title/description/text, so it must not inflate
+    # coverage. (date_coverage above intentionally counts it — its date is real.)
     w, wp = doc_where("document_id")
     summarized = cur.execute(
-        f"SELECT COUNT(*) FROM summaries{w}", wp
+        f"SELECT COUNT(*) FROM summaries{w}"
+        f"{' AND' if w else ' WHERE'} model != ?",
+        [*wp, BACKFILL_MODEL],
     ).fetchone()[0]
 
     # Anchor-split containers (#254) own zero chunks and so owe no summary — they

--- a/bartleby/skill_scripts/list_documents.py
+++ b/bartleby/skill_scripts/list_documents.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import argparse
 
+from bartleby.lib.consts import BACKFILL_MODEL
 from bartleby.skill_runner import build_arg_parser, run
 from bartleby.skill_scripts._common import (
     add_date_filter_args, add_file_like_arg, add_returning_arg, comma_int_list,
@@ -206,9 +207,15 @@ def work(*, conn, args, session_id) -> dict:
 
     rows = cur.execute(
         "SELECT d.document_id, d.file_name, d.page_count, d.token_count, d.created_at, "
-        "       s.title AS summary_title, s.description AS summary_description, "
+        # A backfill stub (#536) carries a date but no real summary: its title/
+        # description are empty and has_summary must read false. Suppress its
+        # title/description to NULL here so coverage and the listed fields stay
+        # honest; authored_date still rides along from the same row. The three
+        # '?' bind BACKFILL_MODEL (leading, before any WHERE params).
+        "       (CASE WHEN s.model = ? THEN NULL ELSE s.title END) AS summary_title, "
+        "       (CASE WHEN s.model = ? THEN NULL ELSE s.description END) AS summary_description, "
         "       s.authored_date AS summary_authored_date, "
-        "       (s.summary_id IS NOT NULL) AS has_summary, "
+        "       (s.summary_id IS NOT NULL AND s.model != ?) AS has_summary, "
         "       COALESCE(cc.n, 0) AS chunk_count, "
         "       COALESCE(ic.n, 0) AS image_count "
         "FROM documents d "
@@ -221,7 +228,8 @@ def work(*, conn, args, session_id) -> dict:
         "  ON ic.document_id = d.document_id "
         f"{where_clause}"
         f"ORDER BY {_ORDER_BY[args.sort]} LIMIT ? OFFSET ?",
-        [*where_params, args.limit, args.offset],
+        [BACKFILL_MODEL, BACKFILL_MODEL, BACKFILL_MODEL,
+         *where_params, args.limit, args.offset],
     )
 
     documents = []

--- a/bartleby/skill_scripts/read_document.py
+++ b/bartleby/skill_scripts/read_document.py
@@ -7,10 +7,18 @@ override.
 
 Successful output:
     {
-      "document": {"id": int, "file_name": str, "token_count": int},
+      "document": {
+        "id": int, "file_name": str, "token_count": int,
+        "authored_date": str|null
+      },
       "summary": str|null,
       "full_text": str|null
     }
+
+``authored_date`` is the document's date (lives on its summary row); it is
+populated regardless of whether the summary text is real, because a
+``backfill``-stub row carries a real date but no summary text. ``summary`` is
+``null`` for such a stub (and for a document with no summary row at all).
 
 DOCUMENT_TOO_LARGE error envelope (when --full would exceed max_read_tokens):
     {
@@ -26,6 +34,7 @@ from __future__ import annotations
 import argparse
 
 from bartleby.config import load_config
+from bartleby.lib.consts import BACKFILL_MODEL
 from bartleby.skill_runner import SkillError, build_arg_parser, run
 from bartleby.skill_scripts._common import positive_int
 
@@ -83,13 +92,19 @@ def work(*, conn, args, session_id) -> dict:
                 max_read_tokens=max_read_tokens,
             )
 
+    # Fetch the summary row regardless of mode: the date rides on it and is
+    # exposed even when the text is suppressed or --full was requested. A
+    # backfill stub carries a real date but no summary text, so its `text` ('')
+    # is reported as null — the date is honest, the "summary" is not.
+    row = cur.execute(
+        "SELECT text, model, authored_date FROM summaries WHERE document_id = ?",
+        (doc_id,),
+    ).fetchone()
+    authored_date = row[2] if row else None
+
     summary_text: str | None = None
-    if want_summary:
-        row = cur.execute(
-            "SELECT text FROM summaries WHERE document_id = ?",
-            (doc_id,),
-        ).fetchone()
-        summary_text = row[0] if row else None
+    if want_summary and row is not None and row[1] != BACKFILL_MODEL:
+        summary_text = row[0]
 
     full_text: str | None = None
     if want_full:
@@ -100,6 +115,7 @@ def work(*, conn, args, session_id) -> dict:
             "id": doc_id,
             "file_name": file_name,
             "token_count": token_count,
+            "authored_date": authored_date,
         },
         "summary": summary_text,
         "full_text": full_text,

--- a/docs/decisions/GH-0536-backfill-dates.md
+++ b/docs/decisions/GH-0536-backfill-dates.md
@@ -1,0 +1,80 @@
+# `scribe backfill-dates` bulk-sets authored_date from a filename, with honest stub summaries (issue #536)
+
+> Source: [#536](https://github.com/jswest/bartleby/issues/536)
+
+`authored_date` lives on the `summaries` table and was populated **only** by the
+LLM summarizer at ingest. A templated corpus ingested without summarization (the
+press-release corpus: `summary_coverage` 0/174,787) therefore had *zero* dates,
+so `scan --sort date` and `--authored-after/before` were dead on arrival even
+though every filename encodes a date. `save_date` sets one document at a time and
+needs a pre-existing summary row — useless at this scale.
+
+**A human-run CLI admin op, deliberately off the agent surface.**
+`bartleby scribe backfill-dates <project> --from-filename '(?P<date>…)'
+[--match-path] [--overwrite] [--dry-run]` is a sibling of `scribe` ingest and
+`project upgrade`, not a skill script — it's a bulk write over a whole corpus,
+the kind of thing an operator runs once, not something an agent reaches for
+mid-research. It lives in `bartleby/commands/backfill.py` and is wired as an
+*optional* subcommand under `scribe` (bare `bartleby scribe --files …` is
+unchanged; `--files` is validated in dispatch, not via argparse `required=True`,
+so a subcommand invocation doesn't trip it).
+
+**Schema-stable: no `SCHEMA_VERSION` bump, no re-ingest.** The `authored_date`
+and `model` columns already exist; the command only INSERTs/UPDATEs `summaries`
+rows and the read side only adjusts queries. No DDL, so the release drift gate is
+not implicated.
+
+**The stub contract.** A document with an existing summary gets an
+`UPDATE summaries SET authored_date` (only where it `IS NULL`, unless
+`--overwrite`). A document with *no* summary gets a date-only **stub**:
+`model='backfill'`, empty `title`/`description`/`text`, the date — and **no
+summary chunks**. Empty text is not chunked or embedded, so the typed-chunk
+helpers are correctly never called here (the chunks discipline holds: the stub
+simply has nothing to chunk). The sentinel is defined once as
+`BACKFILL_MODEL = "backfill"` in `bartleby/lib/consts.py`, imported wherever the
+read side discriminates so a rename can't drift copy-to-copy.
+
+**The read side must not let a stub lie.** A raw `COUNT(*) FROM summaries` would
+let stubs inflate coverage, and a `''` title/text would read as a (blank)
+summary. So:
+
+- `describe_corpus.summary_coverage.summarized` counts `WHERE model != 'backfill'`
+  — a stub correctly reads as *unsummarized*. (`date_coverage` /
+  `documents_by_year` are left alone: a stub's date is real, so it *should* count
+  as dated.)
+- `list_documents.has_summary` is `(summary_id IS NOT NULL AND model != 'backfill')`
+  — false for a stub — and the stub's `title`/`description` are suppressed to
+  NULL, while `authored_date` still rides along from the row.
+- `read_document --summary` returns `null` (not `''`) for a stub, and the
+  envelope gains a new `authored_date` field populated regardless of stub status
+  (the date is real even when the summary text is suppressed).
+
+**Sections (#254) get the parent's date, via a stub.** Section rows share their
+parent's `file_name` (`bartleby/ingest/writer.py`), so the same regex matches
+them and they inherit the parent's date — which is what we want, so chunk- and
+section-level date filtering works. We create stubs for section rows too rather
+than special-casing them out.
+
+**Safety, by construction.** The regex *must* carry a named `date` group
+(refused up front via `FilenameDateError` before any document is scanned — an
+operator mistake, not a per-doc miss). A per-document match is normalized through
+the existing `normalize_authored_date`; a match that captures a non-date
+(`2024-13-40`) is **counted and reported as invalid, never silently written as
+NULL**. `--dry-run` mutates nothing and prints the same counts (matched /
+unmatched / would-insert-stub / would-update / invalid) plus a few sample
+`file_name → date` pairs — essential before a 174k-doc run. The whole thing is
+idempotent: a second run re-fills nothing (NULL-only by default) and
+re-INSERTs nothing (the stub already exists). The filename-extraction helpers
+(`compile_filename_date_regex` / `extract_filename_date`) are colocated beside
+`normalize_authored_date` in `bartleby/ingest/summarize.py` so a later
+metadata-facet sub-issue (#48 seeds) can reuse the named-capture mechanism.
+
+**Out of scope** (explicitly not built here): high-cardinality metadata facets,
+`--where`, frontmatter parsing, the metadata sidecar.
+
+Touches: new `bartleby/commands/backfill.py`; `bartleby/ingest/summarize.py`
+(extraction helpers + `FilenameDateError`); `bartleby/lib/consts.py`
+(`BACKFILL_MODEL`); `bartleby/cli.py` (the `scribe backfill-dates` subparser +
+dispatch); the three read-side scripts `read_document.py` / `list_documents.py` /
+`describe_corpus.py`; a reusable `dated_corpus` fixture in
+`tests/_skill_fixtures.py`; and `tests/test_backfill_dates.py`.

--- a/tests/_skill_fixtures.py
+++ b/tests/_skill_fixtures.py
@@ -194,6 +194,87 @@ def seeded_project(project_env):
     }
 
 
+@pytest.fixture
+def dated_corpus(project_env):
+    """A corpus whose filenames encode dates, for `scribe backfill-dates` (#536).
+
+    Wave-1 shared fixture: later authored-date sub-issues reuse it. Every
+    document's `file_name` is `<key>__YYYY-MM-DD__slug.md` so a single named-
+    capture regex (`(?P<date>\\d{4}-\\d{2}-\\d{2})`) matches all of them. The
+    documents exercise every backfill branch:
+
+    - ``summary_doc``   — has a *real* summary (model='test') with a NULL date;
+                          backfill should UPDATE the date on it.
+    - ``stub_doc``      — has NO summary row; backfill should INSERT a stub.
+    - ``dated_doc``     — has a real summary that ALREADY carries a date; backfill
+                          leaves it (idempotent) unless --overwrite.
+    - ``nomatch_doc``   — `file_name` has no date; backfill should not touch it.
+    - ``bad_date_doc``  — `file_name` matches the regex but the captured value is
+                          an impossible calendar date (2024-13-40); counted as
+                          invalid, never written.
+    - ``parent_doc`` / ``section_doc`` — a #254 anchor-split pair sharing one
+                          `file_name`; both should get the parent's date (the
+                          section via a stub).
+
+    Returns the project name and every document id under those keys.
+    """
+    conn = open_db(project_env)
+    try:
+        cur = conn.cursor()
+
+        def _doc(file_hash, file_name, *, parent=None):
+            cur.execute(
+                "INSERT INTO documents "
+                "(file_hash, file_name, file_path, page_count, token_count, "
+                " parent_document_id) VALUES (?, ?, ?, ?, ?, ?)",
+                (file_hash, file_name, f"/corpus/{file_name}", 1, 100, parent),
+            )
+            doc_id = conn.last_insert_rowid()
+            insert_document_chunks(conn, doc_id, [
+                ChunkInput(text=f"body of {file_name}", embedding=_emb(),
+                           chunk_index=0),
+            ])
+            return doc_id
+
+        def _summary(doc_id, *, authored_date, model="test"):
+            cur.execute(
+                "INSERT INTO summaries "
+                "(document_id, title, description, text, model, authored_date) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (doc_id, "T", "D", "real summary text", model, authored_date),
+            )
+            return conn.last_insert_rowid()
+
+        summary_doc = _doc("d1", "A001__2021-03-15__alpha.md")
+        _summary(summary_doc, authored_date=None)
+
+        stub_doc = _doc("d2", "B002__2022-07-04__beta.md")
+
+        dated_doc = _doc("d3", "C003__2023-01-09__gamma.md")
+        _summary(dated_doc, authored_date="2099-12-31")
+
+        nomatch_doc = _doc("d4", "D004__no-date-here__delta.md")
+
+        bad_date_doc = _doc("d5", "E005__2024-13-40__epsilon.md")
+
+        # #254 anchor-split pair: a section row shares the parent's file_name.
+        parent_doc = _doc("d6", "F006__2020-05-20__zeta.md")
+        section_doc = _doc("d6-sec", "F006__2020-05-20__zeta.md", parent=parent_doc)
+    finally:
+        conn.close()
+
+    return {
+        "project": project_env,
+        "summary_doc": summary_doc,
+        "stub_doc": stub_doc,
+        "dated_doc": dated_doc,
+        "nomatch_doc": nomatch_doc,
+        "bad_date_doc": bad_date_doc,
+        "parent_doc": parent_doc,
+        "section_doc": section_doc,
+    }
+
+
 def seed_image(conn, document_id: int, *, file_hash: str, file_path: str,
                description: str = "A test image scene.",
                ocr_text: str = "WELCOME",

--- a/tests/test_backfill_dates.py
+++ b/tests/test_backfill_dates.py
@@ -1,0 +1,207 @@
+"""Tests for `bartleby scribe backfill-dates` (#536).
+
+Covers the backfill command (filename → authored_date, stub creation, dry-run,
+overwrite, invalid-date counting, idempotency, #254 sections) and the
+honest-stub read side (describe_corpus / list_documents / read_document).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bartleby.commands import backfill
+from bartleby.db.connection import open_db
+from bartleby.ingest.summarize import (
+    FilenameDateError,
+    compile_filename_date_regex,
+    extract_filename_date,
+)
+from bartleby.skill_scripts import describe_corpus, list_documents, read_document
+from tests._skill_fixtures import (  # noqa: F401
+    dated_corpus,
+    project_env,
+    seeded_project,
+)
+
+ISO_RE = r"(?P<date>\d{4}-\d{2}-\d{2})"
+
+
+def _date(project, document_id):
+    conn = open_db(project)
+    try:
+        row = conn.cursor().execute(
+            "SELECT authored_date, model FROM summaries WHERE document_id = ?",
+            (document_id,),
+        ).fetchone()
+        return row if row else None
+    finally:
+        conn.close()
+
+
+def _summary_count(project, document_id):
+    conn = open_db(project)
+    try:
+        return conn.cursor().execute(
+            "SELECT COUNT(*) FROM summaries WHERE document_id = ?",
+            (document_id,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _capture_console(monkeypatch):
+    """Collect ``console.info`` lines (the report rows). The shared Rich Console
+    binds its stream at import time, so capsys/capfd miss it — the repo's idiom
+    is to monkeypatch the console functions directly."""
+    lines: list[str] = []
+    monkeypatch.setattr(backfill.console, "info", lambda m: lines.append(m))
+    monkeypatch.setattr(backfill.console, "big", lambda m: lines.append(m))
+    monkeypatch.setattr(backfill.console, "complete", lambda m: lines.append(m))
+    return lines
+
+
+# ---- helper: compile/extract ------------------------------------------------
+
+def test_compile_requires_named_date_group():
+    with pytest.raises(FilenameDateError):
+        compile_filename_date_regex(r"\d{4}-\d{2}-\d{2}")
+
+
+def test_compile_rejects_bad_regex():
+    with pytest.raises(FilenameDateError):
+        compile_filename_date_regex(r"(?P<date>")
+
+
+def test_extract_returns_raw_substring_or_none():
+    c = compile_filename_date_regex(ISO_RE)
+    assert extract_filename_date(c, "X__2021-03-15__y.md") == "2021-03-15"
+    assert extract_filename_date(c, "no-date.md") is None
+
+
+# ---- command: writes & counts ----------------------------------------------
+
+def test_backfill_updates_existing_summary_and_inserts_stub(dated_corpus):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+
+    # real summary got its NULL date filled
+    assert _date(dated_corpus["project"], dated_corpus["summary_doc"]) == (
+        "2021-03-15", "test")
+    # no-summary doc got a backfill stub
+    assert _date(dated_corpus["project"], dated_corpus["stub_doc"]) == (
+        "2022-07-04", "backfill")
+
+
+def test_backfill_leaves_dated_summary_unless_overwrite(dated_corpus):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    assert _date(dated_corpus["project"], dated_corpus["dated_doc"])[0] == "2099-12-31"
+
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE,
+                  overwrite=True)
+    assert _date(dated_corpus["project"], dated_corpus["dated_doc"])[0] == "2023-01-09"
+
+
+def test_backfill_skips_unmatched(dated_corpus):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    # nomatch doc has no summary and stays summary-less
+    assert _summary_count(dated_corpus["project"], dated_corpus["nomatch_doc"]) == 0
+
+
+def test_backfill_counts_invalid_date_never_writes(dated_corpus, monkeypatch):
+    lines = _capture_console(monkeypatch)
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    # bad_date_doc matched the regex but 2024-13-40 is not a real date → no row
+    assert _summary_count(dated_corpus["project"], dated_corpus["bad_date_doc"]) == 0
+    assert any("invalid date:      1" in ln for ln in lines)
+
+
+def test_backfill_dates_sections_too(dated_corpus):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    assert _date(dated_corpus["project"], dated_corpus["parent_doc"]) == (
+        "2020-05-20", "backfill")
+    # the #254 section shares the parent file_name, gets the same date via a stub
+    assert _date(dated_corpus["project"], dated_corpus["section_doc"]) == (
+        "2020-05-20", "backfill")
+
+
+def test_backfill_dry_run_mutates_nothing(dated_corpus, monkeypatch):
+    lines = _capture_console(monkeypatch)
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE,
+                  dry_run=True)
+    assert _date(dated_corpus["project"], dated_corpus["summary_doc"]) == (None, "test")
+    assert _summary_count(dated_corpus["project"], dated_corpus["stub_doc"]) == 0
+    # stub_doc + parent_doc + section_doc (dated_doc already has a date → skipped)
+    assert any("would insert stub:  3" in ln for ln in lines)
+    assert any("would update date:  1" in ln for ln in lines)  # summary_doc
+
+
+def test_backfill_is_idempotent(dated_corpus):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    before = _summary_count(dated_corpus["project"], dated_corpus["stub_doc"])
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    after = _summary_count(dated_corpus["project"], dated_corpus["stub_doc"])
+    assert before == after == 1
+    assert _date(dated_corpus["project"], dated_corpus["stub_doc"]) == (
+        "2022-07-04", "backfill")
+
+
+def test_backfill_bad_regex_exits_nonzero(dated_corpus, capsys):
+    with pytest.raises(SystemExit) as exc:
+        backfill.main(project=dated_corpus["project"],
+                      from_filename=r"\d{4}")  # no named group
+    assert exc.value.code != 0
+
+
+# ---- honest-stub read side --------------------------------------------------
+
+def test_stub_does_not_inflate_summary_coverage(dated_corpus, capsys):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    capsys.readouterr()
+    describe_corpus.main(["--project", dated_corpus["project"]])
+    out = json.loads(capsys.readouterr().out)
+    # Only the two real summaries (summary_doc, dated_doc) count as summarized,
+    # not the backfill stubs.
+    assert out["summary_coverage"]["summarized"] == 2
+    # but the date block counts every dated doc, stubs included
+    assert out["authored_date"]["dated_document_count"] >= 4
+
+
+def test_list_documents_has_summary_false_for_stub(dated_corpus, capsys):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    capsys.readouterr()
+    list_documents.main(["--project", dated_corpus["project"], "--limit", "100"])
+    out = json.loads(capsys.readouterr().out)
+    by_id = {d["id"]: d for d in out["documents"]}
+    stub = by_id[dated_corpus["stub_doc"]]
+    assert stub["has_summary"] is False
+    assert stub["authored_date"] == "2022-07-04"
+    assert stub["title"] is None
+    # a real summary still reads has_summary=true
+    assert by_id[dated_corpus["summary_doc"]]["has_summary"] is True
+
+
+def test_read_document_suppresses_stub_summary_but_keeps_date(dated_corpus, capsys):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    capsys.readouterr()
+    read_document.main([
+        "--project", dated_corpus["project"],
+        "--document", str(dated_corpus["stub_doc"]),
+        "--summary",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["summary"] is None
+    assert out["document"]["authored_date"] == "2022-07-04"
+
+
+def test_read_document_exposes_authored_date_for_real_summary(dated_corpus, capsys):
+    backfill.main(project=dated_corpus["project"], from_filename=ISO_RE)
+    capsys.readouterr()
+    read_document.main([
+        "--project", dated_corpus["project"],
+        "--document", str(dated_corpus["summary_doc"]),
+        "--summary",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["summary"] == "real summary text"
+    assert out["document"]["authored_date"] == "2021-03-15"


### PR DESCRIPTION
Part of #539. Implements #536.

## What

Adds `bartleby scribe backfill-dates <project> --from-filename '(?P<date>…)' [--match-path] [--overwrite] [--dry-run]` — a human-run admin op (sibling of `scribe` ingest / `project upgrade`, deliberately off the agent surface) that bulk-populates `authored_date` from a named-capture filename regex, plus the honest-stub read-side changes.

- **UPDATE** existing summaries (NULL-only unless `--overwrite`).
- **INSERT** a date-only **stub** where no summary exists: `model='backfill'`, empty `title`/`description`/`text`, **no summary chunks** (empty text isn't chunked, so the typed chunk helpers are correctly never called). #254 section rows share the parent `file_name`, match the same regex, and get the parent's date via a stub too.
- The sentinel `BACKFILL_MODEL = "backfill"` is defined once in `bartleby/lib/consts.py`; the filename-extraction helpers (`compile_filename_date_regex` / `extract_filename_date` / `FilenameDateError`) are colocated beside `normalize_authored_date` in `summarize.py` for a later metadata sub-issue to reuse.

## Why honest stubs

A raw `COUNT(*) FROM summaries` would let stubs inflate coverage and a `''` title/text would read as a blank summary. So the read side discriminates on the sentinel:
- `describe_corpus.summary_coverage.summarized` → `model != 'backfill'` (date_coverage left alone — a stub's date is real).
- `list_documents.has_summary` → false for stubs; their title/description suppressed to NULL.
- `read_document --summary` → `null` for stubs; envelope gains a new `authored_date` field populated regardless of stub status.

## Acceptance criteria met

- `scan --sort date` / `--authored-after/before` work after backfill (they read `summaries.authored_date`, which is now populated); `describe_corpus.authored_date.dated_document_count` reflects the backfilled total (stubs included).
- `summary_coverage` does **not** rise from stubs; `list_documents` shows `has_summary=false`; `read_document --summary` returns `null` for them but `read_document` exposes their `authored_date`.
- `--dry-run` mutates nothing; invalid dates (regex matches but not a real calendar date) are counted and reported, never written. Idempotent / re-runnable.

## Notes

- **Schema-stable: no `SCHEMA_VERSION` bump, no re-ingest** (`authored_date` and `model` columns already exist).
- Establishes a reusable `dated_corpus` test fixture in `tests/_skill_fixtures.py` for later authored-date sub-issues.
- Full suite green: 1106 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)