### PR TITLE
Fix race in write_active_session_id (unique temp, not shared .tmp)

### DIFF
--- a/bartleby/session.py
+++ b/bartleby/session.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypedDict
@@ -99,15 +100,27 @@ def read_active_session_id(project_name: str) -> int | None:
 def write_active_session_id(project_name: str, session_id: int) -> None:
     f = _active_session_file(project_name)
     f.parent.mkdir(parents=True, exist_ok=True)
-    # Write to a sibling temp file, then atomically rename over the pointer.
-    # A concurrent reader (read_active_session_id) either sees the old id or
-    # the new one in full — never a half-written line. os.replace is atomic
-    # on the same filesystem; the temp file sits beside the target to stay
-    # there. A leftover .tmp from a crash mid-write is harmless: the rename is
-    # the only step that publishes the value.
-    tmp = f.with_name(f.name + ".tmp")
-    tmp.write_text(str(session_id), encoding="utf-8")
-    os.replace(tmp, f)
+    # Write to a *unique* sibling temp file, then atomically rename over the
+    # pointer. A concurrent reader (read_active_session_id) either sees the old
+    # id or the new one in full — never a half-written line. os.replace is atomic
+    # on the same filesystem; the temp sits beside the target to stay there.
+    #
+    # The temp name must be unique per writer: a shared ".active_session.tmp" let
+    # two concurrent writers clobber one temp and race on the rename — the second
+    # os.replace then raised FileNotFoundError because the first already renamed
+    # it away. Last writer wins, which is fine (all ids are valid). Clean up our
+    # own temp on failure so a crash doesn't leave it behind.
+    fd, tmp = tempfile.mkstemp(dir=f.parent, prefix=f.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(str(session_id))
+        os.replace(tmp, f)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def clear_active_session(project_name: str) -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -222,6 +222,35 @@ def test_write_active_session_id_leaves_no_tmp_file(project):
     assert session_mod.read_active_session_id(project) == 7
 
 
+def test_write_active_session_id_concurrent_writers_no_race(project):
+    # Regression for #553: a shared ".active_session.tmp" let concurrent writers
+    # clobber one temp and race on the rename — the second os.replace raised
+    # FileNotFoundError. Unique temps fix it: many overlapping writers all
+    # succeed, the pointer lands on one written id, and no temp is left behind.
+    import threading
+
+    ids = list(range(1, 51))
+    errors: list[Exception] = []
+
+    def writer(sid: int) -> None:
+        try:
+            for _ in range(10):
+                session_mod.write_active_session_id(project, sid)
+        except Exception as exc:  # noqa: BLE001 - surfaced via assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(sid,)) for sid in ids]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert session_mod.read_active_session_id(project) in ids
+    pdir = bartleby.project.get_project_dir(project)
+    assert not list(pdir.glob(".active_session.*.tmp"))
+
+
 def test_generate_name_is_kebab_pair():
     name = session_mod.generate_name()
     a, _, b = name.partition("-")


### PR DESCRIPTION
Closes #553

## Problem
`bartleby/session.py:write_active_session_id` wrote to a **fixed** sibling temp `.active_session.tmp`, then `os.replace`d it over the pointer. Two concurrent writers shared that one temp and raced on the rename:

1. A and B both write `.active_session.tmp`.
2. A `os.replace(tmp, f)` → temp renamed away.
3. B `os.replace(tmp, f)` → temp already gone → `FileNotFoundError`.

`ensure_active_session` / run-start call this, and the agent fires skill calls concurrently — so it surfaced as an intermittent `INTERNAL_ERROR` in the pi-vm container (not VM-specific; it's a plain race).

## Fix
Standard atomic-write with a **unique** temp — `tempfile.mkstemp(dir=f.parent, prefix=f.name + ".", suffix=".tmp")` → write → same atomic `os.replace`, plus best-effort cleanup of our own temp on failure. Concurrent writers can no longer clobber each other; last writer wins (all ids valid). No schema change → patch-level.

## Test
Adds `test_write_active_session_id_concurrent_writers_no_race` (50 threads × 10 writes). Verified it **reliably fails on the old code** (`FileNotFoundError`, 49/50 writers) and **passes on the fix**.

- `uv run pytest` → **1150 passed, 2 skipped**.
- `simplify-refactor` pass: already minimal, no changes.

## Rollout note
The pi-vm image installs the latest **release** tag of Bartleby, so this needs a release + image rebuild to reach the running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)