### PR TITLE
Part of #565: fix concurrent finding-write BusyError (BEGIN IMMEDIATE)

### DIFF
--- a/bartleby/db/connection.py
+++ b/bartleby/db/connection.py
@@ -52,9 +52,16 @@ def _attach(conn: apsw.Connection) -> None:
     conn.enable_load_extension(False)
     cur = conn.cursor()
     cur.execute("PRAGMA foreign_keys = ON")
+    # busy_timeout MUST be set before `journal_mode = WAL`: that pragma itself
+    # takes a database lock, so when several connections open the same project
+    # DB concurrently (e.g. a handful of agents writing findings at once),
+    # whichever runs the WAL pragma second would get an instant BusyError with
+    # no timeout configured yet. Setting the timeout first makes every later
+    # statement — the WAL pragma and the `BEGIN IMMEDIATE` at the mutating seam
+    # — wait out a held lock instead of failing on first contact (#562).
+    cur.execute("PRAGMA busy_timeout = 5000")
     cur.execute("PRAGMA journal_mode = WAL")
     cur.execute("PRAGMA synchronous = NORMAL")
-    cur.execute("PRAGMA busy_timeout = 5000")
 
 
 def open_db(project_name: str | None = None) -> apsw.Connection:

--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -21,10 +21,13 @@ and calls :func:`run`. The runner:
 - Exits 0 on success and 1 on failure.
 
 A script that mutates the DB passes ``mutates=True`` to :func:`run`; the runner
