### PR TITLE
pi-vm: AGENT_MODEL/VM_MEMORY runtime knobs + runbook fixes

### DIFF
--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -91,6 +91,19 @@ The benchmark ranks models on a *summarization* task. Top local finishers:
   `gemma4:e2b` at 4.69/5 and ~585 tok/s is the ideal distill model — and small
   enough to tolerate CPU-only inference in the VM.
 
+**Trying a different agent model.** The agent model is a *runtime* knob — set
+`AGENT_MODEL` on **both** the host serve and the run (no rebuild; it must match a
+model your host Ollama serves):
+
+```bash
+AGENT_MODEL=gpt-oss:120b ./scripts/pi-vm/host-agent-ollama.sh   # host GPU serves it
+AGENT_MODEL=gpt-oss:120b ./scripts/pi-vm/run.sh                 # Pi requests it
+```
+
+Defaults to `qwen3.6:35b` if unset. (decant's distill model is a *build-time*
+knob instead — `DECANT_MODEL=<model> ./scripts/pi-vm/build.sh` — since it's baked
+into the image.)
+
 ## Security posture
 
 What this buys you, and what it doesn't:
@@ -207,6 +220,29 @@ BRAVE_SEARCH_API_KEY=brv-... ./scripts/pi-vm/run.sh
 Inside the VM, Pi sees the Bartleby skill (installed to `~/.pi/agent/skills/`
 at build time) and drives it against `/corpus` exactly as Claude Code would.
 
+A couple of things to expect while running these:
+
+- **Step 0, first run:** `container system start` reports "No default kernel
+  configured" and offers to download the recommended guest Linux kernel (the
+  Kata Containers static kernel) — answer `Y` (one-time; the Linux VM needs a
+  kernel).
+- **Step 1 stays running:** `host-agent-ollama.sh` runs `ollama serve` in the
+  **foreground**, so keep it in its own terminal window for the whole session
+  (`Ctrl-C` stops it). On macOS it also surfaces the Ollama desktop/menu-bar app
+  — that's your *daily-driver* `:11434` instance; leave it running (our agent
+  instance is the separate `:11435` process in the terminal). During a session
+  you'll have both alive — different ports, no conflict, shared model store.
+- **Which project?** Pi acts on Bartleby's active project. Set it on the host
+  first with `bartleby project use <name>` — it's stored in
+  `~/.bartleby/config.yaml`, which is shared into the VM via the `/corpus` mount,
+  so the agent inherits it (or pass `--project <name>` on a skill call to
+  override per-call).
+- **Give the VM real RAM.** Apple `container` defaults a guest to **1 GB**, which
+  is far too small here — embeddings (CPU-only in the guest) plus a multi-GB
+  corpus DB will thrash it until it wedges at 100% CPU and the runtime auto-removes
+  it (`--rm`). `run.sh` sets `-m 8g` by default; raise it for heavy ingest with
+  `VM_MEMORY=16g ./scripts/pi-vm/run.sh`. You have 128 GB — don't starve it.
+
 ## Verifying the wiring
 
 Once you're in the container shell (`./scripts/pi-vm/run.sh bash`):
@@ -243,7 +279,50 @@ pi --help            # confirm `pi` is on PATH; see shakeout note if not
 - **Gateway detection.** If `ip route` inside the VM doesn't yield a
   host-reachable address, set `HOST_OLLAMA_IP` explicitly (see networking note).
 - **`container system start`.** Apple `container` needs its runtime started once
