### PR TITLE
pi-vm: resolve BARTLEBY_REF on the host so the install layer cache-busts

### DIFF
--- a/scripts/pi-vm/Containerfile
+++ b/scripts/pi-vm/Containerfile
@@ -34,12 +34,16 @@ RUN if [ "$WITH_DECANT" = "1" ]; then \
 # at /usr/local/bin. --ignore-scripts is what Pi's own docs recommend.
 RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 
-# --- Bartleby (latest release tag), pulled from GitHub ---
+# --- Bartleby (release tag), pulled from GitHub ---
 # Public over HTTPS, so no auth in the build. Ingestion runs on the HOST, so the
 # VM needs no [docling]/[sec2md] extras — the agent only searches/reads/cites an
 # already-ingested corpus.
-RUN BARTLEBY_REF="$(git ls-remote --tags --refs https://github.com/jswest/bartleby.git 'v*' \
-                    | awk -F/ '{print $NF}' | sort -V | tail -1)" \
+#
+# The tag is resolved on the HOST by build.sh and passed in as BARTLEBY_REF, so
+# this layer's cache key changes with each release. Resolving "latest" inside the
+# RUN instead would cache on the command text and silently reinstall a stale tag.
+ARG BARTLEBY_REF
+RUN test -n "${BARTLEBY_REF}" \
     && echo "Installing bartleby ${BARTLEBY_REF}" \
     && uv tool install "git+https://github.com/jswest/bartleby.git@${BARTLEBY_REF}"
 

--- a/scripts/pi-vm/build.sh
+++ b/scripts/pi-vm/build.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
-# Build the research-VM image with Apple `container`. Bartleby (latest release
-# tag) and decant (main) are pulled from GitHub inside the build, so there's no
-# local source to stage — the build context is just this directory. Re-run to
-# pick up a newer Bartleby release / newer decant main.
+# Build the research-VM image with Apple `container`. Bartleby (a release tag,
+# resolved here on the host) and decant (main) are pulled from GitHub inside the
+# build, so there's no local source to stage — the build context is just this
+# directory. Re-run to pick up a newer Bartleby release / newer decant main.
 #
 # Self-cleaning so it can't silently bloat your disk (see "Disk & cleanup" in the
 # runbook): deletes the prior image before building and resets the BuildKit cache
@@ -12,6 +12,11 @@
 #
 # Env:
 #   IMAGE             image tag                   (default: bartleby-pi:latest)
+#   BARTLEBY_REF      Bartleby git ref to install (default: latest v* release tag,
+#                     resolved here). Passed to the build as a build-arg so the
+#                     install layer's cache busts when the release changes — a
+#                     RUN that resolved "latest" itself would cache on its command
+#                     text and silently reinstall a stale tag. Override to pin.
 #   WITH_DECANT       set=1 to add decant, a VM-local Ollama, and the ~7.2 GB
 #                     distill model for in-VM web fetch/search. Default: 0 — a
 #                     lean, corpus-only image with no web reach.
@@ -34,17 +39,28 @@ command -v container >/dev/null || {
   exit 1
 }
 
+# Resolve the Bartleby release tag on the HOST (not inside a cacheable RUN) and
+# pass it as a build-arg, so the install layer rebuilds when a new release lands.
+BARTLEBY_REF="${BARTLEBY_REF:-$(git ls-remote --tags --refs \
+  https://github.com/jswest/bartleby.git 'v*' | awk -F/ '{print $NF}' | sort -V | tail -1)}"
+[ -n "${BARTLEBY_REF}" ] || {
+  echo "Could not resolve a Bartleby release tag (git ls-remote returned nothing)." >&2
+  echo "Check your network, or pin one: BARTLEBY_REF=v0.10.1 ./scripts/pi-vm/build.sh" >&2
+  exit 1
+}
+
 # Drop any prior image first: each rebuild re-tags :latest and orphans the old
 # digest's layers, which `container` has no reliable prune for. Deleting up front
 # keeps exactly one image on disk. (If this build fails, just re-run to recover.)
 container image delete "${IMAGE}" >/dev/null 2>&1 || true
 
 if [ "${WITH_DECANT}" = "1" ]; then
-  echo "Building ${IMAGE} (bartleby=latest release, decant=main, DECANT_MODEL=${DECANT_MODEL}) ..." >&2
+  echo "Building ${IMAGE} (bartleby=${BARTLEBY_REF}, decant=main, DECANT_MODEL=${DECANT_MODEL}) ..." >&2
 else
-  echo "Building ${IMAGE} (bartleby=latest release, WITH_DECANT=0 — lean, no decant/Ollama/model) ..." >&2
+  echo "Building ${IMAGE} (bartleby=${BARTLEBY_REF}, WITH_DECANT=0 — lean, no decant/Ollama/model) ..." >&2
 fi
 container build \
+  --build-arg "BARTLEBY_REF=${BARTLEBY_REF}" \
   --build-arg "WITH_DECANT=${WITH_DECANT}" \
   --build-arg "DECANT_MODEL=${DECANT_MODEL}" \
   -t "${IMAGE}" \


### PR DESCRIPTION
Closes #555

## Problem
The Containerfile resolved the latest `v*` tag **inside** a `RUN`:

```dockerfile
RUN BARTLEBY_REF="$(git ls-remote ... 'v*' | ... | tail -1)" \
    && uv tool install "git+...@${BARTLEBY_REF}"
```

BuildKit keys a `RUN` layer on its **command text**, not the network result — so once that layer is cached it reinstalls whatever tag was latest *when it was first built*. After releasing `v0.10.1`, a rebuild showed `=> CACHED` on this step and silently reinstalled the old `v0.10.0` Bartleby, so the `.active_session` fix never reached the container.

## Fix
Resolve the tag on the **host** in `build.sh` and pass it as `--build-arg BARTLEBY_REF=...`. The layer's cache key now includes the version string, so it rebuilds whenever a new release lands.

- **build.sh** — resolves `BARTLEBY_REF` (honors an env override for pinning), fails clearly if `git ls-remote` returns nothing, passes it as a build-arg, and echoes the concrete tag being built.
- **Containerfile** — `ARG BARTLEBY_REF`, guards non-empty (`test -n`), installs that ref; drops the in-container `git ls-remote`.

## Testing
- Host tag resolution confirmed → `v0.10.1`.
- `bash -n build.sh` clean; Containerfile reviewed (ARG present, no in-RUN resolve).
- `uv run pytest` → **1150 passed, 2 skipped** (no Python touched).
- A real `container build` wasn't run in this env; the change is build-arg plumbing + an `ARG`-guarded install.

## Out of scope
decant is pinned to `@main` (a moving branch, no release cadence) and has the same theoretical staleness, but it's opt-in (`WITH_DECANT=1`) and would need a SHA to cache-bust — left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)