### PR TITLE
pi-vm: optional decant (WITH_DECANT) + self-cleaning build

### DIFF
--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -104,6 +104,24 @@ Defaults to `qwen3.6:35b` if unset. (decant's distill model is a *build-time*
 knob instead — `DECANT_MODEL=<model> ./scripts/pi-vm/build.sh` — since it's baked
 into the image.)
 
+### Don't need web fetch? Drop decant (and ~7.2 GB)
+
+decant — and the VM-local Ollama plus the baked distill model that exist only to
+serve it — is the largest thing in the image. If a run is **corpus-only** (the
+agent searches/reads/cites the ingested corpus and never fetches the web), build
+without it:
+
+```bash
+WITH_DECANT=0 ./scripts/pi-vm/build.sh
+```
+
+That skips the decant install, the VM-local Ollama, and the ~7.2 GB `gemma4:e2b`
+pull — a much smaller image. The entrypoint detects decant's absence at runtime,
+so the lean image just runs Pi + Bartleby against `/corpus` with no web reach.
+Default is `WITH_DECANT=1` (decant included). The trade-off is exactly that
+capability: a lean image has **no in-VM web fetch/search** — rebuild with decant
+when you need it.
+
 ## Security posture
 
 What this buys you, and what it doesn't:
@@ -209,6 +227,7 @@ container system start          # starts the container runtime
 
 # 2. build the research-VM image (pulls Bartleby release + decant main from GitHub)
 ./scripts/pi-vm/build.sh                       # -> bartleby-pi:latest
+#    corpus-only (no web)? skip decant + its ~7.2 GB model: WITH_DECANT=0 ./scripts/pi-vm/build.sh
 
 # 3. run it — mounts ~/.bartleby as /corpus, drops you into Pi
 BRAVE_SEARCH_API_KEY=brv-... ./scripts/pi-vm/run.sh
@@ -305,24 +324,38 @@ support SQLite's `immutable=1` URI escape hatch.)
 ## Disk & cleanup
 
 The **container** is disposable — `run.sh` uses `--rm`, so `Ctrl-C` removes the
-running VM and no stopped containers pile up. The **image** is the disk cost: it's
-large (~10–15 GB — the baked `gemma4:e2b` plus Node/Ollama/deps) and persists by
-design. Each `build.sh` re-tags `:latest` and **orphans the previous image's
-layers**, which are *not* auto-cleaned, so repeated rebuilds stack up multi-GB
-ghosts.
+running VM and no stopped containers pile up. Two things *do* accumulate, and
+`build.sh` now cleans up both for you:
 
-Reclaim space (verify the verbs with `container --help` — the CLI is young):
+1. **Orphaned images.** Each build re-tags `:latest` and orphans the previous
+   digest's layers (~10–15 GB — the baked `gemma4:e2b` plus Node/Ollama/deps),
+   which `container` has no reliable prune for. `build.sh` deletes the prior
+   image *before* building, so exactly one stays on disk.
+2. **The BuildKit cache.** The builder container accretes a layer cache on every
+   build — it grew to **75 GB** during development. The nasty part: this cache
+   lives *inside the builder container* and is **invisible to `container system
+   df`**, so nothing warns you. `build.sh` resets it after a successful build
+   (`container builder delete`; the builder recreates itself on the next build).
+   Set **`KEEP_BUILD_CACHE=1`** to keep it for fast incremental rebuilds while
+   you're iterating on the `Containerfile`.
+
+So in normal use, repeated `build.sh` runs no longer stack up ghosts. To inspect
+or reclaim by hand (note: `container image` is **singular** — `container images`
+is not a valid verb):
 
 ```bash
-container images ls                          # what's on disk
-container images delete bartleby-pi:latest   # delete by name — the reliable way
+container system df                          # images/containers/volumes usage…
+                                             # …but NOT the builder cache (see above)
+container image ls                           # images on disk
+container image delete bartleby-pi:latest    # delete by name — the reliable way
+container builder delete                     # nuke the BuildKit cache (recreates on next build)
 container ls -a                              # stopped containers (should be none; --rm)
 ```
 
 Don't rely on `container image prune` to reclaim the big images — it's
 [known-buggy](https://github.com/apple/container/issues/901) (removes only
-orphaned blobs, not whole images). Simplest habit: `container images delete
-bartleby-pi:latest` before a fresh rebuild.
+orphaned blobs, not whole images). And remember `du` is the *only* way to see the
+builder cache: `du -sh "$HOME/Library/Application Support/com.apple.container/containers"`.
 
 ## Files
 

