### PR TITLE
Part of #539: search date filters (scan parity)

### DIFF
--- a/bartleby/skill_scripts/search.py
+++ b/bartleby/skill_scripts/search.py
@@ -14,17 +14,20 @@ semantic (vector) leg, which embeds the chunk text and is unaffected.
 ``--tag <name>`` (repeatable, OR semantics) restricts to chunks whose
 underlying document carries any of the given tags. ``--file-like <pattern>``
 (SQL ``LIKE``, repeatable for OR) restricts to chunks whose document's
-``file_name`` matches a pattern. Both combine naturally with ``--in-documents``
-(intersection: the document must be in every active set) and drop findings the
-same way (findings have no document anchor).
+``file_name`` matches a pattern. ``--authored-after`` / ``--authored-before``
+add inclusive ``YYYY-MM-DD`` date bounds over the document's summarizer-inferred
+``authored_date`` — with ``scan``'s exact semantics: because the date is often
+NULL, a bound excludes undated documents by default (``--include-nulls`` keeps
+them) and ``excluded_null_dated`` reports the count dropped. All of these combine
+naturally with ``--in-documents`` (intersection: the document must be in every
+active set) and drop findings the same way (findings have no document anchor).
 
-Whenever a scope filter (``--in-documents`` / ``--tag`` / ``--file-like``) is
-active the response carries a nested ``filters`` object echoing it — ``{tags,
-in_documents, file_like, authored_after, authored_before, include_nulls,
-excluded_null_dated}`` — the same contract ``scan`` / ``list_documents`` /
-``describe_corpus`` emit (search takes no date bounds, so those keys are
-null/0). It is absent on an unfiltered search; the query terms themselves always
-stay top-level under ``query``.
+Whenever a scope filter (``--in-documents`` / ``--tag`` / ``--file-like`` / a
+date bound) is active the response carries a nested ``filters`` object echoing
+it — ``{tags, in_documents, file_like, authored_after, authored_before,
+include_nulls, excluded_null_dated}`` — the same contract ``scan`` /
+``list_documents`` / ``describe_corpus`` emit. It is absent on an unfiltered
+search; the query terms themselves always stay top-level under ``query``.
 
 Output:
     {
@@ -89,9 +92,9 @@ import subprocess
 from bartleby.db.schema import EMBEDDING_DIM
 from bartleby.skill_runner import SkillError, build_arg_parser, run
 from bartleby.skill_scripts._common import (
-    add_file_like_arg, add_returning_arg, apply_preview, chunk_locations,
-    comma_int_list, memory_enabled, positive_int, project_row, source_names,
-    text_qualified_fts, validate_returning,
+    add_date_filter_args, add_file_like_arg, add_returning_arg, apply_preview,
+    chunk_locations, comma_int_list, memory_enabled, positive_int, project_row,
+    source_names, text_qualified_fts, validate_returning,
 )
 from bartleby.skill_scripts._tags import resolve_scope
 
@@ -158,6 +161,7 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         ),
     )
     add_file_like_arg(p)