-  per boot before `build`/`run`.
+  per boot before `build`/`run`, and may need a moment to settle — if `build` or
+  `run` errors with `XPC connection error: Connection invalid`, the runtime
+  wasn't up yet; just re-run.
+
+## Viewing findings while the agent runs
+
+If you browse the corpus with `bartleby serve` **on the host** while the VM agent
+is working the same project, expect intermittent `500`s —
+`SqliteError: database disk image is malformed`. Your data is **not** corrupt;
+it's a SQLite WAL limitation. Bartleby opens corpus DBs in **WAL mode**, whose
+write-ahead index lives in a shared-memory sidecar (`bartleby.db-shm`) that is
+only coherent *within one kernel*. With the agent (Linux guest) holding the DB
+read-write over the `/corpus` mount **and** the host `bartleby serve` reading it
+at the same time, two kernels share one WAL DB — which SQLite explicitly does not
+support. The host reader sees the guest's wal-index as garbage and reports
+"malformed." It clears the moment the agent's writes are checkpointed (`-wal`
+back to `0` bytes).
+
+Practical rule: **don't drive the host viewer against a project the VM agent is
+actively writing.** View between runs, or refresh once the agent is idle. (There
+is no clean reader-side fix — `better-sqlite3`, which the web UI uses, doesn't
+support SQLite's `immutable=1` URI escape hatch.)
+
+## Disk & cleanup
+
+The **container** is disposable — `run.sh` uses `--rm`, so `Ctrl-C` removes the
+running VM and no stopped containers pile up. The **image** is the disk cost: it's
+large (~10–15 GB — the baked `gemma4:e2b` plus Node/Ollama/deps) and persists by
+design. Each `build.sh` re-tags `:latest` and **orphans the previous image's
+layers**, which are *not* auto-cleaned, so repeated rebuilds stack up multi-GB
+ghosts.
+
+Reclaim space (verify the verbs with `container --help` — the CLI is young):
+
+```bash
+container images ls                          # what's on disk
+container images delete bartleby-pi:latest   # delete by name — the reliable way
+container ls -a                              # stopped containers (should be none; --rm)
+```
+
+Don't rely on `container image prune` to reclaim the big images — it's
+[known-buggy](https://github.com/apple/container/issues/901) (removes only
+orphaned blobs, not whole images). Simplest habit: `container images delete
+bartleby-pi:latest` before a fresh rebuild.
 
 ## Files
 

--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -140,7 +140,9 @@ is left as a follow-up; the filesystem boundary is the load-bearing protection.
   `decant url`). Pass it as `BRAVE_SEARCH_API_KEY`, or leave it in your host
   `~/.decant/config.yaml` — `run.sh` reads the value from there as a fallback
   (the config file itself is never mounted into the box).
-- The **decant** source at `~/Code/decant` (override with `DECANT_SRC`).
+
+No local Bartleby/decant checkout is needed — the build pulls both from GitHub
+(Bartleby's latest release tag, decant's `main`).
 
 ## The Apple `container` networking note
 
@@ -170,8 +172,17 @@ distill model + both configs, and mounts *only* the corpus. The alternative
 (bind-mounting the Bartleby/decant source for live editing) was rejected because
 it would let the agent see and modify your tool source, which partly defeats the
 isolation. Pure build gives a reproducible, disposable image and the tightest
-blast radius. The cost is a rebuild when Bartleby or decant changes — run
-`build.sh` again.
+blast radius.
+
+Bartleby and decant are pulled **from GitHub at build time** — Bartleby's latest
+release tag (resolved via `git ls-remote`) and decant's `main` — not from your
+local working copy. That keeps the build context tiny and the image pinned to
+*published* code, which is the right default for a VM whose job is to *run*
+research over an already-ingested corpus (ingestion happens on the host, so the
+image needs no `[docling]`/`[sec2md]` extras). The trade-off: the VM runs
+published versions, not your in-flight local edits to Bartleby/decant — to test
+those you'd push/release first. Re-run `build.sh` to pick up a newer release or
+newer decant `main`.
 
 ## Step by step
 
@@ -183,7 +194,7 @@ container system start          # starts the container runtime
 # 1. host: start the dedicated agent Ollama (GPU), separate from your daily one
 ./scripts/pi-vm/host-agent-ollama.sh          # serves qwen3.6:35b on :11435
 
-# 2. build the research-VM image (stages bartleby + ~/Code/decant source)
+# 2. build the research-VM image (pulls Bartleby release + decant main from GitHub)
 ./scripts/pi-vm/build.sh                       # -> bartleby-pi:latest
 
 # 3. run it — mounts ~/.bartleby as /corpus, drops you into Pi
@@ -239,7 +250,7 @@ pi --help            # confirm `pi` is on PATH; see shakeout note if not
 | File | Role |
 | --- | --- |
 | [`scripts/pi-vm/host-agent-ollama.sh`](../scripts/pi-vm/host-agent-ollama.sh) | Host: dedicated agent Ollama on `:11435` (GPU) |
-| [`scripts/pi-vm/build.sh`](../scripts/pi-vm/build.sh) | Stage source + build the image (pure build) |
+| [`scripts/pi-vm/build.sh`](../scripts/pi-vm/build.sh) | Build the image (pulls Bartleby release + decant main from GitHub) |
 | [`scripts/pi-vm/Containerfile`](../scripts/pi-vm/Containerfile) | The research-VM image |
 | [`scripts/pi-vm/entrypoint.sh`](../scripts/pi-vm/entrypoint.sh) | In-VM: start local Ollama, render configs, launch Pi |
 | [`scripts/pi-vm/run.sh`](../scripts/pi-vm/run.sh) | Run the VM, mount the corpus |

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -1,7 +1,7 @@
 # Pure-build research VM: Pi + Bartleby + decant + a VM-local Ollama (CPU) for
 # decant's distill model. The big agent model runs on the HOST GPU; see