--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -104,23 +104,22 @@ Defaults to `qwen3.6:35b` if unset. (decant's distill model is a *build-time*
 knob instead — `DECANT_MODEL=<model> ./scripts/pi-vm/build.sh` — since it's baked
 into the image.)
 
-### Don't need web fetch? Drop decant (and ~7.2 GB)
+### Web fetch is opt-in: add decant with `WITH_DECANT=1`
 
 decant — and the VM-local Ollama plus the baked distill model that exist only to
-serve it — is the largest thing in the image. If a run is **corpus-only** (the
-agent searches/reads/cites the ingested corpus and never fetches the web), build
-without it:
+serve it — is the largest thing in the image, so the **default build is lean**:
+Pi + Bartleby against `/corpus`, no decant, no web reach. That fits corpus-only
+runs, where the agent searches/reads/cites the already-ingested corpus. When you
+want in-VM web fetch/search, build it in:
 
 ```bash
-WITH_DECANT=0 ./scripts/pi-vm/build.sh
+WITH_DECANT=1 ./scripts/pi-vm/build.sh
 ```
 
-That skips the decant install, the VM-local Ollama, and the ~7.2 GB `gemma4:e2b`
-pull — a much smaller image. The entrypoint detects decant's absence at runtime,
-so the lean image just runs Pi + Bartleby against `/corpus` with no web reach.
-Default is `WITH_DECANT=1` (decant included). The trade-off is exactly that
-capability: a lean image has **no in-VM web fetch/search** — rebuild with decant
-when you need it.
+That adds the decant install, the VM-local Ollama, and the ~7.2 GB `gemma4:e2b`
+pull. The entrypoint detects decant at runtime, so the same entrypoint serves
+both the lean and full images. Default is `WITH_DECANT=0` (lean); the trade-off
+is exactly that capability — a lean image has **no in-VM web fetch/search**.
 
 ## Security posture
 
@@ -225,9 +224,9 @@ container system start          # starts the container runtime
 # 1. host: start the dedicated agent Ollama (GPU), separate from your daily one
 ./scripts/pi-vm/host-agent-ollama.sh          # serves qwen3.6:35b on :11435
 
-# 2. build the research-VM image (pulls Bartleby release + decant main from GitHub)
+# 2. build the research-VM image (lean by default: Bartleby release, no decant)
 ./scripts/pi-vm/build.sh                       # -> bartleby-pi:latest
-#    corpus-only (no web)? skip decant + its ~7.2 GB model: WITH_DECANT=0 ./scripts/pi-vm/build.sh
+#    need in-VM web fetch? add decant + its ~7.2 GB model: WITH_DECANT=1 ./scripts/pi-vm/build.sh
 
 # 3. run it — mounts ~/.bartleby as /corpus, drops you into Pi
 BRAVE_SEARCH_API_KEY=brv-... ./scripts/pi-vm/run.sh

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -5,8 +5,8 @@
 # Node base: guarantees Node >=22.19 + npm for the Pi install, and is still
 # Debian/apt underneath so the rest of this file is unchanged.
 #
-# WITH_DECANT=0 drops decant, the VM-local Ollama, and the ~7.2 GB distill model
-# — a much smaller, web-fetch-less image for corpus-only research (default: on).
+# The default build is lean (corpus-only, no web reach). WITH_DECANT=1 adds
+# decant, a VM-local Ollama, and the ~7.2 GB distill model for in-VM web fetch.
 FROM node:22-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"
 
