### PR TITLE
Fix Pi-VM build (zstd) + run.sh reads Brave key from decant config

### DIFF
--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -137,7 +137,9 @@ is left as a follow-up; the filesystem boundary is the load-bearing protection.
   (`ollama pull qwen3.6:35b` — `gemma4:e2b` is re-pulled inside the VM at build
   time, so the host copy is optional).
 - A **Brave Search API key** if you want `decant search` (not needed for
-  `decant url`). Pass it as `BRAVE_SEARCH_API_KEY`.
+  `decant url`). Pass it as `BRAVE_SEARCH_API_KEY`, or leave it in your host
+  `~/.decant/config.yaml` — `run.sh` reads the value from there as a fallback
+  (the config file itself is never mounted into the box).
 - The **decant** source at `~/Code/decant` (override with `DECANT_SRC`).
 
 ## The Apple `container` networking note

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -6,7 +6,7 @@ FROM debian:trixie-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl git iproute2 tesseract-ocr \
+      ca-certificates curl git iproute2 tesseract-ocr zstd \
       python3 python3-venv \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/pi-vm/run.sh
+++ b/scripts/pi-vm/run.sh
@@ -12,7 +12,9 @@
 #   BARTLEBY_HOME       host corpus root    (default: ~/.bartleby)
 #   AGENT_OLLAMA_PORT   host agent port     (default: 11435)
 #   HOST_OLLAMA_IP      override gateway autodetect (optional)
-#   BRAVE_SEARCH_API_KEY  passed through for `decant search` (optional)
+#   BRAVE_SEARCH_API_KEY  passed through for `decant search` (optional). If unset,
+#                       falls back to brave_api_key in your host decant config
+#                       (~/.decant/config.yaml, or $DECANT_CONFIG).
 #
 # Pass a command to run instead of interactive Pi, e.g.:
 #   ./run.sh pi -p "Summarize project X"
@@ -34,10 +36,21 @@ command -v container >/dev/null || {
   exit 1
 }
 
+# Brave key: an explicit BRAVE_SEARCH_API_KEY wins; otherwise read the value out
+# of the host decant config so you needn't re-export it. We pass only the value
+# as an env var — the host config file is never mounted into the box.
+BRAVE_KEY="${BRAVE_SEARCH_API_KEY:-}"
+DECANT_CFG="${DECANT_CONFIG:-${HOME}/.decant/config.yaml}"
+if [ -z "${BRAVE_KEY}" ] && [ -f "${DECANT_CFG}" ]; then
+  BRAVE_KEY="$(sed -n 's/^[[:space:]]*brave_api_key:[[:space:]]*//p' "${DECANT_CFG}" \
+               | head -1 | tr -d ' "')"
+  case "${BRAVE_KEY}" in null|"~") BRAVE_KEY="" ;; esac   # YAML null -> no key
+fi
+
 ARGS=(run -it --rm --name bartleby-pi
       -v "${CORPUS}:/corpus"
       -e "AGENT_OLLAMA_PORT=${AGENT_PORT}")
-[ -n "${HOST_OLLAMA_IP:-}" ]      && ARGS+=(-e "HOST_OLLAMA_IP=${HOST_OLLAMA_IP}")
-[ -n "${BRAVE_SEARCH_API_KEY:-}" ] && ARGS+=(-e "BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY}")
+[ -n "${HOST_OLLAMA_IP:-}" ] && ARGS+=(-e "HOST_OLLAMA_IP=${HOST_OLLAMA_IP}")
+[ -n "${BRAVE_KEY}" ]        && ARGS+=(-e "BRAVE_SEARCH_API_KEY=${BRAVE_KEY}")
 
 exec container "${ARGS[@]}" "${IMAGE}" "$@"


### PR DESCRIPTION
Two fixes found during the Pi-in-VM shakedown.

## 1. Build failed: Ollama installer needs `zstd`
`curl … ollama.com/install.sh | sh` now aborts with "This version requires zstd for extraction"; `debian:trixie-slim` doesn't ship `zstd`. Added it to the first `apt-get install`.

## 2. `run.sh`: fall back to the Brave key in the host decant config
When `BRAVE_SEARCH_API_KEY` isn't set, `run.sh` now reads `brave_api_key` from the host `~/.decant/config.yaml` (or `$DECANT_CONFIG`) so you don't have to re-export it.

**Safety:** only the *value* is passed as an env var — the host config file is **never mounted** into the container (no host-filesystem hole, and decant still uses the VM-local Ollama). An explicit env var wins; a YAML `null`/empty key leaves search disabled. The key's blast radius is small (rate-limited search API, rotatable) and it would be in the box regardless.

## Validation
- `run.sh` passes `bash -n`; key-parse logic checked against plain / quoted / `null` / empty configs.
- Full suite green: **1129 passed**.

Runbook prereqs updated to mention the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)