-# docs/pi-vm-runbook.md. The build context is assembled by build.sh, which
-# stages the Bartleby and decant source trees next to this file.
+# docs/pi-vm-runbook.md. Bartleby and decant are pulled from GitHub (not local
+# source), so the build context is just this directory (scripts/pi-vm/).
 # Node base: guarantees Node >=22.19 + npm for the Pi install, and is still
 # Debian/apt underneath so the rest of this file is unchanged.
 FROM node:22-bookworm-slim
@@ -24,11 +24,15 @@ RUN curl -fsSL https://ollama.com/install.sh | sh
 # at /usr/local/bin. --ignore-scripts is what Pi's own docs recommend.
 RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 
-# --- Bartleby + decant from staged local source (pure build) ---
-COPY bartleby/ /opt/bartleby/
-COPY decant/   /opt/decant/
-RUN uv tool install /opt/bartleby \
-    && uv tool install /opt/decant
+# --- Bartleby (latest release tag) + decant (main), pulled from GitHub ---
+# Both repos are public over HTTPS, so no auth in the build. Ingestion runs on
+# the HOST, so the VM needs no [docling]/[sec2md] extras — the agent only
+# searches/reads/cites an already-ingested corpus.
+RUN BARTLEBY_REF="$(git ls-remote --tags --refs https://github.com/jswest/bartleby.git 'v*' \
+                    | awk -F/ '{print $NF}' | sort -V | tail -1)" \
+    && echo "Installing bartleby ${BARTLEBY_REF}, decant@main" \
+    && uv tool install "git+https://github.com/jswest/bartleby.git@${BARTLEBY_REF}" \
+    && uv tool install "git+https://github.com/jswest/decant.git@main"
 
 # Install the Bartleby skill where Pi discovers skills.
 RUN bartleby ready --dest /root/.pi/agent/skills --force
@@ -39,10 +43,10 @@ RUN ollama serve >/tmp/ollama-build.log 2>&1 & \
     until ollama list >/dev/null 2>&1; do sleep 0.5; done; \
     ollama pull "${DECANT_MODEL}"
 
-# Config templates + entrypoint.
-COPY pi-vm/models.json        /opt/pi-vm/models.json
-COPY pi-vm/decant-config.yaml /opt/pi-vm/decant-config.yaml
-COPY pi-vm/entrypoint.sh      /usr/local/bin/entrypoint.sh
+# Config templates + entrypoint (build context is scripts/pi-vm/ itself).
+COPY models.json        /opt/pi-vm/models.json
+COPY decant-config.yaml /opt/pi-vm/decant-config.yaml
+COPY entrypoint.sh      /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Bartleby's corpus root inside the VM (mounted by run.sh).

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -36,6 +36,7 @@ RUN BARTLEBY_REF="$(git ls-remote --tags --refs https://github.com/jswest/bartle
 
 # Install the Bartleby skill where Pi discovers skills.
 RUN bartleby ready --dest /root/.pi/agent/skills --force
+RUN HF_HUB_OFFLINE=0 bartleby embed "warmup" >/dev/null
 
 # Bake decant's distill model into the image (pure build = reproducible/offline).
 ARG DECANT_MODEL=gemma4:e2b

--- a/scripts/pi-vm/README.md
+++ b/scripts/pi-vm/README.md
@@ -22,7 +22,7 @@ BRAVE_SEARCH_API_KEY=brv-... ./run.sh              # mount ~/.bartleby, launch P
 | File | Side | Role |
 | --- | --- | --- |
 | `host-agent-ollama.sh` | host | Dedicated agent Ollama on `:11435` (GPU), separate from your daily `:11434` |
-| `build.sh` | host | Stage Bartleby + decant source, build `bartleby-pi:latest` |
+| `build.sh` | host | Build `bartleby-pi:latest` (pulls Bartleby release + decant main from GitHub) |
 | `Containerfile` | — | The research-VM image (Pi + Bartleby + decant + VM-local Ollama) |
 | `run.sh` | host | Run the VM, mount the corpus read-write |
 | `entrypoint.sh` | VM | Start local Ollama, render configs, launch Pi |