-# decant is optional. WITH_DECANT=0 skips it, its VM-local Ollama, and its model.
-ARG WITH_DECANT=1
+# decant is optional and off by default. WITH_DECANT=1 adds it, its VM-local
+# Ollama, and its model.
+ARG WITH_DECANT=0
 
 # Ollama (Linux). CPU-only inside the VM — used solely for decant's small model,
 # so it's installed only when decant is. (zstd above is for this installer.)

--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -1,9 +1,12 @@
-# Pure-build research VM: Pi + Bartleby + decant + a VM-local Ollama (CPU) for
-# decant's distill model. The big agent model runs on the HOST GPU; see
-# docs/pi-vm-runbook.md. Bartleby and decant are pulled from GitHub (not local
-# source), so the build context is just this directory (scripts/pi-vm/).
+# Pure-build research VM: Pi + Bartleby, optionally + decant and a VM-local
+# Ollama (CPU) for decant's distill model. The big agent model runs on the HOST
+# GPU; see docs/pi-vm-runbook.md. Bartleby and decant are pulled from GitHub (not
+# local source), so the build context is just this directory (scripts/pi-vm/).
 # Node base: guarantees Node >=22.19 + npm for the Pi install, and is still
 # Debian/apt underneath so the rest of this file is unchanged.
+#
+# WITH_DECANT=0 drops decant, the VM-local Ollama, and the ~7.2 GB distill model
+# — a much smaller, web-fetch-less image for corpus-only research (default: on).
 FROM node:22-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -16,33 +19,47 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"
 
-# Ollama (Linux). CPU-only inside the VM — used solely for decant's small model.
-RUN curl -fsSL https://ollama.com/install.sh | sh
+# decant is optional. WITH_DECANT=0 skips it, its VM-local Ollama, and its model.
+ARG WITH_DECANT=1
+
+# Ollama (Linux). CPU-only inside the VM — used solely for decant's small model,
+# so it's installed only when decant is. (zstd above is for this installer.)
+RUN if [ "$WITH_DECANT" = "1" ]; then \
+      curl -fsSL https://ollama.com/install.sh | sh; \
+    else echo "WITH_DECANT=0: skipping Ollama install"; fi
 
 # Pi coding agent via npm. The pi.dev/install.sh script needs a TTY, so it can't
 # run in a non-interactive build; npm is the headless path. `pi` lands on PATH
 # at /usr/local/bin. --ignore-scripts is what Pi's own docs recommend.
 RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 
-# --- Bartleby (latest release tag) + decant (main), pulled from GitHub ---
-# Both repos are public over HTTPS, so no auth in the build. Ingestion runs on
-# the HOST, so the VM needs no [docling]/[sec2md] extras — the agent only
-# searches/reads/cites an already-ingested corpus.
+# --- Bartleby (latest release tag), pulled from GitHub ---
+# Public over HTTPS, so no auth in the build. Ingestion runs on the HOST, so the
+# VM needs no [docling]/[sec2md] extras — the agent only searches/reads/cites an
+# already-ingested corpus.
 RUN BARTLEBY_REF="$(git ls-remote --tags --refs https://github.com/jswest/bartleby.git 'v*' \
                     | awk -F/ '{print $NF}' | sort -V | tail -1)" \