+    add_date_filter_args(p)
     p.add_argument(
         "--add-context",
         type=_context_value,
@@ -414,6 +418,9 @@ def work(*, conn, args, session_id) -> dict:
     scope = resolve_scope(
         conn, in_documents=args.in_documents, tags=args.tags,
         file_like=args.file_like,
+        authored_after=args.authored_after,
+        authored_before=args.authored_before,
+        include_nulls=args.include_nulls,
     )
     # None = whole corpus, [] = a filter matched nothing, else the resolved slice.
     restrict = scope.document_ids

--- a/docs/decisions/GH-0537-search-date-filters.md
+++ b/docs/decisions/GH-0537-search-date-filters.md
@@ -1,0 +1,58 @@
+# `search` gains date filters with scan parity, by reusing the shared scope resolver (issue #537)
+
+> Source: [#537](https://github.com/jswest/bartleby/issues/537)
+
+`scan` could filter and sort by `authored_date`; `search` only *surfaced* the
+date in its output and could not filter on it. The `search` response already
+echoed stubbed `authored_after` / `authored_before` / `include_nulls` /
+`excluded_null_dated` keys (via `Scope.echo_into`) — so the contract was
+half-built: the keys were there, but no flag could ever set them to anything but
+null/0. This wires them to real behavior.
+
+**Reuse the existing shared resolver, don't reimplement.** The date-bound logic
+already lives in one place — `resolve_scope` (and its `_apply_date_bound` helper)
+in `bartleby/skill_scripts/_tags.py`, which `scan` / `list_documents` /
+`describe_corpus` all route through. It already accepts `authored_after` /
+`authored_before` / `include_nulls`, validates the bounds (`INVALID_DATE`),
+narrows the document set, and computes `excluded_null_dated`. So "extract scan's
+date-bound logic into a shared helper" was already done in the #536 wave; this
+sub-issue's job was to make `search` a *fourth consumer* of it, not to extract
+anything new. The change is therefore deliberately tiny:
+
+- `search.parse_args` calls the shared `add_date_filter_args(p)` (the same
+  flag-and-help trio `scan` uses) instead of hand-rolling three `add_argument`s,
+  so the CLI surface can't drift from scan's wording.
+- `search.work` threads `authored_after` / `authored_before` / `include_nulls`
+  into its existing `resolve_scope(...)` call.
+
+That's it for behavior. The `excluded_null_dated` count needed no new wiring:
+`scope.echo_into` (already on every search response) emits the true count the
+resolver computed, so the previously-stubbed key now carries real data for free.
+
+**Identical semantics to scan, by construction.** Because both scripts call the
+same resolver, the bounds are inclusive `YYYY-MM-DD` (`>= after` / `<= before`),
+undated documents are excluded by default and counted in `excluded_null_dated`,
+and `--include-nulls` keeps them and zeroes the count — with no second copy of
+the SQL to drift. A `test_search_date_filter_matches_scan_on_same_bounds` parity
+test pins this: search and scan resolve the same surviving document set and the
+same `excluded_null_dated` for the same corpus and bounds.
+
+**The date narrows search's document scope, intersecting like every other
+filter.** `search`'s `restrict = scope.document_ids` already drives
+`_build_scope`, so a date bound that narrows `document_ids` naturally restricts
+the document leg, restricts summaries/images to the surviving documents (the
+existing `--in-documents` intersection semantics), and drops findings (they have
+no document anchor and so no date) — consistent with how `--tag` / `--file-like`
+already behave. No new scope branching was needed.
+
+**Schema-stable: no `SCHEMA_VERSION` bump, no re-ingest.** This is a read-side
+filter over an existing column; no DDL.
+
+**Out of scope** (per the issue): ranking changes — the date is a filter, not an
+RRF signal; and `read_document` date surfacing, which landed in #536.
+
+Touches: `bartleby/skill_scripts/search.py` (the `add_date_filter_args` call,
+three kwargs into `resolve_scope`, and a docstring update); a date-filter test
+block in `tests/test_skill_search.py` reusing the shared `dated_corpus` fixture
+(including the scan-parity test). No change to the shared resolver in `_tags.py`
+or to `scan`'s external behavior.

--- a/tests/test_skill_search.py
+++ b/tests/test_skill_search.py
@@ -11,7 +11,9 @@ from bartleby.skill_scripts import search as search_script
 from bartleby.db.chunks import ChunkInput, insert_finding_chunks
 from bartleby.db.connection import open_db
 from bartleby.db.schema import EMBEDDING_DIM
-from tests._skill_fixtures import project_env, seeded_project  # noqa: F401
+from tests._skill_fixtures import (  # noqa: F401
+    dated_corpus, project_env, seeded_project,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -886,3 +888,156 @@ def test_search_default_projection_unchanged_without_returning(seeded_project, c
         "page_number", "authored_date", "chunk_index", "section_heading",
         "content_type", "text", "rank", "score", "normalized_score",
     }
+
+
+# ---------- date filters (--authored-after/before/--include-nulls), #537 ----------
+#
+# Reuse the shared `dated_corpus` fixture (#536): seven single-chunk documents
+# whose chunk text is `body of <file_name>`, so the literal token "body" matches
+# every document. Only `dated_doc` carries a date (2099-12-31); the rest are
+# undated (no summary, or a NULL-dated summary). Date bounds are resolved by the
+# same `resolve_scope` helper `scan` uses, so these also pin scan-parity.
+
+
+def _set_summary_date(project, document_id, value):
+    """Stamp authored_date onto a doc's summary, creating one if absent.
+
+    Lets a test add an in-range dated doc without editing the shared fixture's
+    shape (the director's note prefers a per-test row over a fixture change).
+    """
+    conn = open_db(project)
+    try:
+        conn.cursor().execute(
+            "INSERT INTO summaries (document_id, title, description, text, model, "
+            "authored_date) VALUES (?, '', '', '', 'test', ?) "
+            "ON CONFLICT(document_id) DO UPDATE SET authored_date = excluded.authored_date",
+            (document_id, value),
+        )
+    finally:
+        conn.close()
+
+
+def test_search_authored_after_filters_to_dated_doc(dated_corpus, capsys):
+    # Only dated_doc (2099-12-31) is on-or-after 2000-01-01; the six undated
+    # docs are excluded by default and counted in excluded_null_dated.
+    _run([
+        "--project", dated_corpus["project"], "--full-text",
+        "--authored-after", "2000-01-01",
+        "body",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert {r["source_id"] for r in out["results"]} == {dated_corpus["dated_doc"]}
+    f = out["filters"]
+    assert f["authored_after"] == "2000-01-01"
+    assert f["authored_before"] is None
+    assert f["include_nulls"] is False
+    assert f["excluded_null_dated"] == 6
+
+
+def test_search_authored_before_excludes_later_dated_doc(dated_corpus, capsys):
+    # dated_doc is 2099-12-31, so a 2024 upper bound drops it; nothing dated
+    # survives, and the six undated docs are still excluded.
+    _run([
+        "--project", dated_corpus["project"], "--full-text",
+        "--authored-before", "2024-01-01",
+        "body",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["results"] == []
+    assert out["filters"]["authored_before"] == "2024-01-01"
+    assert out["filters"]["excluded_null_dated"] == 6
+
+
+def test_search_inclusive_bounds_match_scan_boundary(dated_corpus, capsys):
+    # Inclusive: the exact boundary date is kept (>= / <=, not > / <).
+    _run([
+        "--project", dated_corpus["project"], "--full-text",
+        "--authored-after", "2099-12-31", "--authored-before", "2099-12-31",
+        "body",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert {r["source_id"] for r in out["results"]} == {dated_corpus["dated_doc"]}
+
+
+def test_search_include_nulls_keeps_undated(dated_corpus, capsys):
+    # With --include-nulls the six undated docs ride along beside dated_doc, and
+    # excluded_null_dated zeroes out.
+    _run([
+        "--project", dated_corpus["project"], "--full-text",
+        "--authored-after", "2000-01-01", "--include-nulls",
+        "body",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert len(out["results"]) == 7
+    f = out["filters"]
+    assert f["include_nulls"] is True
+    assert f["excluded_null_dated"] == 0
+
+
+def test_search_invalid_date_bound_errors(dated_corpus, capsys):
+    with pytest.raises(SystemExit) as exc:
+        _run([
+            "--project", dated_corpus["project"], "--full-text",
+            "--authored-after", "2099", "body",
+        ])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "INVALID_DATE"
+
+
+def test_search_date_bound_ands_with_in_documents(dated_corpus, capsys):
+    # The date bound intersects the document scope: dated_doc is on-bound but
+    # excluded from the in-documents slice → no hits, and the undated docs in
+    # the slice are counted as dropped.
+    _run([
+        "--project", dated_corpus["project"], "--full-text",
+        "--in-documents", str(dated_corpus["stub_doc"]),
+        "--authored-after", "2000-01-01",
+        "body",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["results"] == []
+    f = out["filters"]
+    assert f["in_documents"] == [dated_corpus["stub_doc"]]
+    # stub_doc is undated and the only doc in scope → 1 dropped.
+    assert f["excluded_null_dated"] == 1
+
+
+def test_search_unfiltered_omits_date_keys(dated_corpus, capsys):
+    # No bound, no scope → no filters echo at all (uniform with scan).
+    _run([
+        "--project", dated_corpus["project"], "--full-text", "body",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert "filters" not in out
+
+
+def test_search_date_filter_matches_scan_on_same_bounds(dated_corpus, capsys):
+    """Scan parity: search and scan resolve identical doc sets + counts for the
+    same corpus and bounds (both route through resolve_scope)."""
+    from bartleby.skill_scripts import scan as scan_script
+
+    # Add a second in-range dated doc so the surviving set is non-trivial.
+    _set_summary_date(dated_corpus["project"], dated_corpus["summary_doc"], "2010-06-01")
+
+    args = ["--authored-after", "2000-01-01", "--authored-before", "2050-01-01"]
+
+    scan_script.main([
+        "--project", dated_corpus["project"], "body", *args,
+    ])
+    scan_out = json.loads(capsys.readouterr().out)
+
+    _run([
+        "--project", dated_corpus["project"], "--full-text", "body", *args,
+    ])
+    search_out = json.loads(capsys.readouterr().out)
+
+    # Same surviving document set (search's source_id == document_id for
+    # document-kind chunks) and the same excluded_null_dated count.
+    scan_docs = {m["document_id"] for m in scan_out["matches"]}
+    search_docs = {r["source_id"] for r in search_out["results"]}
+    assert search_docs == scan_docs == {dated_corpus["summary_doc"]}
+    assert (
+        search_out["filters"]["excluded_null_dated"]
+        == scan_out["filters"]["excluded_null_dated"]
+    )


### PR DESCRIPTION
## What

Adds `--authored-after` / `--authored-before` / `--include-nulls` to `search`, wiring the already-stubbed `authored_after` / `authored_before` / `include_nulls` / `excluded_null_dated` response keys to real behavior.

## How

Rather than copy `scan`'s date SQL, `search` becomes a fourth consumer of the **already-shared** scope resolver — `resolve_scope` (and `_apply_date_bound`) in `bartleby/skill_scripts/_tags.py` — that `scan` / `list_documents` / `describe_corpus` already route through. The resolver already accepts the date kwargs, validates bounds (`INVALID_DATE`), narrows the document set, and computes `excluded_null_dated`.

The diff is therefore tiny:
- `parse_args` calls the shared `add_date_filter_args(p)` (the same flag/help trio `scan` uses) so the CLI surface can't drift.
- `work()` threads `authored_after` / `authored_before` / `include_nulls` into its existing `resolve_scope(...)` call.
- `excluded_null_dated` needs no new wiring: `Scope.echo_into` (already on every search response) emits the resolver's count for free.

Because both scripts share one resolver, semantics are identical by construction — inclusive `YYYY-MM-DD` bounds, undated docs excluded by default (`--include-nulls` keeps them), honest dropped-count. `scan`'s external behavior is unchanged.

## Acceptance criteria

- [x] `search --authored-after/before` filters by the document's `authored_date`.
- [x] Undated chunks excluded unless `--include-nulls`.
- [x] `excluded_null_dated` reports the true count.
- [x] Semantics match `scan` on the same corpus and bounds (pinned by a parity test).

## Tests

New date-filter block in `tests/test_skill_search.py` reusing the shared `dated_corpus` fixture (#536), including a scan↔search parity test. Whole suite green: **1114 passed**.

Schema-stable (read-side filter over an existing column): no `SCHEMA_VERSION` bump, no re-ingest. Ranking untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)