### PR TITLE
Add runbook + helper scripts for running Pi in an isolated VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,10 @@ No prompts, source text, or research notes leave the machine.
 
 If you can't fit either tier, the middle path is **local ingest + cloud research**: keep `provider: ollama` for the deterministic ingest pipeline, but point Goose or Pi (or Claude Code) at a frontier API for the agent layer. Source documents still never leave the machine; only the agent's queries do.
 
+### Sandboxing Pi in an isolated VM
+
+Pi is a minimal harness with an unsandboxed `bash` tool — handing a local model a shell on your machine. To keep that off your Mac, [`docs/pi-vm-runbook.md`](docs/pi-vm-runbook.md) walks through running Pi (plus `decant` for web fetches) inside an isolated Apple `container` VM that mounts only your corpus: the big agent model stays on the host GPU, `decant`'s small distill model runs CPU-only inside the box, and helper scripts live in [`scripts/pi-vm/`](scripts/pi-vm/).
+
 ### Model downloads and offline mode
 
 Bartleby pulls a few models from the Hugging Face Hub on demand: the embedding model (always), and — when you ingest with the Docling converter — Docling's layout and table models (the first time a conversion needs them). They cache under `~/.cache/huggingface/hub` and download once.

--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -1,0 +1,244 @@
+# Running Bartleby with Pi in an isolated VM
+
+A runbook for driving the Bartleby research skill with [Pi](https://pi.dev) and
+local Ollama models, while keeping Pi's unsandboxed shell off your Mac.
+
+> **Status: first-draft, needs a shakeout run.** The helper scripts in
+> [`scripts/pi-vm/`](../scripts/pi-vm/) encode the design below, but they have
+> not yet been run end-to-end on a clean machine. Three things are most likely
+> to need adjustment on first use: Apple `container`'s host-networking (reaching
+> the host Ollama), where the Pi installer puts the `pi` binary on `PATH`, and
+> the in-build model pull. Each is flagged inline below and in the scripts.
+
+---
+
+## Why bother
+
+Pi is a *minimal* agent harness: four core tools (`read`, `write`, `edit`,
+`bash`) and **no permission gates or filesystem/network sandboxing by default**
+([pi.dev](https://pi.dev)). That's a deliberate design choice — you adapt Pi to
+your workflow — but it means a local model gets an unconfined shell on whatever
+machine Pi runs on. With Claude Code you'd have both Anthropic-grade alignment
+*and* the permission system in front of `bash`; with Pi + a local model you have
+neither. The VM is the substitute for both.
+
+So: **run Pi inside a disposable Linux VM**, mount only the one corpus it should
+touch, and keep the blast radius to the box.
+
+## The constraint that shapes everything
+
+You **cannot** usefully run Ollama *inside* a Linux VM/container on Apple
+Silicon. The Apple GPU can't be passed through to a Linux guest (macOS holds it
+for the display), so containerized Ollama falls back to **CPU-only inference —
+3–5× slower** ([ollama#5652](https://github.com/ollama/ollama/issues/5652)).
+For a 35B agent model that's unusable.
+
+The resolution: **isolate the agent, not the inference.** The model just emits
+text; the danger is the agent *acting* on that text (`bash`/`write`/`edit`). So
+inference stays where it's fast (the host GPU), and the agent's hands stay in
+the box.
+
+## Topology
+
+```
+┌─ macOS host (M4 Max, Metal GPU) ──────────────────────────────────┐
+│                                                                     │
+│  ollama :11434   ← your daily-driver instance (untouched)           │
+│  ollama :11435   ← DEDICATED agent instance, qwen3.6:35b  (GPU)     │ ← host-agent-ollama.sh
+│       ▲                                                             │
+│       │ only VM→host path: Pi → agent model                        │
+│  ┌────┼──────────────────── Apple `container` VM ────────────────┐ │
+│  │    │                                                           │ │
+│  │   Pi ──bash/write/edit──▶ confined to the VM filesystem        │ │
+│  │    └─ runs `bartleby skill …` over the mounted corpus DB        │ │
+│  │                                                                 │ │
+│  │   ollama :11434 (VM-local, CPU) ◀── decant, gemma4:e2b          │ │
+│  │   decant ──▶ web (outbound NAT) ──▶ Brave + fetched URLs         │ │
+│  │                                                                 │ │
+│  │   mount: host ~/.bartleby  →  /corpus   (read-write)            │ │
+│  └─────────────────────────────────────────────────────────────────┘
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Two Ollama roles, deliberately split:
+
+| Role | Where | Model | Why |
+| --- | --- | --- | --- |
+| **Agent** (drives Pi) | Host, dedicated instance `:11435` | `qwen3.6:35b` | Big model → needs the GPU. A *separate* process/port from your daily `:11434`, independently start/stoppable. |
+| **decant distill** | VM-local `:11434` (CPU) | `gemma4:e2b` | Small model, summarization is its whole job. Keeping it in the VM means raw web content never reaches the host. |
+
+### Can I run Ollama on the host *and* in the VM at once?
+
+Yes. They're separate processes in separate network namespaces — no port or
+socket clash, and they happily share the on-disk model blobs. The only cost is
+that the in-VM instance is CPU-only, which is exactly why we give it the small
+`gemma4:e2b` distill model and leave the 35B agent model on the host GPU.
+
+### Model picks (from `bartleby benchmark`)
+
+The benchmark ranks models on a *summarization* task. Top local finishers:
+`gemma4:31b` (4.75/5), `qwen3.6:35b` (4.72/5 at ~175 tok/s), `gemma4:e2b`
+(4.69/5 at ~585 tok/s). Two caveats drove the picks here:
+
+- **Agent ≠ summarizer.** An agent loop is many multi-turn *tool calls*, and
+  tool-calling reliability is not what the summarization benchmark measures. The
+  README already warns local models follow tool-use protocols less reliably. The
+  qwen3 family is a steadier tool-caller than gemma4, and at ~175 tok/s it's
+  ~3.7× faster than `gemma4:31b` — throughput compounds over a long loop. So the
+  **agent** model is `qwen3.6:35b` (swap to `gpt-oss:120b` for more reasoning
+  headroom; you have the RAM).
+- **decant's job *is* summarization**, so the benchmark transfers cleanly:
+  `gemma4:e2b` at 4.69/5 and ~585 tok/s is the ideal distill model — and small
+  enough to tolerate CPU-only inference in the VM.
+
+## Security posture
+
+What this buys you, and what it doesn't:
+
+- **Pi's `bash` is confined to the VM.** A confused or jailbroken local model
+  can't read your SSH keys, touch other repos, or `rm -rf $HOME`. Worst case is
+  a trashed container, which you rebuild.
+- **Only the corpus is mounted** — `~/.bartleby` → `/corpus`, read-write
+  (the agent writes findings/tags, which go through Bartleby's typed `chunks`
+  helpers, never raw SQL). Nothing else of your home directory is visible. With
+  a **pure-build** image (the choice here) the agent never even sees the
+  Bartleby or decant *source* — it's baked in, not mounted.
+- **decant's web access stays in the box.** Raw fetched pages and their
+  summarization never leave the VM; only what the agent pulls back via the skill
+  crosses the mount.
+
+### Will decant reach the web outside the box?
+
+**Yes — outbound internet works.** Apple `container` gives containers NAT
+internet by default, so decant reaches Brave and the URLs you fetch. Outbound is
+the easy direction; the *hard* direction on Apple `container` is reaching host
+services (see the networking note below), which is why the agent-Ollama hop
+needs explicit wiring while decant's web access just works.
+
+**The trade-off to know:** Pi shares the container's network namespace, so if
+decant can reach the web, **so can Pi's `bash`** — the agent could phone home or
+exfiltrate the corpus. That's acceptable here because the box holds no host
+secrets and only your corpus, but if you want to close it:
+
+- Run with an **egress allowlist** — a proxy or firewall that permits only
+  Brave's API + the domains you're researching, and the host agent-Ollama IP.
+- Or accept the open egress and rely on the filesystem isolation (the corpus is
+  the only sensitive thing in the box, and you put it there on purpose).
+
+This is a deliberate, documented gap rather than a silent one. Tightening egress
+is left as a follow-up; the filesystem boundary is the load-bearing protection.
+
+## Prerequisites
+
+- **macOS 26+** (you're on 26.3 — full Apple Containerization support; macOS 15
+  is degraded).
+- **Apple `container`**: `brew install container` (formula, not a cask).
+- **Ollama on the host** with `qwen3.6:35b` and `gemma4:e2b` pulled
+  (`ollama pull qwen3.6:35b` — `gemma4:e2b` is re-pulled inside the VM at build
+  time, so the host copy is optional).
+- A **Brave Search API key** if you want `decant search` (not needed for
+  `decant url`). Pass it as `BRAVE_SEARCH_API_KEY`.
+- The **decant** source at `~/Code/decant` (override with `DECANT_SRC`).
+
+## The Apple `container` networking note
+
+This is the one genuinely fiddly part. Apple `container` does **not** provide
+`host.docker.internal`, and reaching host services from a container is a known
+gap ([apple/container#346](https://github.com/apple/container/issues/346)).
+Two moving parts:
+
+1. **Host side** — the dedicated agent Ollama must bind somewhere the VM can
+   reach, not `127.0.0.1`. [`host-agent-ollama.sh`](../scripts/pi-vm/host-agent-ollama.sh)
+   binds it to `0.0.0.0:11435`. That also exposes it to your LAN; if that
+   bothers you, enable the macOS firewall or bind to the vmnet bridge IP only.
+2. **VM side** — the container reaches the host via its **default gateway**,
+   which points at the host bridge. [`entrypoint.sh`](../scripts/pi-vm/entrypoint.sh)
+   auto-detects it with `ip route` and renders Pi's `models.json` to
+   `http://<gateway>:11435/v1`. If auto-detection picks the wrong address, pass
+   `HOST_OLLAMA_IP=<addr>` to `run.sh` to override.
+
+If the host hop proves painful, **colima** is the fallback — it gives you
+`host.docker.internal` for free at the cost of Apple `container`'s cleaner
+VM-per-container model.
+
+## Build vs. mount: why pure build
+
+This setup is **pure build** — the image bakes Pi + Bartleby + decant + the
+distill model + both configs, and mounts *only* the corpus. The alternative
+(bind-mounting the Bartleby/decant source for live editing) was rejected because
+it would let the agent see and modify your tool source, which partly defeats the
+isolation. Pure build gives a reproducible, disposable image and the tightest
+blast radius. The cost is a rebuild when Bartleby or decant changes — run
+`build.sh` again.
+
+## Step by step
+
+```bash
+# 0. one-time: install Apple container
+brew install container
+container system start          # starts the container runtime
+
+# 1. host: start the dedicated agent Ollama (GPU), separate from your daily one
+./scripts/pi-vm/host-agent-ollama.sh          # serves qwen3.6:35b on :11435
+
+# 2. build the research-VM image (stages bartleby + ~/Code/decant source)
+./scripts/pi-vm/build.sh                       # -> bartleby-pi:latest
+
+# 3. run it — mounts ~/.bartleby as /corpus, drops you into Pi
+BRAVE_SEARCH_API_KEY=brv-... ./scripts/pi-vm/run.sh
+
+#    or run Pi non-interactively:
+./scripts/pi-vm/run.sh pi -p "Summarize the strongest findings in project X"
+```
+
+Inside the VM, Pi sees the Bartleby skill (installed to `~/.pi/agent/skills/`
+at build time) and drives it against `/corpus` exactly as Claude Code would.
+
+## Verifying the wiring
+
+Once you're in the container shell (`./scripts/pi-vm/run.sh bash`):
+
+```bash
+# agent Ollama reachable on the host?
+curl -s "http://$(ip route | awk '/default/{print $3}'):11435/v1/models" | head
+
+# decant's local Ollama up?
+curl -s http://127.0.0.1:11434/api/tags | head
+
+# decant can reach the web?
+decant url https://example.com --question "what is this page"
+
+# Bartleby sees the corpus?
+bartleby project list
+
+# Pi sees the skill?
+pi --help            # confirm `pi` is on PATH; see shakeout note if not
+```
+
+## Shakeout notes (things to confirm on first run)
+
+- **`pi` on `PATH`.** The curl installer (`https://pi.dev/install.sh`) may drop
+  the binary somewhere not on the default `PATH`. If `pi` isn't found, either
+  symlink it into `/usr/local/bin` in the `Containerfile` or switch to the npm
+  install (`npm install -g --ignore-scripts @earendil-works/pi-coding-agent`,
+  which needs Node in the image).
+- **In-build model pull.** The `Containerfile` runs `ollama serve` in the
+  background during build to `ollama pull gemma4:e2b`. If that's flaky, move the
+  pull to `entrypoint.sh` (first-run) backed by a persistent volume — at the
+  cost of pure-build self-containment.
+- **Gateway detection.** If `ip route` inside the VM doesn't yield a
+  host-reachable address, set `HOST_OLLAMA_IP` explicitly (see networking note).
+- **`container system start`.** Apple `container` needs its runtime started once
+  per boot before `build`/`run`.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| [`scripts/pi-vm/host-agent-ollama.sh`](../scripts/pi-vm/host-agent-ollama.sh) | Host: dedicated agent Ollama on `:11435` (GPU) |
+| [`scripts/pi-vm/build.sh`](../scripts/pi-vm/build.sh) | Stage source + build the image (pure build) |
+| [`scripts/pi-vm/Containerfile`](../scripts/pi-vm/Containerfile) | The research-VM image |
+| [`scripts/pi-vm/entrypoint.sh`](../scripts/pi-vm/entrypoint.sh) | In-VM: start local Ollama, render configs, launch Pi |
+| [`scripts/pi-vm/run.sh`](../scripts/pi-vm/run.sh) | Run the VM, mount the corpus |
+| [`scripts/pi-vm/models.json`](../scripts/pi-vm/models.json) | Pi provider config (→ host agent Ollama) |
+| [`scripts/pi-vm/decant-config.yaml`](../scripts/pi-vm/decant-config.yaml) | decant config (→ VM-local Ollama) |

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -1,0 +1,49 @@
+# Pure-build research VM: Pi + Bartleby + decant + a VM-local Ollama (CPU) for
+# decant's distill model. The big agent model runs on the HOST GPU; see
+# docs/pi-vm-runbook.md. The build context is assembled by build.sh, which
+# stages the Bartleby and decant source trees next to this file.
+FROM debian:trixie-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git iproute2 tesseract-ocr \
+      python3 python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv (Python tooling) — installs to /root/.local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Ollama (Linux). CPU-only inside the VM — used solely for decant's small model.
+RUN curl -fsSL https://ollama.com/install.sh | sh
+
+# Pi coding agent. NOTE: confirm `pi` lands on PATH; see runbook shakeout notes.
+# (Alternative: npm install -g --ignore-scripts @earendil-works/pi-coding-agent)
+RUN curl -fsSL https://pi.dev/install.sh | sh
+
+# --- Bartleby + decant from staged local source (pure build) ---
+COPY bartleby/ /opt/bartleby/
+COPY decant/   /opt/decant/
+RUN uv tool install /opt/bartleby \
+    && uv tool install /opt/decant
+
+# Install the Bartleby skill where Pi discovers skills.
+RUN bartleby ready --dest /root/.pi/agent/skills --force
+
+# Bake decant's distill model into the image (pure build = reproducible/offline).
+ARG DECANT_MODEL=gemma4:e2b
+RUN ollama serve >/tmp/ollama-build.log 2>&1 & \
+    until ollama list >/dev/null 2>&1; do sleep 0.5; done; \
+    ollama pull "${DECANT_MODEL}"
+
+# Config templates + entrypoint.
+COPY pi-vm/models.json        /opt/pi-vm/models.json
+COPY pi-vm/decant-config.yaml /opt/pi-vm/decant-config.yaml
+COPY pi-vm/entrypoint.sh      /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Bartleby's corpus root inside the VM (mounted by run.sh).
+ENV BARTLEBY_HOME=/corpus
+WORKDIR /corpus
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/scripts/pi-vm/README.md
+++ b/scripts/pi-vm/README.md
@@ -1,0 +1,34 @@
+# Pi-in-a-VM helper scripts
+
+Run the Bartleby research skill with [Pi](https://pi.dev) and local Ollama
+models inside an isolated Apple `container` VM. Full rationale, topology, and
+the security trade-offs are in
+[`docs/pi-vm-runbook.md`](../../docs/pi-vm-runbook.md) — **read that first.**
+
+> First-draft scripts, not yet shaken out end-to-end. See the shakeout notes in
+> the runbook.
+
+## Quick start
+
+```bash
+brew install container && container system start   # one-time
+./host-agent-ollama.sh                             # host GPU: qwen3.6:35b on :11435
+./build.sh                                         # pure-build the image
+BRAVE_SEARCH_API_KEY=brv-... ./run.sh              # mount ~/.bartleby, launch Pi
+```
+
+## What each file does
+
+| File | Side | Role |
+| --- | --- | --- |
+| `host-agent-ollama.sh` | host | Dedicated agent Ollama on `:11435` (GPU), separate from your daily `:11434` |
+| `build.sh` | host | Stage Bartleby + decant source, build `bartleby-pi:latest` |
+| `Containerfile` | — | The research-VM image (Pi + Bartleby + decant + VM-local Ollama) |
+| `run.sh` | host | Run the VM, mount the corpus read-write |
+| `entrypoint.sh` | VM | Start local Ollama, render configs, launch Pi |
+| `models.json` | VM | Pi provider config → host agent Ollama (`__HOST_OLLAMA__` templated) |
+| `decant-config.yaml` | VM | decant config → VM-local Ollama (`__BRAVE_KEY__` templated) |
+
+The split: the **agent** model (`qwen3.6:35b`) runs on the host GPU; **decant's**
+distill model (`gemma4:e2b`) runs CPU-only inside the VM so web content stays in
+the box. The only VM→host network path is Pi reaching the agent model.

--- a/scripts/pi-vm/build.sh
+++ b/scripts/pi-vm/build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Pure build: stage the local Bartleby + decant source into a clean context and
+# build the research-VM image with Apple `container`. Re-run whenever Bartleby
+# or decant changes (pure build means no live source mount).
+#
+# Env:
+#   DECANT_SRC   path to the decant repo      (default: ~/Code/decant)
+#   IMAGE        image tag                     (default: bartleby-pi:latest)
+#   DECANT_MODEL distill model baked into VM   (default: gemma4:e2b)
+#
+# See docs/pi-vm-runbook.md.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/.." && pwd)"          # bartleby repo root
+DECANT_SRC="${DECANT_SRC:-${HOME}/Code/decant}"
+IMAGE="${IMAGE:-bartleby-pi:latest}"
+DECANT_MODEL="${DECANT_MODEL:-gemma4:e2b}"
+
+command -v container >/dev/null || {
+  echo "Apple 'container' not found. Install with: brew install container" >&2
+  exit 1
+}
+[ -d "${DECANT_SRC}" ] || {
+  echo "decant source not found at ${DECANT_SRC}; set DECANT_SRC." >&2
+  exit 1
+}
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "${STAGE}"' EXIT
+echo "Staging build context in ${STAGE} ..." >&2
+
+EXCLUDES=(--exclude '.git' --exclude '.venv' --exclude '__pycache__'
+          --exclude '.pytest_cache' --exclude 'node_modules')
+
+rsync -a "${EXCLUDES[@]}" \
+      --exclude 'benchmarks/results' --exclude 'benchmarks/judgements' \
+      "${REPO_ROOT}/" "${STAGE}/bartleby/"
+rsync -a "${EXCLUDES[@]}" "${DECANT_SRC}/" "${STAGE}/decant/"
+
+# pi-vm/ holds the Containerfile + configs + entrypoint the Containerfile COPYs.
+mkdir -p "${STAGE}/pi-vm"
+cp "${HERE}/models.json" "${HERE}/decant-config.yaml" "${HERE}/entrypoint.sh" \
+   "${STAGE}/pi-vm/"
+cp "${HERE}/Containerfile" "${STAGE}/Containerfile"
+
+echo "Building ${IMAGE} (DECANT_MODEL=${DECANT_MODEL}) ..." >&2
+container build \
+  --build-arg "DECANT_MODEL=${DECANT_MODEL}" \
+  -t "${IMAGE}" \
+  -f "${STAGE}/Containerfile" \
+  "${STAGE}"
+
+echo "Built ${IMAGE}. Next: ./scripts/pi-vm/run.sh" >&2

--- a/scripts/pi-vm/decant-config.yaml
+++ b/scripts/pi-vm/decant-config.yaml
@@ -1,0 +1,14 @@
+# decant config rendered into ~/.decant/config.yaml by entrypoint.sh.
+# Points at the VM-LOCAL Ollama (CPU) so raw web content never leaves the box.
+contact_email: bartleby-pi-vm@localhost
+ollama:
+  host: http://127.0.0.1:11434
+  model: gemma4:e2b
+  request_timeout_s: 300
+cache:
+  ttl_hours: 24
+fetch:
+  request_timeout_s: 60
+search:
+  # Rendered from $BRAVE_SEARCH_API_KEY at container start; `null` = no web search.
+  brave_api_key: __BRAVE_KEY__

--- a/scripts/pi-vm/entrypoint.sh
+++ b/scripts/pi-vm/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# In-VM entrypoint. Runs inside the Apple `container` Linux guest.
+#   1. start the VM-local Ollama (CPU) that serves decant's distill model
+#   2. detect the host bridge IP so Pi can reach the host agent Ollama
+#   3. render Pi's models.json (-> host :11435) and decant's config (-> VM-local)
+#   4. hand off to Pi (interactive) or whatever command was passed
+#
+# See docs/pi-vm-runbook.md.
+set -euo pipefail
+
+# 1. VM-local Ollama (serves decant's small model, CPU-only — expected).
+ollama serve >/tmp/ollama.log 2>&1 &
+until ollama list >/dev/null 2>&1; do sleep 0.5; done
+
+# 2. Host bridge IP. Apple `container` has no host.docker.internal; the default
+#    gateway points at the host bridge. Override with HOST_OLLAMA_IP if wrong.
+HOST_IP="${HOST_OLLAMA_IP:-$(ip route 2>/dev/null | awk '/default/ {print $3; exit}')}"
+AGENT_PORT="${AGENT_OLLAMA_PORT:-11435}"
+if [ -z "${HOST_IP}" ]; then
+  echo "WARN: could not detect host gateway IP; set HOST_OLLAMA_IP." >&2
+  HOST_IP="127.0.0.1"
+fi
+
+# 3a. Pi -> host agent Ollama.
+mkdir -p /root/.pi/agent
+sed "s|__HOST_OLLAMA__|http://${HOST_IP}:${AGENT_PORT}/v1|g" \
+    /opt/pi-vm/models.json > /root/.pi/agent/models.json
+
+# 3b. decant -> VM-local Ollama. Brave key from env if provided, else null.
+mkdir -p /root/.decant
+sed "s|__BRAVE_KEY__|${BRAVE_SEARCH_API_KEY:-null}|g" \
+    /opt/pi-vm/decant-config.yaml > /root/.decant/config.yaml
+
+echo "Pi agent model -> http://${HOST_IP}:${AGENT_PORT}  |  decant -> VM-local Ollama" >&2
+
+# 4. Hand off.
+if [ "$#" -eq 0 ]; then
+  exec pi
+else
+  exec "$@"
+fi

--- a/scripts/pi-vm/host-agent-ollama.sh
+++ b/scripts/pi-vm/host-agent-ollama.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Host-side: launch a DEDICATED Ollama instance for the Pi agent, separate from
+# your daily-driver Ollama on :11434. This one runs on the Apple GPU (Metal) and
+# serves the big agent model fast. It is a distinct process/port, so it does not
+# touch your interactive Ollama and can be stopped independently.
+#
+# It binds to 0.0.0.0 so the Apple `container` VM can reach it (Apple container
+# has no host.docker.internal). That also exposes it to your LAN — enable the
+# macOS firewall or bind to the vmnet bridge IP if that matters to you.
+#
+# See docs/pi-vm-runbook.md.
+set -euo pipefail
+
+PORT="${AGENT_OLLAMA_PORT:-11435}"
+MODEL="${AGENT_MODEL:-qwen3.6:35b}"
+BIND="${AGENT_OLLAMA_BIND:-0.0.0.0:${PORT}}"
+
+command -v ollama >/dev/null || { echo "ollama not found on PATH" >&2; exit 1; }
+
+echo "Starting dedicated agent Ollama on ${BIND} (model: ${MODEL})..." >&2
+OLLAMA_HOST="${BIND}" ollama serve &
+SRV=$!
+trap 'kill "${SRV}" 2>/dev/null || true' EXIT INT TERM
+
+# Wait for the server, then make sure the model is present (instant if the blob
+# is already in your shared ~/.ollama model store).
+until OLLAMA_HOST="${BIND}" ollama list >/dev/null 2>&1; do sleep 0.5; done
+OLLAMA_HOST="${BIND}" ollama pull "${MODEL}"
+
+echo "Agent Ollama ready on ${BIND}. Leave this running; Ctrl-C to stop." >&2
+wait "${SRV}"

--- a/scripts/pi-vm/models.json
+++ b/scripts/pi-vm/models.json
@@ -1,0 +1,13 @@
+{
+  "providers": {
+    "ollama-agent": {
+      "baseUrl": "__HOST_OLLAMA__",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "compat": { "supportsDeveloperRole": false },
+      "models": [
+        { "id": "qwen3.6:35b" }
+      ]
+    }
+  }
+}

--- a/scripts/pi-vm/run.sh
+++ b/scripts/pi-vm/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Launch the research VM. Mounts ONLY the corpus dir (read-write — the agent
+# writes findings/tags through Bartleby's typed helpers). Everything else (Pi,
+# Bartleby, decant, the distill model) is baked into the image.
+#
+# Prereq: the host agent Ollama must be running first:
+#   ./scripts/pi-vm/host-agent-ollama.sh
+#
+# Env:
+#   IMAGE               image tag           (default: bartleby-pi:latest)
+#   BARTLEBY_HOME       host corpus root    (default: ~/.bartleby)
+#   AGENT_OLLAMA_PORT   host agent port     (default: 11435)
+#   HOST_OLLAMA_IP      override gateway autodetect (optional)
+#   BRAVE_SEARCH_API_KEY  passed through for `decant search` (optional)
+#
+# Pass a command to run instead of interactive Pi, e.g.:
+#   ./run.sh pi -p "Summarize project X"
+#   ./run.sh bash
+#
+# See docs/pi-vm-runbook.md.
+set -euo pipefail
+
+IMAGE="${IMAGE:-bartleby-pi:latest}"
+CORPUS="${BARTLEBY_HOME:-${HOME}/.bartleby}"
+AGENT_PORT="${AGENT_OLLAMA_PORT:-11435}"
+
+command -v container >/dev/null || {
+  echo "Apple 'container' not found. Install with: brew install container" >&2
+  exit 1
+}
+[ -d "${CORPUS}" ] || {
+  echo "Corpus dir ${CORPUS} not found; set BARTLEBY_HOME to your corpus root." >&2
+  exit 1
+}
+
+ARGS=(run -it --rm --name bartleby-pi
+      -v "${CORPUS}:/corpus"
+      -e "AGENT_OLLAMA_PORT=${AGENT_PORT}")
+[ -n "${HOST_OLLAMA_IP:-}" ]      && ARGS+=(-e "HOST_OLLAMA_IP=${HOST_OLLAMA_IP}")
+[ -n "${BRAVE_SEARCH_API_KEY:-}" ] && ARGS+=(-e "BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY}")
+
+exec container "${ARGS[@]}" "${IMAGE}" "$@"


### PR DESCRIPTION
## What

Documents and scripts a way to run the Bartleby research skill with [Pi](https://pi.dev) + local Ollama models **inside an isolated Apple `container` VM**, so Pi's unsandboxed `bash` tool never touches the host.

## Why

Pi is a minimal harness: four core tools (`read`/`write`/`edit`/`bash`) and **no permission gates or sandboxing by default**. Driving it with a local model hands that model a shell on whatever machine Pi runs on — with neither Claude-grade alignment nor a permission system in front of `bash`. The VM is the substitute.

## Design

- **Agent model (`qwen3.6:35b`) stays on the host GPU** as a *dedicated* Ollama instance on `:11435`, separate from the daily-driver `:11434`. Linux guests get no Metal passthrough on Apple Silicon, so in-VM inference would be CPU-only — we isolate the *agent*, not the *inference*.
- **decant's distill model (`gemma4:e2b`) runs CPU-only inside the VM**, so raw fetched web content never leaves the box. The only VM→host path is Pi reaching the agent model.
- **Only the corpus (`~/.bartleby`) is mounted**, read-write. Pure build (Pi + Bartleby + decant + distill model baked in) means the agent never sees the tool source.
- Model picks come from `bartleby benchmark`, with the caveat that the benchmark measures *summarization*, not multi-turn tool-calling — hence `qwen3.6:35b` (steadier tool-caller, ~3.7× faster than `gemma4:31b`) for the agent.

## Contents

- `docs/pi-vm-runbook.md` — rationale, topology, security posture (incl. the decant web-egress trade-off), step-by-step, Apple `container` networking note, shakeout notes.
- `scripts/pi-vm/` — `host-agent-ollama.sh`, `build.sh`, `Containerfile`, `entrypoint.sh`, `run.sh`, `models.json` + `decant-config.yaml` templates, quickstart README.
- README link under *Running fully local*.

## Status / caveats

**First-draft, not yet shaken out end-to-end** (`container` isn't installed locally; a build is network-heavy). Three spots flagged inline that may need adjustment on first run: Apple `container` host-networking (reaching the host Ollama), where the Pi installer puts `pi` on `PATH`, and the in-build `ollama pull`.

## Validation

- Shell scripts pass `bash -n`; `models.json` / `decant-config.yaml` parse clean.
- Full suite green: **1129 passed** (docs + shell only — no Python touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)