-    && echo "Installing bartleby ${BARTLEBY_REF}, decant@main" \
-    && uv tool install "git+https://github.com/jswest/bartleby.git@${BARTLEBY_REF}" \
-    && uv tool install "git+https://github.com/jswest/decant.git@main"
+    && echo "Installing bartleby ${BARTLEBY_REF}" \
+    && uv tool install "git+https://github.com/jswest/bartleby.git@${BARTLEBY_REF}"
+
+# decant (main) — only when WITH_DECANT=1.
+RUN if [ "$WITH_DECANT" = "1" ]; then \
+      echo "Installing decant@main" \
+      && uv tool install "git+https://github.com/jswest/decant.git@main"; \
+    else echo "WITH_DECANT=0: skipping decant"; fi
 
 # Install the Bartleby skill where Pi discovers skills.
 RUN bartleby ready --dest /root/.pi/agent/skills --force
 RUN HF_HUB_OFFLINE=0 bartleby embed "warmup" >/dev/null
 
 # Bake decant's distill model into the image (pure build = reproducible/offline).
+# Skipped with the rest of decant when WITH_DECANT=0 — this is the ~7.2 GB layer.
 ARG DECANT_MODEL=gemma4:e2b
-RUN ollama serve >/tmp/ollama-build.log 2>&1 & \
-    until ollama list >/dev/null 2>&1; do sleep 0.5; done; \
-    ollama pull "${DECANT_MODEL}"
+RUN if [ "$WITH_DECANT" = "1" ]; then \
+      ollama serve >/tmp/ollama-build.log 2>&1 & \
+      until ollama list >/dev/null 2>&1; do sleep 0.5; done; \
+      ollama pull "${DECANT_MODEL}"; \
+    else echo "WITH_DECANT=0: skipping distill model pull"; fi
 
 # Config templates + entrypoint (build context is scripts/pi-vm/ itself).
 COPY models.json        /opt/pi-vm/models.json

--- a/scripts/pi-vm/build.sh
+++ b/scripts/pi-vm/build.sh
@@ -12,9 +12,9 @@
 #
 # Env:
 #   IMAGE             image tag                   (default: bartleby-pi:latest)
-#   WITH_DECANT       set=0 to drop decant, the VM-local Ollama, and the ~7.2 GB
-#                     distill model — a smaller, web-fetch-less image for
-#                     corpus-only research (default: 1, decant included).
+#   WITH_DECANT       set=1 to add decant, a VM-local Ollama, and the ~7.2 GB
+#                     distill model for in-VM web fetch/search. Default: 0 — a
+#                     lean, corpus-only image with no web reach.
 #   DECANT_MODEL      distill model baked into VM (default: gemma4:e2b; ignored
 #                     when WITH_DECANT=0).
 #   KEEP_BUILD_CACHE  set=1 to keep the BuildKit cache after a successful build