-then wraps the ``work`` call in a single ``with conn:`` transaction so the whole
-mutation commits or rolls back atomically. Read-only scripts (the default) open
-no transaction. The audit write always lands, transaction or not — including
-when a mutation rolled back.
+then wraps the ``work`` call in a single ``BEGIN IMMEDIATE`` transaction so the
+whole mutation commits or rolls back atomically. ``BEGIN IMMEDIATE`` (rather
+than apsw's deferred ``with conn:``) takes the write lock up front so concurrent
+writers serialize under ``busy_timeout`` instead of failing the read-to-write
+upgrade with an instant ``BusyError`` (see the comment at the seam). Read-only
+scripts (the default) open no transaction. The audit write always lands,
+transaction or not — including when a mutation rolled back.
 """
 
 from __future__ import annotations
@@ -194,16 +197,32 @@ def run(
             session_id = ensure_active_session(project)
         if mutates:
             # One transaction at the seam: a mutating script's entire ``work``
-            # commits or rolls back atomically. apsw's ``with conn:`` is a
-            # deferred transaction (no write lock until the first write), and
-            # the ``with conn:`` blocks inside the chunk helpers nest under it
-            # as savepoints rather than committing independently — so a partial
-            # write (e.g. chunks deleted but the row delete then raises) leaves
-            # nothing behind. The audit ``log_call`` below stays OUTSIDE this
-            # block on purpose: a rolled-back mutation must still record that it
-            # was attempted and failed.
-            with conn:
+            # commits or rolls back atomically. We open it with an explicit
+            # ``BEGIN IMMEDIATE`` rather than apsw's ``with conn:`` (a *deferred*
+            # transaction). A deferred txn takes no write lock until its first
+            # write, so a ``work`` that reads before writing hits the SQLite
+            # read-to-write upgrade trap: the upgrade returns ``SQLITE_BUSY``
+            # immediately, *ignoring* ``busy_timeout`` (the timeout governs the
+            # initial lock acquisition, not a mid-transaction upgrade). With a
+            # handful of concurrent finding writes into one session that meant a
+            # spurious first-attempt ``BusyError`` instead of serializing.
+            # Taking the write lock up front makes ``busy_timeout`` (set in
+            # ``connection._attach``) govern the wait, so concurrent writers
+            # block and serialize. The ``with conn:`` blocks inside the chunk
+            # helpers still nest under this open transaction as savepoints
+            # rather than committing independently, so a partial write (e.g.
+            # chunks deleted but the row delete then raises) leaves nothing
+            # behind. The audit ``log_call`` below stays OUTSIDE this block on
+            # purpose: a rolled-back mutation must still record that it was
+            # attempted and failed.
+            conn.cursor().execute("BEGIN IMMEDIATE")
+            try:
                 result = work(conn=conn, args=args, session_id=session_id)
+            except BaseException:
+                conn.cursor().execute("ROLLBACK")
+                raise
+            else:
+                conn.cursor().execute("COMMIT")
         else:
             result = work(conn=conn, args=args, session_id=session_id)
     except SkillError as e:

--- a/tests/test_skill_concurrent_writes.py
+++ b/tests/test_skill_concurrent_writes.py
@@ -1,0 +1,233 @@
+"""Concurrent finding-write regression test for the runner's mutating seam (#562).
+
+Several agents (or one agent issuing rapid calls) can drive ``save_finding`` /
+``edit_finding`` into the *same* session at once. Each invocation is a separate
+process/connection, but they all contend for the one project DB's single write
+lock.
+
+The bug (#562): the mutating seam in ``skill_runner.run`` used to open the
+transaction with apsw's ``with conn:`` — a *deferred* transaction that takes no
+write lock until its first write. A ``work`` that reads before it writes (every
+finding write does: it resolves the session, validates citations, …) then hits
+SQLite's read-to-write upgrade trap, where the upgrade returns ``SQLITE_BUSY``
+*immediately*, ignoring ``busy_timeout``. So a handful of concurrent writers
+produced spurious first-attempt ``BusyError``\\ s instead of serializing.
+
+The fix opens the seam with ``BEGIN IMMEDIATE``, taking the write lock up front
+so ``busy_timeout`` governs the wait and concurrent writers block-and-serialize.
+This test spawns N concurrent writers against one sandbox project DB and asserts
+none fail (in particular, none fail with a ``BusyError``). It is verifiable
+in-suite: no live corpus, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+
+import pytest
+
+from bartleby.db.connection import open_db
+from bartleby.skill_scripts import edit_finding, save_finding
+from tests._skill_fixtures import (  # noqa: F401
+    mock_embed,
+    project_env,
+    seeded_project,
+)
+
+
+class _ThreadLocalStdout:
+    """Route ``sys.stdout`` writes to a per-thread buffer.
+
+    The skill scripts print their JSON envelope to ``sys.stdout`` via
+    ``_print_json``. With many writer threads sharing the one process stdout,
+    their envelopes would interleave into an unparseable mush. This proxy hands
+    each thread its own ``StringIO`` so every thread reads back exactly its own
+    invocation's result; threads without a registered buffer fall through to the
+    real stream.
+    """
+
+    def __init__(self, real):
+        self._real = real
+        self._buffers: dict[int, object] = {}
+
+    def register(self, buf) -> None:
+        self._buffers[threading.get_ident()] = buf
+
+    def _target(self):
+        return self._buffers.get(threading.get_ident(), self._real)
+
+    def write(self, s):
+        return self._target().write(s)
+
+    def flush(self):
+        return self._target().flush()
+
+
+def _run_writer(fn, argv, results, idx, tls):
+    import io
+
+    buf = io.StringIO()
+    tls.register(buf)
+    outcome: dict = {"idx": idx}
+    try:
+        fn(argv)
+    except SystemExit as e:
+        # The runner exits non-zero on any error (BusyError included).
+        outcome["exit_code"] = e.code
+    except BaseException as e:  # noqa: BLE001 — surface anything unexpected
+        outcome["raised"] = f"{type(e).__name__}: {e}"
+    finally:
+        outcome["stdout"] = buf.getvalue()
+    results[idx] = outcome
+
+
+def _cited_chunk(project, doc_id):
+    conn = open_db(project)
+    try:
+        return conn.cursor().execute(
+            "SELECT chunk_id FROM chunks WHERE source_kind='document' "
+            "AND source_id = ? ORDER BY chunk_index LIMIT 1",
+            (doc_id,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _assert_no_busy(outcomes):
+    """No writer may fail — and emphatically not with a BusyError."""
+    for o in outcomes:
+        # An unexpected non-SystemExit escape is a hard failure.
+        assert "raised" not in o, f"writer {o['idx']} raised: {o.get('raised')}"
+        stdout = o.get("stdout", "")
+        envelope = json.loads(stdout) if stdout.strip() else {}
+        code = envelope.get("code")
+        err = envelope.get("error", "")
+        assert "Busy" not in str(code) and "Busy" not in str(err), (
+            f"writer {o['idx']} hit a BusyError: {envelope}"
+        )
+        # Success: the runner exited 0 (no SystemExit recorded) and the
+        # envelope carries no error code.
+        assert o.get("exit_code") is None, (
+            f"writer {o['idx']} exited non-zero: {envelope}"
+        )
+        assert code is None, f"writer {o['idx']} reported error {code}: {envelope}"
+
+
+def _run_concurrently(fn, argvs):
+    """Run ``fn(argv)`` for each argv on its own thread; return ordered outcomes.
+
+    Swaps in a thread-local stdout proxy for the duration (restored in a
+    ``finally`` so the autouse ``BARTLEBY_HOME`` isolation is never touched —
+    ``monkeypatch.undo()`` would revert *every* patch, including that one).
+    """
+    tls = _ThreadLocalStdout(sys.stdout)
+    real_stdout = sys.stdout
+    sys.stdout = tls
+    try:
+        results: dict[int, dict] = {}
+        threads = [
+            threading.Thread(target=_run_writer, args=(fn, argv, results, i, tls))
+            for i, argv in enumerate(argvs)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+    finally:
+        sys.stdout = real_stdout
+    return [results[i] for i in range(len(argvs))]
+
+
+def test_concurrent_save_findings_serialize(seeded_project, tmp_path):
+    """N threads saving findings into one session DB all succeed (serialize)."""
+    project = seeded_project["project"]
+    cited = _cited_chunk(project, seeded_project["doc_a"])
+
+    n = 6
+    argvs = []
+    for i in range(n):
+        bf = tmp_path / f"save_{i}.md"
+        bf.write_text(f"Concurrent claim {i}[^{cited}].", encoding="utf-8")
+        argvs.append([
+            "--project", project,
+            "--title", f"concurrent-{i}",
+            "--description", "race",
+            "--body-file", str(bf),
+        ])
+
+    outcomes = _run_concurrently(save_finding.main, argvs)
+    _assert_no_busy(outcomes)
+
+    # All N findings landed — serialization preserved every write.
+    conn = open_db(project)
+    try:
+        count = conn.cursor().execute(
+            "SELECT COUNT(*) FROM findings WHERE title LIKE 'concurrent-%'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == n
+
+
+def _save_one(project, title, body_file) -> int:
+    """Save a single finding sequentially; return its id (capturing stdout)."""
+    import io
+
+    buf = io.StringIO()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        save_finding.main([
+            "--project", project,
+            "--title", title,
+            "--description", "seed",
+            "--body-file", str(body_file),
+        ])
+    finally:
+        sys.stdout = old
+    return json.loads(buf.getvalue())["finding_id"]
+
+
+def test_concurrent_edit_findings_serialize(seeded_project, tmp_path):
+    """N threads editing distinct findings in one session DB all succeed.
+
+    ``edit_finding`` reads the stored body before it rewrites it — the exact
+    read-then-write shape that tripped the deferred-transaction BUSY trap.
+    """
+    project = seeded_project["project"]
+    cited = _cited_chunk(project, seeded_project["doc_a"])
+
+    n = 6
+    finding_ids: list[int] = []
+    # Seed N findings up front (sequentially) so each thread edits its own.
+    for i in range(n):
+        bf = tmp_path / f"seed_{i}.md"
+        bf.write_text(f"Seed body {i}[^{cited}].", encoding="utf-8")
+        finding_ids.append(_save_one(project, f"edit-seed-{i}", bf))
+
+    argvs = []
+    for i in range(n):
+        bf = tmp_path / f"edit_{i}.md"
+        bf.write_text(f"Edited body {i}[^{cited}].", encoding="utf-8")
+        argvs.append([
+            "--project", project,
+            "--finding", str(finding_ids[i]),
+            "--body-file", str(bf),
+        ])
+
+    outcomes = _run_concurrently(edit_finding.main, argvs)
+    _assert_no_busy(outcomes)
+
+    # Every edit took effect.
+    conn = open_db(project)
+    try:
+        cur = conn.cursor()
+        for i, fid in enumerate(finding_ids):
+            body = cur.execute(
+                "SELECT body FROM findings WHERE finding_id = ?", (fid,)
+            ).fetchone()[0]
+            assert body == f"Edited body {i}[^{cited}]."
+    finally:
+        conn.close()

--- a/tests/test_skill_concurrent_writes.py
+++ b/tests/test_skill_concurrent_writes.py
@@ -26,8 +26,6 @@ import json
 import sys
 import threading
 
-import pytest
-
 from bartleby.db.connection import open_db
 from bartleby.skill_scripts import edit_finding, save_finding
 from tests._skill_fixtures import (  # noqa: F401


### PR DESCRIPTION
Part of #565. Part of #562.

## Problem

~5 concurrent `save_finding`/`edit_finding` calls into one session DB hit a spurious **first-attempt `BusyError`** instead of serializing. Two coupled root causes, both the SQLite "lock taken with no busy timeout configured" trap:

1. **The read-to-write upgrade trap at the mutating seam.** `skill_runner.run` opened the mutating transaction with apsw's `with conn:` — a *deferred* transaction that takes no write lock until its first write. Every finding write reads before it writes (resolve session, validate citations, read prior body), so it hits SQLite's read-to-write upgrade: the upgrade returns `SQLITE_BUSY` **immediately, ignoring `busy_timeout`** (the timeout governs initial lock acquisition, not a mid-transaction upgrade).

2. **`journal_mode = WAL` ran before `busy_timeout` was set.** In `connection._attach`, the WAL pragma itself takes a database lock; with the timeout pragma running *after* it, a second connection opening the same DB concurrently `BusyError`'d on first contact during `open_db`.

## Fix

1. `bartleby/skill_runner.py` — replace the bare `with conn:` at the seam with an explicit `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`. The write lock is taken up front, so `busy_timeout` (5s) governs the wait and concurrent writers block-and-serialize. The inner `with conn:` blocks in the chunk helpers (`bartleby/db/chunks.py`) still nest as **savepoints** under the now-open outer transaction — atomic rollback is preserved (covered by the existing `test_save_finding_failure_mid_write_leaves_no_trace`).
2. `bartleby/db/connection.py` — set `PRAGMA busy_timeout` **before** `PRAGMA journal_mode = WAL` in `_attach`, so the WAL pragma (and every later statement) waits out a held lock instead of failing on first contact.

## Test

`tests/test_skill_concurrent_writes.py` — spawns N threads doing `save_finding` / `edit_finding` into one sandbox project DB (built from fixtures, no live corpus, no network) and asserts none fail with a first-attempt `BusyError`; both writes serialize and all land. Verified the test **fails on the pre-fix code** and passes after.

## Schema

Skill/query-surface only — **no** `SCHEMA_VERSION` bump, no `upgrades.py`, no re-ingest.

Full suite: `1152 passed, 2 skipped` (the 2 skips are the drawer-absent skill-drift tests).