### PR TITLE
Part of #539: probe_dates skill + verify-then-prompt guidance

### DIFF
--- a/bartleby/skill/SKILL.md
+++ b/bartleby/skill/SKILL.md
@@ -36,6 +36,7 @@ bartleby skill read_chunks --around-chunk 1629 --window 5           # the target
 bartleby skill read_document --document 4 --summary
 bartleby skill save_finding --title "..." --description "..." --body-file ~/.bartleby/tmp/finding.md
 bartleby skill save_date --document 12 --date 2024-03-08              # backfill a date you read in the document
+bartleby skill probe_dates --regex '(?P<date>\d{4}-\d{2}-\d{2})'     # read-only: would this regex date the corpus? (verify before prompting a human)
 bartleby skill add_tag --name ch --description "Central Hudson rate-case filings"
 bartleby skill assign_tag --documents 9,12,30 --tag bad_ocr        # manual (no-LLM) batch assignment
 ```
@@ -101,6 +102,16 @@ Each result carries three signals you can use to triage:
 - `score` — the raw RRF score. These are tiny by design (around `0.015–0.033`) and only comparable within a single query's results, not across queries. Prefer `rank` and `normalized_score`.
 
 Every `search` hit and every `scan` match also carries `authored_date` — the originating document's summarizer-inferred date, or `null` when the document is undated (or, for findings, has no document). It rides along in **all** modes, including `--brief`, so you can triage or order matches by time without a second lookup. Don't parse dates out of filenames; read this field. (It's the same value `list_documents` reports and `--authored-after`/`--authored-before` filter on.)
+
+### Undated corpus, temporal task: verify before you prompt
+
+When your task needs dates (filtering, ordering, "what happened before X") and `describe_corpus` shows a high `undated_document_count`, the dates may still be recoverable from the filenames in bulk — but **don't prompt the human blindly**. Verify a candidate regex first with `probe_dates` (read-only — it writes nothing):
+
+1. Look at a few `file_name`s (via `list_documents`) and draft a regex with a named `date` group, e.g. `(?P<date>\d{4}-\d{2}-\d{2})`.
+2. Run `bartleby skill probe_dates --regex '<regex>'` and read `match_rate`, `normalized_ok`, `normalized_invalid`, `examples`, and `unmatched_examples`. Iterate on the regex against the `unmatched_examples` until the rate is high (or you conclude no regex fits).
+3. **Only prompt the human when the probe returns a `suggested_command`** (it does so only on a high `match_rate`). Hand them that exact line — it is `bartleby scribe backfill-dates … --from-filename '<regex>'`.
+4. **You cannot run the backfill yourself.** `bartleby scribe backfill-dates` is a human-run admin command — it is *not* a skill script and not on your surface. `probe_dates` is the agent-side discovery/validation; the human runs the write.
+5. **If no regex clears the bar** (dates aren't in the filenames in any regexable form, or every candidate matches poorly), say so and proceed *without* temporal filtering rather than send the human on a fix that won't help. A low `match_rate` or matches that land mostly in `normalized_invalid` both mean "not recoverable this way." `save_date` remains the per-document path when you've *read* a date in a specific document's text.
 
 ## Citing chunks correctly
 

--- a/bartleby/skill_scripts/probe_dates.py
+++ b/bartleby/skill_scripts/probe_dates.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+r"""probe_dates — dry-run a date regex over the corpus before prompting a human.
+
+A **read-only** validation surface (writes nothing). Given a regex with a named
+``date`` group, it reports how well that regex would extract dates from each
+document's ``file_name`` (default) or a sample of document body text — so an
+agent can *confirm* a candidate regex works before telling a human to run the
+human-only admin command ``bartleby scribe backfill-dates``. The agent cannot
+run the backfill itself; this script is the agent-side discovery/validation
+twin of the backfill command's own ``--dry-run`` preview.
+
+It reuses the backfill helpers (#536): ``compile_filename_date_regex`` (which
+enforces the named ``date`` group), ``extract_filename_date``, and
+``normalize_authored_date`` — extraction and date-validity are identical to
+what the actual backfill would do, so a high ``match_rate`` here predicts a
+clean backfill.
+
+Fields:
+    --regex REGEX        Required. Must contain a named group 'date', e.g.
+                         '(?P<date>\d{4}-\d{2}-\d{2})'. A malformed regex or a
+                         missing 'date' group is a usage error (INVALID_REGEX).
+    --field {filename,body}
+                         filename (default): match each document's file_name.
+                         Cheap — probes the full corpus unless --sample caps it.
+                         body: match a sample of document body text. ALWAYS
+                         sampled (sampled:true), since a full-corpus body scan
+                         is expensive.
+    --sample N           Cap the population probed to N documents (default 200).
+                         For --field filename it bounds an otherwise-full scan;
+                         for --field body it is the (always-on) sample size.
+    --file-like PATTERN  Scope to documents whose file_name matches this SQL
+                         LIKE pattern (repeatable, OR'd), consistent with
+                         scan / search / list_documents.
+
+Output (JSON):
+    {
+      "field": "filename"|"body",
+      "regex": str,
+      "sampled": bool,             # true if the probe saw a capped sample
+      "sample_size": int|null,     # the --sample cap when sampling, else null
+      "population": int,           # documents actually probed
+      "matched": int,              # documents whose file_name/body the regex hit
+      "match_rate": float,         # matched / population (0.0 when population==0)
+      "normalized_ok": int,        # matched AND a valid YYYY-MM-DD calendar date
+      "normalized_invalid": int,   # matched but NOT a valid YYYY-MM-DD
+      "examples": [                # a few good hits, for eyeballing
+        {"file_name": str, "extracted": str, "normalized": str}, ...
+      ],
+      "unmatched_examples": [str], # a few file_names the regex missed
+      "suggested_command": str|null,  # the exact backfill line to hand a human,
+                                       # emitted ONLY when match_rate is high
+      "match_threshold": float,    # the match_rate cutoff for suggested_command
+      "filters": {"file_like": [...]}  # present only when --file-like is active
+    }
+
+``suggested_command`` is emitted only when ``match_rate`` >= ``MATCH_THRESHOLD``
+(0.9): a regex that matches most of the corpus is worth handing to a human; a
+sparse one isn't, and prompting with it would waste a round-trip. When no regex
+clears the bar the agent should report dates aren't recoverable and proceed
+without temporal filtering rather than send the human on a useless fix.
+``normalized_invalid`` counts matches whose captured text isn't a real calendar
+date (e.g. ``2024-13-40``) — these are NOT good and never reach
+``normalized_ok``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+
+from bartleby.ingest.summarize import (
+    FilenameDateError,
+    compile_filename_date_regex,
+    extract_filename_date,
+    normalize_authored_date,
+)
+from bartleby.project import get_active_project
+from bartleby.skill_runner import SkillError, build_arg_parser, run
+from bartleby.skill_scripts._common import add_file_like_arg, positive_int
+
+
+# Emit a suggested backfill command only when the regex clears this match rate.
+# 0.9 is deliberately strict: handing a human a command that only dates a
+# fraction of the corpus invites a wasted round-trip. Documented in the
+# docstring and the GH-0538 decision file.
+MATCH_THRESHOLD = 0.9
+
+# A few examples each way is enough to eyeball; more just bloats the envelope.
+_EXAMPLE_LIMIT = 5
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = build_arg_parser("probe_dates", __doc__)
+    p.add_argument(
+        "--regex", required=True,
+        help=r"Regex with a named group 'date' (e.g. '(?P<date>\d{4}-\d{2}-\d{2})').",
+    )
+    p.add_argument(
+        "--field", choices=["filename", "body"], default="filename",
+        help="filename (default) or body. body is always sampled.",
+    )
+    p.add_argument(
+        "--sample", type=positive_int, default=200,
+        help="Cap the population probed (default 200). Always on for --field body.",
+    )
+    add_file_like_arg(p)
+    return p.parse_args(argv)
+
+
+def _probe_targets(conn, args) -> list[tuple[int, str, str]]:
+    """Return ``(document_id, file_name, probe_text)`` rows to match against.
+
+    For ``--field filename`` the probe text is the file_name; for ``--field
+    body`` it is the document's concatenated body-chunk text. ``--file-like``
+    scopes the document set (OR'd patterns), consistent with scan/search.
+
+    ``--field body`` is always sampled to ``--sample`` (a full-corpus body scan
+    is expensive); ``--field filename`` is capped only when ``--sample`` is
+    below the matching-document count.
+    """
+    cur = conn.cursor()
+    where = ""
+    params: list = []
+    if args.file_like:
+        clause = " OR ".join("file_name LIKE ?" for _ in args.file_like)
+        where = f"WHERE {clause} "
+        params = list(args.file_like)
+
+    if args.field == "filename":
+        rows = cur.execute(
+            f"SELECT document_id, file_name FROM documents {where}"
+            "ORDER BY document_id LIMIT ?",
+            [*params, args.sample],
+        )
+        return [(doc_id, name, name) for doc_id, name in rows]
+
+    # body: join document-track chunks, concatenate per document, always sampled.
+    rows = cur.execute(
+        "SELECT d.document_id, d.file_name, "
+        "       GROUP_CONCAT(c.text, ' ') AS body "
+        "FROM documents d "
+        "JOIN chunks c ON c.source_kind = 'document' AND c.source_id = d.document_id "
+        f"{where}"
+        "GROUP BY d.document_id, d.file_name "
+        "ORDER BY d.document_id LIMIT ?",
+        [*params, args.sample],
+    )
+    return [(doc_id, name, body or "") for doc_id, name, body in rows]
+
+
+def work(*, conn, args, session_id) -> dict:
+    try:
+        compiled = compile_filename_date_regex(args.regex)
+    except FilenameDateError as e:
+        raise SkillError("INVALID_REGEX", str(e)) from e
+
+    targets = _probe_targets(conn, args)
+    population = len(targets)
+
+    # --field body is always a sample; --field filename is a sample only when the
+    # --sample cap actually bit (population reached the cap, so more may exist).
+    sampled = args.field == "body" or population >= args.sample
+
+    matched = 0
+    normalized_ok = 0
+    normalized_invalid = 0
+    examples: list[dict] = []
+    unmatched_examples: list[str] = []
+
+    for _doc_id, file_name, probe_text in targets:
+        extracted = extract_filename_date(compiled, probe_text)
+        if extracted is None:
+            if len(unmatched_examples) < _EXAMPLE_LIMIT:
+                unmatched_examples.append(file_name)
+            continue
+        matched += 1
+        normalized = normalize_authored_date(extracted)
+        if normalized is None:
+            normalized_invalid += 1
+        else:
+            normalized_ok += 1
+            if len(examples) < _EXAMPLE_LIMIT:
+                examples.append({
+                    "file_name": file_name,
+                    "extracted": extracted,
+                    "normalized": normalized,
+                })
+
+    match_rate = matched / population if population else 0.0
+
+    suggested_command = None
+    if match_rate >= MATCH_THRESHOLD:
+        project = args.project or get_active_project()
+        suggested_command = (
+            f"bartleby scribe backfill-dates {project} "
+            f"--from-filename {shlex.quote(args.regex)}"
+        )
+
+    result = {
+        "field": args.field,
+        "regex": args.regex,
+        "sampled": sampled,
+        "sample_size": args.sample if sampled else None,
+        "population": population,
+        "matched": matched,
+        "match_rate": round(match_rate, 4),
+        "normalized_ok": normalized_ok,
+        "normalized_invalid": normalized_invalid,
+        "examples": examples,
+        "unmatched_examples": unmatched_examples,
+        "suggested_command": suggested_command,
+        "match_threshold": MATCH_THRESHOLD,
+    }
+    if args.file_like:
+        result["filters"] = {"file_like": args.file_like}
+    return result
+
+
+def main(argv: list[str] | None = None) -> None:
+    run(tool_name="probe_dates", parse_args=parse_args, work=work, argv=argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/decisions/GH-0538-probe-dates.md
+++ b/docs/decisions/GH-0538-probe-dates.md
@@ -1,0 +1,73 @@
+# `probe_dates` skill validates a date regex before the agent prompts a human (issue #538)
+
+> Source: [#538](https://github.com/jswest/bartleby/issues/538)
+
+`scribe backfill-dates` (#536) is a **human-run** bulk write that dates an
+undated corpus from a filename regex — but it's deliberately off the agent
+surface. An agent facing a temporal task on an undated corpus therefore has to
+*tell* a human to run it, and prompting blindly is a wasted round-trip: the date
+may not sit in the filename in any regexable form, or a candidate regex may match
+poorly. The agent needs a way to **confirm a regex would work** before it says
+anything.
+
+**A read-only skill script, the agent-side twin of backfill's `--dry-run`.**
+`bartleby skill probe_dates --regex '(?P<date>…)' [--field filename|body]
+[--sample N] [--file-like PATTERN]` lives at
+`bartleby/skill_scripts/probe_dates.py` and is dispatchable on drop-in (the
+dispatcher derives its allowlist from the package directory — no registry edit).
+It **writes nothing**: it reports how well the regex extracts dates over the
+filenames (default) or a body sample, so the agent can iterate on the regex and
+decide whether to prompt. The backfill command's own `--dry-run` stays the
+human-side preview of the actual write; same helpers, different actors.
+
+**Reuses #536's helpers, no reimplementation.** Extraction and date-validity go
+through `compile_filename_date_regex` (which enforces the named `date` group),
+`extract_filename_date`, and `normalize_authored_date` from
+`bartleby/ingest/summarize.py`. So a clean probe here predicts a clean backfill —
+the two surfaces can't drift in what they consider a match or a valid date. A
+malformed regex or a missing `date` group is a usage error surfaced as
+`INVALID_REGEX` (JSON envelope, non-zero exit), reusing `FilenameDateError`.
+
+**Output contract.** `sampled` / `sample_size` / `population` / `matched` /
+`match_rate` / `normalized_ok` / `normalized_invalid` / `examples` (a few
+`file_name → extracted → normalized` good hits) / `unmatched_examples` (a few
+file_names the regex missed, to refine against) / `suggested_command` /
+`match_threshold`. A match whose captured text isn't a real calendar date
+(`2024-13-40`) lands in `normalized_invalid` and **never** in `normalized_ok` —
+the same honest-NULL posture backfill takes.
+
+**`suggested_command` is gated on a high match rate (`MATCH_THRESHOLD = 0.9`).**
+It is emitted *only* when `match_rate >= 0.9`, carrying the exact
+`bartleby scribe backfill-dates <project> --from-filename '<regex>'` line for the
+human (regex `shlex.quote`d). 0.9 is deliberately strict: handing a human a
+command that dates only a fraction of the corpus invites a wasted round-trip. The
+threshold is a published output field (`match_threshold`) so the agent isn't
+guessing the cutoff. `match_rate` counts *regex hits* (not normalizable dates),
+so a regex that matches everything but captures junk still clears the rate — the
+agent reads `normalized_invalid` to see that and refine; invalidity is reported,
+not suppressed.
+
+**`--field body` is always sampled.** A full-corpus body scan is expensive, so
+`--field body` always sets `sampled: true` and caps at `--sample` (default 200),
+matching the body chunks via `GROUP_CONCAT` per document. `--field filename` is
+cheap and probes the full corpus unless `--sample` actually bites (population
+reaches the cap), in which case `sampled` flips true. `--file-like` scopes the
+probe with the same OR'd SQL `LIKE` semantics as `scan` / `search` /
+`list_documents`.
+
+**SKILL.md — verify-then-prompt.** A new subsection under the authored-date prose
+spells out the flow: on a high `undated_document_count` from `describe_corpus`,
+draft a regex, run `probe_dates`, iterate against `unmatched_examples`, and prompt
+the human **only** when a `suggested_command` comes back. It states plainly that
+the agent **cannot run the backfill itself** — `scribe backfill-dates` is a
+human-run admin command, not a skill script. If no regex clears the bar, the
+agent reports dates aren't recoverable and proceeds *without* temporal filtering
+rather than sending the human on a useless fix; `save_date` stays the
+per-document path when a date is actually read in a document's text.
+
+**Out of scope:** non-date facet probing (future, with the #48 sidecar / facets
+work); any write path.
+
+Touches: new `bartleby/skill_scripts/probe_dates.py`; new
+`tests/test_skill_probe_dates.py`; `bartleby/skill/SKILL.md` (a quick-reference
+example line + the verify-then-prompt subsection).

--- a/tests/test_skill_probe_dates.py
+++ b/tests/test_skill_probe_dates.py
@@ -1,0 +1,186 @@
+"""Tests for skill_scripts/probe_dates.py — the read-only date-regex prober.
+
+Reuses the shared `dated_corpus` fixture (#536): seven single-chunk documents
+named `<key>__YYYY-MM-DD__slug.md`. Six filenames carry a date-shaped token; one
+(`nomatch_doc`, `D004__no-date-here__delta.md`) does not. Of the six matches,
+`bad_date_doc` (`E005__2024-13-40__epsilon.md`) captures an impossible calendar
+date — it must land under `normalized_invalid`, never `normalized_ok`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bartleby.db.connection import open_db
+from bartleby.skill_scripts import probe_dates
+from bartleby.skill_scripts.probe_dates import MATCH_THRESHOLD
+from tests._skill_fixtures import (  # noqa: F401
+    dated_corpus, project_env, seeded_project,
+)
+
+
+_DATE_RE = r"(?P<date>\d{4}-\d{2}-\d{2})"
+
+
+def _run(argv):
+    probe_dates.main(argv)
+
+
+def _out(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+def test_filename_match_counts(dated_corpus, capsys):
+    # Six of seven file_names carry a date-shaped token; nomatch_doc misses.
+    # bad_date_doc matches but its capture (2024-13-40) is not a real date.
+    _run(["--project", dated_corpus["project"], "--regex", _DATE_RE])
+    out = _out(capsys)
+    assert out["field"] == "filename"
+    assert out["population"] == 7
+    assert out["matched"] == 6
+    assert out["normalized_ok"] == 5
+    assert out["normalized_invalid"] == 1
+    # 6/7 ~= 0.857, below the 0.9 threshold → no command suggested.
+    assert out["match_rate"] == pytest.approx(6 / 7, abs=1e-4)
+    assert out["suggested_command"] is None
+    assert out["match_threshold"] == MATCH_THRESHOLD
+
+
+def test_examples_and_unmatched_examples(dated_corpus, capsys):
+    _run(["--project", dated_corpus["project"], "--regex", _DATE_RE])
+    out = _out(capsys)
+    # Examples are good (normalized) hits: file_name -> extracted -> normalized.
+    assert out["examples"]
+    for ex in out["examples"]:
+        assert set(ex) == {"file_name", "extracted", "normalized"}
+        assert ex["extracted"] == ex["normalized"]
+    # bad_date_doc's invalid capture never appears among the good examples.
+    assert "2024-13-40" not in {ex["extracted"] for ex in out["examples"]}
+    # The one filename without a date is surfaced for refinement.
+    assert "D004__no-date-here__delta.md" in out["unmatched_examples"]
+
+
+def test_suggested_command_only_on_high_match_rate(dated_corpus, capsys):
+    # Scope away nomatch_doc (D004...) with --file-like, OR'ing the dated
+    # prefixes so every probed filename carries a date token: 6/6 = 1.0 >= 0.9.
+    patterns = ["A001%", "B002%", "C003%", "E005%", "F006%"]
+    argv = ["--project", dated_corpus["project"], "--regex", _DATE_RE]
+    for p in patterns:
+        argv += ["--file-like", p]
+    _run(argv)
+    out = _out(capsys)
+    assert out["matched"] == out["population"]
+    assert out["match_rate"] == 1.0
+    assert out["suggested_command"] == (
+        f"bartleby scribe backfill-dates {dated_corpus['project']} "
+        f"--from-filename '{_DATE_RE}'"
+    )
+    assert out["filters"] == {"file_like": patterns}
+
+
+def test_invalid_only_match_yields_no_normalized_ok(dated_corpus, capsys):
+    # Scope to bad_date_doc alone: it matches the regex but normalizes invalid.
+    _run([
+        "--project", dated_corpus["project"], "--regex", _DATE_RE,
+        "--file-like", "E005%",
+    ])
+    out = _out(capsys)
+    assert out["population"] == 1
+    assert out["matched"] == 1
+    assert out["normalized_ok"] == 0
+    assert out["normalized_invalid"] == 1
+    # A regex that only ever captures junk dates is a 1.0 match_rate but the
+    # caller can see every match is invalid; we still emit the command (it
+    # cleared the rate) — invalidity is reported, not suppressed.
+    assert out["suggested_command"] is not None
+
+
+def test_body_field_is_always_sampled(dated_corpus, capsys):
+    # Body chunks read "body of <file_name>", so the date token rides in the body
+    # too. --field body must mark sampled:true regardless of population size.
+    _run([
+        "--project", dated_corpus["project"], "--regex", _DATE_RE,
+        "--field", "body",
+    ])
+    out = _out(capsys)
+    assert out["field"] == "body"
+    assert out["sampled"] is True
+    assert out["sample_size"] == 200
+    assert out["matched"] == 6
+
+
+def test_filename_sample_caps_population_and_marks_sampled(dated_corpus, capsys):
+    # A --sample below the corpus size bites: population is capped and sampled
+    # flips true (for --field filename, sampled means the cap actually bit).
+    _run([
+        "--project", dated_corpus["project"], "--regex", _DATE_RE,
+        "--sample", "3",
+    ])
+    out = _out(capsys)
+    assert out["population"] == 3
+    assert out["sampled"] is True
+    assert out["sample_size"] == 3
+
+
+def test_filename_unsampled_when_corpus_below_cap(dated_corpus, capsys):
+    # Default --sample 200 exceeds the 7-doc corpus, so the filename probe sees
+    # everything: sampled false, sample_size null.
+    _run(["--project", dated_corpus["project"], "--regex", _DATE_RE])
+    out = _out(capsys)
+    assert out["sampled"] is False
+    assert out["sample_size"] is None
+
+
+def test_missing_date_group_is_usage_error(dated_corpus, capsys):
+    # The #536 helper enforces the named `date` group; a regex without one is a
+    # usage error surfaced as INVALID_REGEX (JSON envelope, non-zero exit).
+    with pytest.raises(SystemExit):
+        _run([
+            "--project", dated_corpus["project"], "--regex", r"\d{4}-\d{2}-\d{2}",
+        ])
+    out = _out(capsys)
+    assert out["code"] == "INVALID_REGEX"
+
+
+def test_malformed_regex_is_usage_error(dated_corpus, capsys):
+    with pytest.raises(SystemExit):
+        _run([
+            "--project", dated_corpus["project"], "--regex", r"(?P<date>[",
+        ])
+    out = _out(capsys)
+    assert out["code"] == "INVALID_REGEX"
+
+
+def _snapshot_db(project):
+    """Return a comparable snapshot of every row that probe_dates could touch."""
+    conn = open_db(project)
+    try:
+        cur = conn.cursor()
+        docs = list(cur.execute(
+            "SELECT document_id, file_name FROM documents ORDER BY document_id"))
+        summaries = list(cur.execute(
+            "SELECT document_id, authored_date, model FROM summaries "
+            "ORDER BY document_id"))
+        chunks = list(cur.execute(
+            "SELECT chunk_id, source_kind, source_id, text FROM chunks "
+            "ORDER BY chunk_id"))
+    finally:
+        conn.close()
+    return docs, summaries, chunks
+
+
+def test_probe_writes_nothing(dated_corpus, capsys):
+    # Read-only contract: the DB is byte-identical before and after a probe that
+    # exercises both fields and an emitted suggested_command.
+    before = _snapshot_db(dated_corpus["project"])
+    _run(["--project", dated_corpus["project"], "--regex", _DATE_RE])
+    capsys.readouterr()
+    _run([
+        "--project", dated_corpus["project"], "--regex", _DATE_RE,
+        "--field", "body",
+    ])
+    capsys.readouterr()
+    after = _snapshot_db(dated_corpus["project"])
+    assert before == after


### PR DESCRIPTION
## What

Adds a **read-only** `probe_dates` skill script and a verify-then-prompt section to SKILL.md.

`bartleby skill probe_dates --regex '(?P<date>…)' [--field filename|body] [--sample N] [--file-like PATTERN]` reports how well a candidate date regex would extract dates from the corpus — `match_rate`, `normalized_ok`, `normalized_invalid`, `examples` (`file_name → extracted → normalized`), `unmatched_examples` — and emits the exact `bartleby scribe backfill-dates … --from-filename '<regex>'` line as `suggested_command` **only** when `match_rate >= 0.9` (a published `match_threshold` field). **Writes nothing.**

## Why

`scribe backfill-dates` (#536) is a human-run bulk write off the agent surface. An agent facing a temporal task on an undated corpus shouldn't prompt the human blindly — the dates may not be regexable, or a candidate regex may match poorly. `probe_dates` is the agent-side discovery/validation twin of backfill's own `--dry-run`: confirm a regex works, then prompt; if none clears the bar, report dates aren't recoverable and proceed without temporal filtering.

## Notes

- **Reuses #536's helpers** (`compile_filename_date_regex` / `extract_filename_date` / `normalize_authored_date` in `bartleby/ingest/summarize.py`) — no reimplementation of regex extraction or date normalization. So the probe and the actual backfill can't drift on what counts as a match or a valid date; an invalid calendar date (`2024-13-40`) lands in `normalized_invalid`, never `normalized_ok`.
- **Read-only**, verified by a test asserting the DB is byte-identical before/after probing both fields.
- `--field body` is always sampled (`sampled: true`); `--field filename` may probe the full corpus or a sample.
- SKILL.md states plainly the agent **cannot run the backfill itself** (human-run admin command).
- Dispatchable on drop-in (no registry edit). No `SCHEMA_VERSION` bump.

## Acceptance criteria

- [x] Good regex over a date-encoded corpus → high `match_rate` + `suggested_command`; writes nothing.
- [x] `--field body` samples and marks `sampled: true`.
- [x] A regex matching text but yielding invalid dates lands under `normalized_invalid`, not counted as good.
- [x] SKILL.md describes the verify-then-prompt flow and states the agent can't run the backfill.

Full suite: 1127 passed. Decision: `docs/decisions/GH-0538-probe-dates.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)