### PR TITLE
web: contain wide finding tables within the report column

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -343,6 +343,9 @@ input[type="number"] {
 .markdown-body {
   font-family: var(--font-serif);
   line-height: 1.6;
+  /* Long unbreakable tokens (URLs, hashes, dotted entity strings) wrap inside
+     the column instead of spilling past its right edge onto the viewer. */
+  overflow-wrap: break-word;
 }
 .markdown-body > * + * {
   margin-top: var(--space-lg);
@@ -448,6 +451,14 @@ input[type="number"] {
   margin: var(--space-2xl) 0;
 }
 .markdown-body table {
+  /* A wide table scrolls horizontally *within* the report column rather than
+     painting over the sticky viewer. A table box can't establish its own
+     scroll container, so render it as a block that sizes to its content
+     (max-content) but is capped at the column width (max-width:100%). */
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   font-family: var(--font-sans);
   font-size: var(--text-sm);


### PR DESCRIPTION
## What
Wide markdown tables on the finding page (`/findings/<id>`) rendered at their natural width and spilled past the right edge of the left `.report` column, painting over the sticky source viewer (and giving narrow viewports a horizontal scrollbar).

## Why / root cause
The grid is fine — `.report { min-width: 0 }` already stops content from expanding the track. But `.markdown-body table` had no width containment and `.report` is `overflow-x: visible`, so an over-wide table painted outside its box.

## Fix
- `.markdown-body table`: GitHub-markdown pattern — `display: block; width: max-content; max-width: 100%; overflow-x: auto`, so a wide table scrolls horizontally *within* the column instead of spilling.
- `.markdown-body`: `overflow-wrap: break-word`, so long unbreakable tokens (URLs/hashes) in prose wrap rather than overflow.

No JS/marked/Svelte changes, no schema impact.

## Verification
Playwright against a throwaway sandbox finding (8-col table + long-URL paragraph): **before** — table box 992px, overlapped the viewer by 345px; **after** — capped at the 606px column with internal scroll, zero viewer overlap, prose URL wraps.

**Tests skipped** — `skip-tests`, CSS-only diff touches no test-affecting source. `simplify-refactor` gate ran clean.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