--- a/scripts/pi-vm/build.sh
+++ b/scripts/pi-vm/build.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Pure build: stage the local Bartleby + decant source into a clean context and
-# build the research-VM image with Apple `container`. Re-run whenever Bartleby
-# or decant changes (pure build means no live source mount).
+# Build the research-VM image with Apple `container`. Bartleby (latest release
+# tag) and decant (main) are pulled from GitHub inside the build, so there's no
+# local source to stage — the build context is just this directory. Re-run to
+# pick up a newer Bartleby release / newer decant main.
 #
 # Env:
-#   DECANT_SRC   path to the decant repo      (default: ~/Code/decant)
 #   IMAGE        image tag                     (default: bartleby-pi:latest)
 #   DECANT_MODEL distill model baked into VM   (default: gemma4:e2b)
 #
@@ -13,8 +13,6 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "${HERE}/.." && pwd)"          # bartleby repo root
-DECANT_SRC="${DECANT_SRC:-${HOME}/Code/decant}"
 IMAGE="${IMAGE:-bartleby-pi:latest}"
 DECANT_MODEL="${DECANT_MODEL:-gemma4:e2b}"
 
@@ -22,34 +20,12 @@ command -v container >/dev/null || {
   echo "Apple 'container' not found. Install with: brew install container" >&2
   exit 1
 }
-[ -d "${DECANT_SRC}" ] || {
-  echo "decant source not found at ${DECANT_SRC}; set DECANT_SRC." >&2
-  exit 1
-}
 
-STAGE="$(mktemp -d)"
-trap 'rm -rf "${STAGE}"' EXIT
-echo "Staging build context in ${STAGE} ..." >&2
-
-EXCLUDES=(--exclude '.git' --exclude '.venv' --exclude '__pycache__'
-          --exclude '.pytest_cache' --exclude 'node_modules')
-
-rsync -a "${EXCLUDES[@]}" \
-      --exclude 'benchmarks/results' --exclude 'benchmarks/judgements' \
-      "${REPO_ROOT}/" "${STAGE}/bartleby/"
-rsync -a "${EXCLUDES[@]}" "${DECANT_SRC}/" "${STAGE}/decant/"
-
-# pi-vm/ holds the Containerfile + configs + entrypoint the Containerfile COPYs.
-mkdir -p "${STAGE}/pi-vm"
-cp "${HERE}/models.json" "${HERE}/decant-config.yaml" "${HERE}/entrypoint.sh" \
-   "${STAGE}/pi-vm/"
-cp "${HERE}/Containerfile" "${STAGE}/Containerfile"
-
-echo "Building ${IMAGE} (DECANT_MODEL=${DECANT_MODEL}) ..." >&2
+echo "Building ${IMAGE} (bartleby=latest release, decant=main, DECANT_MODEL=${DECANT_MODEL}) ..." >&2
 container build \
   --build-arg "DECANT_MODEL=${DECANT_MODEL}" \
   -t "${IMAGE}" \
-  -f "${STAGE}/Containerfile" \
-  "${STAGE}"
+  -f "${HERE}/Containerfile" \
+  "${HERE}"
 
 echo "Built ${IMAGE}. Next: ./scripts/pi-vm/run.sh" >&2

--- a/scripts/pi-vm/entrypoint.sh
+++ b/scripts/pi-vm/entrypoint.sh
@@ -22,9 +22,11 @@ if [ -z "${HOST_IP}" ]; then
   HOST_IP="127.0.0.1"
 fi
 
-# 3a. Pi -> host agent Ollama.
+# 3a. Pi -> host agent Ollama (model id overridable via AGENT_MODEL).
+AGENT_MODEL="${AGENT_MODEL:-qwen3.6:35b}"
 mkdir -p /root/.pi/agent
-sed "s|__HOST_OLLAMA__|http://${HOST_IP}:${AGENT_PORT}/v1|g" \
+sed -e "s|__HOST_OLLAMA__|http://${HOST_IP}:${AGENT_PORT}/v1|g" \
+    -e "s|__AGENT_MODEL__|${AGENT_MODEL}|g" \
     /opt/pi-vm/models.json > /root/.pi/agent/models.json
 
 # 3b. decant -> VM-local Ollama. Brave key from env if provided, else null.
@@ -32,7 +34,7 @@ mkdir -p /root/.decant
 sed "s|__BRAVE_KEY__|${BRAVE_SEARCH_API_KEY:-null}|g" \
     /opt/pi-vm/decant-config.yaml > /root/.decant/config.yaml
 
-echo "Pi agent model -> http://${HOST_IP}:${AGENT_PORT}  |  decant -> VM-local Ollama" >&2
+echo "Pi -> ${AGENT_MODEL} @ http://${HOST_IP}:${AGENT_PORT}  |  decant -> VM-local Ollama" >&2
 
 # 4. Hand off.
 if [ "$#" -eq 0 ]; then

