### PR TITLE
Install Pi via npm on a Node base (curl installer needs a TTY)

### DIFF
--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -219,11 +219,12 @@ pi --help            # confirm `pi` is on PATH; see shakeout note if not
 
 ## Shakeout notes (things to confirm on first run)
 
-- **`pi` on `PATH`.** The curl installer (`https://pi.dev/install.sh`) may drop
-  the binary somewhere not on the default `PATH`. If `pi` isn't found, either
-  symlink it into `/usr/local/bin` in the `Containerfile` or switch to the npm
-  install (`npm install -g --ignore-scripts @earendil-works/pi-coding-agent`,
-  which needs Node in the image).
+- **`pi` on `PATH`.** The image installs Pi via npm
+  (`npm install -g --ignore-scripts @earendil-works/pi-coding-agent`) on a
+  `node:22` base — the `pi.dev/install.sh` script needs a TTY and won't run in a
+  non-interactive build. The global npm install puts `pi` in `/usr/local/bin`
+  (on `PATH`). If `pi` isn't found at runtime, confirm the global npm bin dir is
+  on `PATH` (`npm root -g` / `npm bin -g`).
 - **In-build model pull.** The `Containerfile` runs `ollama serve` in the
   background during build to `ollama pull gemma4:e2b`. If that's flaky, move the
   pull to `entrypoint.sh` (first-run) backed by a persistent volume — at the

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -2,7 +2,9 @@
 # decant's distill model. The big agent model runs on the HOST GPU; see
 # docs/pi-vm-runbook.md. The build context is assembled by build.sh, which
 # stages the Bartleby and decant source trees next to this file.
-FROM debian:trixie-slim
+# Node base: guarantees Node >=22.19 + npm for the Pi install, and is still
+# Debian/apt underneath so the rest of this file is unchanged.
+FROM node:22-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,9 +19,10 @@ ENV PATH="/root/.local/bin:${PATH}"
 # Ollama (Linux). CPU-only inside the VM — used solely for decant's small model.
 RUN curl -fsSL https://ollama.com/install.sh | sh
 
-# Pi coding agent. NOTE: confirm `pi` lands on PATH; see runbook shakeout notes.
-# (Alternative: npm install -g --ignore-scripts @earendil-works/pi-coding-agent)
-RUN curl -fsSL https://pi.dev/install.sh | sh
+# Pi coding agent via npm. The pi.dev/install.sh script needs a TTY, so it can't
+# run in a non-interactive build; npm is the headless path. `pi` lands on PATH
+# at /usr/local/bin. --ignore-scripts is what Pi's own docs recommend.
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 
 # --- Bartleby + decant from staged local source (pure build) ---
 COPY bartleby/ /opt/bartleby/


### PR DESCRIPTION
Next shakedown reef: the Pi install step failed.

## Problem
`curl -fsSL https://pi.dev/install.sh | sh` aborts in the container build with:
> No terminal detected; install Node.js 22.19.0 or newer and npm, then run this installer again.

The curl installer is TTY/interactive — no good in a non-interactive build.

## Fix
- **`FROM node:22-bookworm-slim`** (was `debian:trixie-slim`) — guarantees Node ≥22.19 + npm, and it's still Debian/apt underneath, so every other build step (apt deps, uv, ollama, tesseract) is unchanged.
- Install Pi headlessly: **`npm install -g --ignore-scripts @earendil-works/pi-coding-agent`** (the flag Pi's docs recommend). `pi` lands on `PATH` at `/usr/local/bin`.

Confirms shakeout-note #1 in the runbook, which is updated to describe the npm-by-design install.

## Validation
Full suite green: **1129 passed**. (Couldn't build the image here — `container` isn't installed on this machine — so build-green confirmation comes from the shakedown re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)