@@ -26,7 +26,7 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 IMAGE="${IMAGE:-bartleby-pi:latest}"
-WITH_DECANT="${WITH_DECANT:-1}"
+WITH_DECANT="${WITH_DECANT:-0}"
 DECANT_MODEL="${DECANT_MODEL:-gemma4:e2b}"
 
 command -v container >/dev/null || {

--- a/scripts/pi-vm/build.sh
+++ b/scripts/pi-vm/build.sh
@@ -5,15 +5,28 @@
 # local source to stage — the build context is just this directory. Re-run to
 # pick up a newer Bartleby release / newer decant main.
 #
+# Self-cleaning so it can't silently bloat your disk (see "Disk & cleanup" in the
+# runbook): deletes the prior image before building and resets the BuildKit cache
+# afterward. During development that cache grew to 75 GB — and it's invisible to
+# `container system df`, so nothing warns you.
+#
 # Env:
-#   IMAGE        image tag                     (default: bartleby-pi:latest)
-#   DECANT_MODEL distill model baked into VM   (default: gemma4:e2b)
+#   IMAGE             image tag                   (default: bartleby-pi:latest)
+#   WITH_DECANT       set=0 to drop decant, the VM-local Ollama, and the ~7.2 GB
+#                     distill model — a smaller, web-fetch-less image for
+#                     corpus-only research (default: 1, decant included).
+#   DECANT_MODEL      distill model baked into VM (default: gemma4:e2b; ignored
+#                     when WITH_DECANT=0).
+#   KEEP_BUILD_CACHE  set=1 to keep the BuildKit cache after a successful build
+#                     (fast incremental rebuilds while iterating on the
+#                     Containerfile). Default: reset it so it can't accumulate.
 #
 # See docs/pi-vm-runbook.md.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 IMAGE="${IMAGE:-bartleby-pi:latest}"
+WITH_DECANT="${WITH_DECANT:-1}"
 DECANT_MODEL="${DECANT_MODEL:-gemma4:e2b}"
 
 command -v container >/dev/null || {
@@ -21,11 +34,29 @@ command -v container >/dev/null || {
   exit 1
 }
 
-echo "Building ${IMAGE} (bartleby=latest release, decant=main, DECANT_MODEL=${DECANT_MODEL}) ..." >&2
+# Drop any prior image first: each rebuild re-tags :latest and orphans the old
+# digest's layers, which `container` has no reliable prune for. Deleting up front
+# keeps exactly one image on disk. (If this build fails, just re-run to recover.)
+container image delete "${IMAGE}" >/dev/null 2>&1 || true
+
+if [ "${WITH_DECANT}" = "1" ]; then
+  echo "Building ${IMAGE} (bartleby=latest release, decant=main, DECANT_MODEL=${DECANT_MODEL}) ..." >&2
+else
+  echo "Building ${IMAGE} (bartleby=latest release, WITH_DECANT=0 — lean, no decant/Ollama/model) ..." >&2
+fi
 container build \
+  --build-arg "WITH_DECANT=${WITH_DECANT}" \
   --build-arg "DECANT_MODEL=${DECANT_MODEL}" \
   -t "${IMAGE}" \
   -f "${HERE}/Containerfile" \
   "${HERE}"
+
+# Reset the BuildKit cache unless we're iterating. Its storage lives inside the
+# builder container — invisible to `container system df` — so it grows silently
+# with every build. The builder recreates itself automatically on the next build.
+if [ -z "${KEEP_BUILD_CACHE:-}" ]; then
+  echo "Resetting BuildKit cache (set KEEP_BUILD_CACHE=1 to keep it for fast rebuilds) ..." >&2
+  container builder delete >/dev/null 2>&1 || true
+fi
 
 echo "Built ${IMAGE}. Next: ./scripts/pi-vm/run.sh" >&2

--- a/scripts/pi-vm/entrypoint.sh
+++ b/scripts/pi-vm/entrypoint.sh
@@ -1,17 +1,29 @@
 #!/usr/bin/env bash
 #
 # In-VM entrypoint. Runs inside the Apple `container` Linux guest.
-#   1. start the VM-local Ollama (CPU) that serves decant's distill model
+#   1. (if decant is baked in) start the VM-local Ollama (CPU) for its model
 #   2. detect the host bridge IP so Pi can reach the host agent Ollama
-#   3. render Pi's models.json (-> host :11435) and decant's config (-> VM-local)
+#   3. render Pi's models.json (-> host :11435) and, if present, decant's config
 #   4. hand off to Pi (interactive) or whatever command was passed
+#
+# Decant is optional at build time (WITH_DECANT=0); we detect it at runtime so
+# the same entrypoint works for both the full and the lean image.
 #
 # See docs/pi-vm-runbook.md.
 set -euo pipefail
 
+# Lean image (WITH_DECANT=0) has neither decant nor the VM-local Ollama.
+if command -v decant >/dev/null 2>&1 && command -v ollama >/dev/null 2>&1; then
+  HAS_DECANT=1
+else
+  HAS_DECANT=0
+fi
+
 # 1. VM-local Ollama (serves decant's small model, CPU-only — expected).
-ollama serve >/tmp/ollama.log 2>&1 &
-until ollama list >/dev/null 2>&1; do sleep 0.5; done
+if [ "${HAS_DECANT}" = "1" ]; then
+  ollama serve >/tmp/ollama.log 2>&1 &
+  until ollama list >/dev/null 2>&1; do sleep 0.5; done
+fi
 
 # 2. Host bridge IP. Apple `container` has no host.docker.internal; the default
 #    gateway points at the host bridge. Override with HOST_OLLAMA_IP if wrong.
@@ -30,11 +42,14 @@ sed -e "s|__HOST_OLLAMA__|http://${HOST_IP}:${AGENT_PORT}/v1|g" \
     /opt/pi-vm/models.json > /root/.pi/agent/models.json
 
 # 3b. decant -> VM-local Ollama. Brave key from env if provided, else null.
-mkdir -p /root/.decant
-sed "s|__BRAVE_KEY__|${BRAVE_SEARCH_API_KEY:-null}|g" \
-    /opt/pi-vm/decant-config.yaml > /root/.decant/config.yaml
-
-echo "Pi -> ${AGENT_MODEL} @ http://${HOST_IP}:${AGENT_PORT}  |  decant -> VM-local Ollama" >&2
+if [ "${HAS_DECANT}" = "1" ]; then
+  mkdir -p /root/.decant
+  sed "s|__BRAVE_KEY__|${BRAVE_SEARCH_API_KEY:-null}|g" \
+      /opt/pi-vm/decant-config.yaml > /root/.decant/config.yaml
+  echo "Pi -> ${AGENT_MODEL} @ http://${HOST_IP}:${AGENT_PORT}  |  decant -> VM-local Ollama" >&2
+else
+  echo "Pi -> ${AGENT_MODEL} @ http://${HOST_IP}:${AGENT_PORT}  |  decant: not installed (lean image)" >&2
+fi
 
 # 4. Hand off.
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
Keeps the research-VM image lean — both halves came out of a shakedown where Apple `container` storage ballooned past 120 GB.

## Optional decant — **lean by default**, opt in with `WITH_DECANT=1`
decant, plus the VM-local Ollama and the baked distill model that exist only to serve it, is the largest thing in the image. The default build now omits it:

```bash
./scripts/pi-vm/build.sh                 # default: lean, corpus-only, no web reach
WITH_DECANT=1 ./scripts/pi-vm/build.sh   # add decant + VM-local Ollama + ~7.2 GB model for in-VM web fetch
```

- **Containerfile** — `ARG WITH_DECANT=0` gates the Ollama install, the decant install, and the `gemma4:e2b` model pull (the ~7.2 GB layer).
- **entrypoint.sh** — detects decant/Ollama at runtime, so the *same* entrypoint serves both the lean and full image (no runtime flag needed); skips the VM-local Ollama + decant config when absent.
- **build.sh** — `WITH_DECANT` defaults to `0`, passed through as a build-arg.
- Trade-off: the default (lean) image has **no in-VM web fetch/search**; build with `WITH_DECANT=1` when you need it.

## Self-cleaning build — no silent bloat
The shakedown surfaced two accumulators; `build.sh` now handles both:

- **Orphaned images** — each build re-tags `:latest` and orphans the old digest (~15 GB). `build.sh` deletes the prior image before building → one image on disk.
- **BuildKit cache** — the builder container accreted a layer cache that hit **75 GB** and is **invisible to `container system df`**. `build.sh` resets it after a successful build (`container builder delete`, recreates on next build). `KEEP_BUILD_CACHE=1` keeps it for fast incremental rebuilds.

## Runbook
- New *"Web fetch is opt-in: add decant with `WITH_DECANT=1`"* subsection + an updated build-step pointer.
- Rewrote **Disk & cleanup** around the two bloat sources and the invisible-cache trap.
- Fixed a latent bug: it used `container images` (plural), which errors — the verb is `container image` (singular).

## Testing
- `uv run pytest` → **1149 passed, 2 skipped**.
- `bash -n` clean on `build.sh` and `entrypoint.sh`; Containerfile conditionals reviewed.
- Note: a full lean-vs-full image build wasn't run here (no `container` build in this env) — the build-time gating is `ARG`-guarded shell `if` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)