--- a/scripts/pi-vm/models.json
+++ b/scripts/pi-vm/models.json
@@ -6,7 +6,7 @@
       "apiKey": "ollama",
       "compat": { "supportsDeveloperRole": false },
       "models": [
-        { "id": "qwen3.6:35b" }
+        { "id": "__AGENT_MODEL__" }
       ]
     }
   }

--- a/scripts/pi-vm/run.sh
+++ b/scripts/pi-vm/run.sh
@@ -10,7 +10,13 @@
 # Env:
 #   IMAGE               image tag           (default: bartleby-pi:latest)
 #   BARTLEBY_HOME       host corpus root    (default: ~/.bartleby)
+#   VM_MEMORY           guest RAM            (default: 8g). Apple container's 1 GB
+#                       default is too small — the guest thrashes (and can wedge
+#                       at 100% CPU) under embeddings + a large corpus DB. Bump it.
 #   AGENT_OLLAMA_PORT   host agent port     (default: 11435)
+#   AGENT_MODEL         Pi's model id       (default: qwen3.6:35b). Must match a
+#                       model served by the host agent Ollama (host-agent-ollama.sh
+#                       honors the same var).
 #   HOST_OLLAMA_IP      override gateway autodetect (optional)
 #   BRAVE_SEARCH_API_KEY  passed through for `decant search` (optional). If unset,
 #                       falls back to brave_api_key in your host decant config
@@ -26,6 +32,7 @@ set -euo pipefail
 IMAGE="${IMAGE:-bartleby-pi:latest}"
 CORPUS="${BARTLEBY_HOME:-${HOME}/.bartleby}"
 AGENT_PORT="${AGENT_OLLAMA_PORT:-11435}"
+VM_MEMORY="${VM_MEMORY:-8g}"
 
 command -v container >/dev/null || {
   echo "Apple 'container' not found. Install with: brew install container" >&2
@@ -49,8 +56,10 @@ fi
 
 ARGS=(run -it --rm --name bartleby-pi
       -v "${CORPUS}:/corpus"
+      -m "${VM_MEMORY}"
       -e "AGENT_OLLAMA_PORT=${AGENT_PORT}")
 [ -n "${HOST_OLLAMA_IP:-}" ] && ARGS+=(-e "HOST_OLLAMA_IP=${HOST_OLLAMA_IP}")
+[ -n "${AGENT_MODEL:-}" ]    && ARGS+=(-e "AGENT_MODEL=${AGENT_MODEL}")
 [ -n "${BRAVE_KEY}" ]        && ARGS+=(-e "BRAVE_SEARCH_API_KEY=${BRAVE_KEY}")
 
 exec container "${ARGS[@]}" "${IMAGE}" "$@"


### PR DESCRIPTION
Bundles the in-flight pi-vm shakedown fixes into one PR. No issue number — these are doc + helper-script tweaks surfaced while running the runbook.

## What's in here

**Runtime knobs (`scripts/pi-vm/`)**
- **`AGENT_MODEL`** — pick the agent model without a rebuild; set it on both `host-agent-ollama.sh` and `run.sh` (rendered into `models.json` by `entrypoint.sh`). Defaults to `qwen3.6:35b`.
- **`VM_MEMORY`** (new) — `run.sh` now passes `-m` (default `8g`). Apple `container` defaults a guest to **1 GB**, which thrashes/wedges at 100% CPU under embeddings + a multi-GB corpus DB (observed live during the shakedown). `VM_MEMORY=16g ./scripts/pi-vm/run.sh` to go higher.

**Runbook (`docs/pi-vm-runbook.md`)**
- `AGENT_MODEL` usage in *Model picks*; clarifies `DECANT_MODEL` is build-time.
- *Things to expect* notes: first-run Kata kernel prompt, host Ollama running foreground + the macOS GUI app surfacing, project selection via `bartleby project use`, and a **give-the-VM-real-RAM** gotcha.
- New **"Viewing findings while the agent runs"** section: host `bartleby serve` returns `500 database disk image is malformed` *while the VM agent is writing the same project*. Not corruption — it's SQLite's single-host WAL invariant (host + Linux guest both holding one WAL DB; the `-shm` wal-index is only coherent within one kernel). Clears on checkpoint; rule of thumb is to view between runs.
- XPC-settle note on `container system start`; new **Disk & cleanup** section.

## Testing
- `uv run pytest` → **1129 passed** (changes are shell + markdown + JSON config; no Python logic touched).
- `bash -n scripts/pi-vm/run.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)