### PR TITLE
finding export/import: out-of-band MD share (Part of #574)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,15 @@ bartleby serve
 
 Spins up a local SvelteKit UI for the active project — a corpus overview, document and finding browsers, and full-corpus search, with inline citations that link into the source PDFs at the cited page (full tour under [`bartleby serve`](#bartleby-serve)). It opens the database read-only, so it's safe to leave running alongside an ingest or a research session. Requires Node.js and npm on `PATH`.
 
+### 6. Share a single finding out of band
+
+```
+bartleby finding export <finding-id>            # writes <slug>.md (or pass --out PATH)
+bartleby finding import path/to/finding.md      # into the active project (or --project)
+```
+
+`finding export` writes a self-describing Markdown artifact: a YAML front-matter block (title, description, and baked-in provenance — the source corpus, the original finding id, and the export date) followed by the body. The body's corpus citations are rewritten inline as inert `[corpus: <file> · p.<N>]` markers so the artifact stands alone on a machine that doesn't have the corpus. `finding import` parses such an artifact into a project through the normal finding write path, prepending the provenance as a header line to the body (there's no author/origin column, so origin lives in the text). Imported corpus citations stay inert markers — they are *not* re-resolved to local chunk ids — and the finding then renders like any other local finding. This is the lightweight, no-S3 alternative to `bartleby project publish` / `import` when you just want to hand one finding to someone.
+
 ---
 
 ## Architecture

--- a/bartleby/cli.py
+++ b/bartleby/cli.py
@@ -103,6 +103,27 @@ def main():
              "prompting (drops its local findings)",
     )
 
+    finding_parser = subparsers.add_parser(
+        "finding", help="Export / import a single finding as a self-describing .md"
+    )
+    finding_sub = finding_parser.add_subparsers(dest="finding_command")
+    fex = finding_sub.add_parser(
+        "export",
+        help="Write a self-describing .md (front-matter + provenance) for a finding",
+    )
+    fex.add_argument("finding_id", type=int, metavar="finding-id")
+    fex.add_argument("--project", type=str, default=None)
+    fex.add_argument(
+        "--out", type=str, default=None, metavar="PATH",
+        help="Output path (default: <slugified-title>.md in the cwd).",
+    )
+    fim = finding_sub.add_parser(
+        "import",
+        help="Import a finding artifact .md into a project (provenance baked in)",
+    )
+    fim.add_argument("path", type=str)
+    fim.add_argument("--project", type=str, default=None)
+
     scribe_parser = subparsers.add_parser(
         "scribe",
         help="Ingest PDF, HTML, MD, TXT, and image files into a project",
@@ -334,6 +355,7 @@ def main():
         "config": lambda: _config(),
         "ready": lambda: _ready(args),
         "project": lambda: _project(args, project_parser),
+        "finding": lambda: _finding(args, finding_parser),
         "scribe": lambda: _scribe(args),
         "session": lambda: _session(args, session_parser),
         "embed": lambda: _embed(args),
@@ -459,6 +481,21 @@ def _project(args, parser):
             name=args.name, from_url=args.from_url,
             without_tags=args.without_tags, yes=args.yes,
         )
+
+
+def _finding(args, parser):
+    from bartleby.commands import finding as finding_cmd
+
+    if not args.finding_command:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.finding_command == "export":
+        finding_cmd.export(
+            finding_id=args.finding_id, project=args.project, out=args.out,
+        )
+    elif args.finding_command == "import":
+        finding_cmd.import_(path=args.path, project=args.project)
 
 
 def _session(args, parser):

--- a/bartleby/commands/finding.py
+++ b/bartleby/commands/finding.py
@@ -1,0 +1,304 @@
+"""`bartleby finding` — out-of-band Markdown share of a single finding.
+
+Two halves of one artifact format:
+
+- ``export <finding-id>`` reads a finding from a corpus and writes a
+  self-describing ``.md``: a YAML front-matter block (title, description, and
+  baked-in provenance — the source corpus, the original finding id, and the
+  export date) followed by the finding body. The body's corpus ``[^N]`` chunk
+  citations are rewritten *inline* as inert ``[corpus: <file> · p.<N>]`` markers
+  so the artifact stands alone on another machine where the raw chunk_ids are
+  meaningless. Finding-to-finding citations are inlined the same way (carrying
+  the cited finding's title). External ``[^url:…]`` / ``[^doc:…]`` markers are
+  left verbatim — they're already self-describing.
+
+- ``import <path>`` parses such an artifact and writes it into the active (or
+  ``--project``) corpus through the same finding write path ``save_finding``
+  uses (chunk + embed the body, insert via the typed chunk helpers). Provenance
+  is prepended to the body as a human-readable header line, so it survives
+  with the finding even though ``findings`` has no author/origin column (no
+  schema change). The corpus citations stay inert ``[corpus: …]`` markers; they
+  are deliberately NOT re-resolved to local chunk_ids (a raw chunk_id has no
+  meaning across machines — the cross-machine natural-key resolver is a
+  deferred follow-up). An imported finding renders like any other local finding
+  in the read-only web viewer.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import apsw
+import yaml
+from rich.console import Console
+
+from bartleby.db.connection import open_db
+from bartleby.lib import console
+from bartleby.project import get_active_project
+
+
+_console = Console()
+
+# Local chunk citation: ``[^N]`` (standard footnote with a chunk_id). Same shape
+# the finding write path recognises (``_common._CITATION_MARKER``).
+_CHUNK_MARKER = re.compile(r"\[\^(\d+)\]")
+# An inert corpus citation an export emits / an import preserves verbatim. It is
+# deliberately NOT a ``[^…]`` footnote (so the finding write path's malformed-
+# and external-citation guards never trip on it) and carries no digits in the
+# leading bracket (so it can't be mistaken for a ``[N]`` malformed marker).
+_INERT_PREFIX = "[corpus: "
+
+
+def _open_or_exit(corpus: str):
+    """Open a corpus DB or exit(1) with a one-line error (no traceback)."""
+    try:
+        return open_db(corpus)
+    except (RuntimeError, FileNotFoundError, apsw.Error) as e:
+        console.error(str(e))
+        sys.exit(1)
+
+
+def _slug(title: str) -> str:
+    """Filename slug from a title — mirrors the web viewer's download logic."""
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug or "finding"
+
+
+def _inert_marker(citation: dict) -> str:
+    """An inert, human-readable ``[corpus: …]`` marker for one resolved citation.
+
+    Carries ``file · page`` for corpus chunks (the metadata a reader needs once
+    the chunk_id is meaningless), or the finding title for finding-kind
+    citations. Never a live link — see the module docstring.
+    """
+    if citation["source_kind"] == "finding":
+        label = citation["source_name"] or f"finding {citation['chunk_id']}"
+        return f"{_INERT_PREFIX}finding · {label}]"
+    file_name = citation["file_name"] or citation["source_name"] or "unknown source"
+    page = citation["page_number"]
+    page_part = f" · p.{page}" if page is not None else ""
+    return f"{_INERT_PREFIX}{file_name}{page_part}]"
+
+
+def _rewrite_citations(body: str, citations: list[dict]) -> str:
+    """Replace each ``[^N]`` marker with its inert ``[corpus: …]`` equivalent.
+
+    ``citations`` is the resolved-citation list (chunk_id → file/page/title) the
+    read path returns. A marker whose chunk_id isn't in the resolved set (a
+    dangling citation — the source was removed) is left as a bare
+    ``[corpus: source no longer available]`` so the provenance fact survives.
+    """
+    by_id = {c["chunk_id"]: c for c in citations}
+
+    def _sub(m: re.Match) -> str:
+        chunk_id = int(m.group(1))
+        citation = by_id.get(chunk_id)
+        if citation is None:
+            return f"{_INERT_PREFIX}source no longer available]"
+        return _inert_marker(citation)
+
+    return _CHUNK_MARKER.sub(_sub, body)
+
+
+def _read_finding_for_export(conn, finding_id: int) -> dict:
+    """Read one finding (title/description/body + resolved citations) for export.
+
+    Mirrors ``read_finding``'s reads but stays CLI-side and does no memory-wall
+    check — export is a human operation over the local corpus, not an agent
+    session.
+    """
+    from bartleby.skill_scripts._common import (
+        finding_chunk_and_citation_ids,
+        resolve_citations,
+    )
+
+    cur = conn.cursor()
+    row = cur.execute(
+        "SELECT title, description, body FROM findings WHERE finding_id = ?",
+        (finding_id,),
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"No finding with id {finding_id} in this corpus.")
+    title, description, body = row
+    _chunk_ids, citation_ids = finding_chunk_and_citation_ids(cur, finding_id)
+    return {
+        "title": title,
+        "description": description,
+        "body": body,
+        "citations": resolve_citations(conn, citation_ids),
+    }
+
+
+def export(*, finding_id: int, project: str | None, out: str | None) -> None:
+    """Emit a self-describing ``.md`` artifact for one finding.
+
+    The artifact carries everything ``import`` needs to stand alone: YAML
+    front-matter (title/description + provenance) and the body with corpus
+    citations rewritten inline as inert ``[corpus: …]`` markers.
+    """
+    corpus = project or get_active_project()
+    if not corpus:
+        console.error("No active project. Specify one with --project.")
+        sys.exit(1)
+
+    conn = _open_or_exit(corpus)
+    try:
+        finding = _read_finding_for_export(conn, finding_id)
+    except ValueError as e:
+        console.error(str(e))
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    rewritten = _rewrite_citations(finding["body"], finding["citations"])
+    front_matter = {
+        "title": finding["title"],
+        "description": finding["description"],
+        "provenance": {
+            "source_corpus": corpus,
+            "source_finding_id": finding_id,
+            "exported_on": date.today().isoformat(),
+        },
+    }
+    artifact = (
+        "---\n"
+        + yaml.safe_dump(front_matter, default_flow_style=False, sort_keys=False)
+        + "---\n\n"
+        + rewritten.rstrip("\n")
+        + "\n"
+    )
+
+    out_path = Path(out) if out else Path(f"{_slug(finding['title'])}.md")
+    out_path.write_text(artifact, encoding="utf-8")
+    _console.print(
+        f"[bold green]Exported finding #{finding_id}[/bold green] "
+        f"from [cyan]{corpus}[/cyan] to [cyan]{out_path}[/cyan]"
+    )
+
+
+# A front-matter document is a leading ``---`` line, the YAML block, a closing
+# ``---`` line, then the body. Captured non-greedily so a ``---`` inside the body
+# (a markdown horizontal rule) doesn't terminate the block early.
+_FRONT_MATTER = re.compile(r"\A---\n(.*?)\n---\n?(.*)\Z", re.DOTALL)
+
+
+def parse_artifact(text: str) -> dict:
+    """Parse an exported artifact into ``{title, description, provenance, body}``.
+
+    Raises ``ValueError`` on a missing/blank front-matter block or a missing
+    title — the artifact is the contract, and a malformed one is a user error,
+    not a traceback.
+    """
+    m = _FRONT_MATTER.match(text)
+    if not m:
+        raise ValueError(
+            "Not a Bartleby finding artifact: missing the leading YAML "
+            "front-matter block (--- ... ---)."
+        )
+    try:
+        meta = yaml.safe_load(m.group(1)) or {}
+    except yaml.YAMLError as e:
+        raise ValueError(f"Malformed front-matter YAML: {e}") from None
+    if not isinstance(meta, dict):
+        raise ValueError("Front-matter must be a YAML mapping.")
+
+    title = (meta.get("title") or "").strip()
+    description = (meta.get("description") or "").strip()
+    body = m.group(2).strip()
+    if not title:
+        raise ValueError("Artifact front-matter is missing a non-empty title.")
+    if not body:
+        raise ValueError("Artifact has an empty body.")
+    return {
+        "title": title,
+        "description": description,
+        "provenance": meta.get("provenance") or {},
+        "body": body,
+    }
+
+
+def _provenance_header(provenance: dict) -> str:
+    """A human-readable provenance line to prepend to an imported body.
+
+    ``findings`` has no author/origin column, so origin must live in the text.
+    Falls back gracefully when a field is absent (a hand-written artifact)."""
+    corpus = provenance.get("source_corpus")
+    orig = provenance.get("source_finding_id")
+    exported = provenance.get("exported_on")
+    bits = []
+    if corpus:
+        bits.append(f"corpus `{corpus}`")
+    if orig is not None:
+        bits.append(f"orig. finding #{orig}")
+    if exported:
+        bits.append(f"exported {exported}")
+    where = ", ".join(bits) if bits else "an external artifact"
+    return f"_Imported from {where}._"
+
+
+def import_(*, path: str, project: str | None) -> None:
+    """Import a finding artifact into a corpus through the finding write path.
+
+    Provenance is baked into the body as a header line (no schema change);
+    corpus citations stay inert ``[corpus: …]`` markers (not re-resolved to
+    local chunk_ids — see the module docstring).
+    """
+    from bartleby.session import ensure_active_session
+    from bartleby.skill_scripts._common import (
+        embed_body_chunks,
+        write_finding_chunks,
+    )
+
+    artifact_path = Path(path)
+    if not artifact_path.is_file():
+        console.error(f"Artifact not found: {artifact_path}")
+        sys.exit(1)
+    try:
+        parsed = parse_artifact(artifact_path.read_text(encoding="utf-8"))
+    except ValueError as e:
+        console.error(str(e))
+        sys.exit(1)
+
+    corpus = project or get_active_project()
+    if not corpus:
+        console.error("No active project. Specify one with --project.")
+        sys.exit(1)
+
+    # Bake provenance into the body so it travels with the finding (no
+    # author/origin column exists). A blank line separates the header from the
+    # original prose.
+    body = f"{_provenance_header(parsed['provenance'])}\n\n{parsed['body']}"
+
+    conn = _open_or_exit(corpus)
+
+    # Embed before opening the write (same ordering rationale as save_finding).
+    chunk_inputs = embed_body_chunks(body)
+    try:
+        session_id = ensure_active_session(corpus)
+        cur = conn.cursor()
+        cur.execute("BEGIN IMMEDIATE")
+        try:
+            cur.execute(
+                "INSERT INTO findings (session_id, title, description, body) "
+                "VALUES (?, ?, ?, ?)",
+                (session_id, parsed["title"], parsed["description"], body),
+            )
+            finding_id = conn.last_insert_rowid()
+            # Corpus citations are inert markers, so there are no live chunk
+            # citations to record — only the body chunks are written.
+            write_finding_chunks(conn, finding_id, chunk_inputs)
+        except BaseException:
+            cur.execute("ROLLBACK")
+            raise
+        else:
+            cur.execute("COMMIT")
+    finally:
+        conn.close()
+
+    _console.print(
+        f"[bold green]Imported finding #{finding_id}[/bold green] "
+        f"into [cyan]{corpus}[/cyan] (provenance baked into the body)"
+    )

--- a/tests/test_finding_export_import.py
+++ b/tests/test_finding_export_import.py
@@ -1,0 +1,236 @@
+"""Tests for `bartleby finding export` / `import` (out-of-band MD share, #518).
+
+Covers the round trip: export a finding to a self-describing artifact, import it
+into a *fresh* corpus, and assert (a) provenance lands in the body, (b) corpus
+citations degrade to inert `[corpus: file · page]` markers rather than live
+chunk links, and (c) the imported finding is a normal local finding.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import bartleby.project
+from bartleby.commands import finding as finding_cmd
+from bartleby.db.connection import open_db
+from bartleby.skill_scripts import save_finding
+from tests._skill_fixtures import (  # noqa: F401
+    mock_embed,
+    project_env,
+    seeded_project,
+)
+
+
+def _save_a_finding(seeded_project, tmp_path, capsys, *, with_page=False):
+    """Save a finding citing real corpus chunks; return its parsed response."""
+    conn = open_db(seeded_project["project"])
+    try:
+        cur = conn.cursor()
+        if with_page:
+            from bartleby.db.chunks import ChunkInput, insert_document_chunks
+            from bartleby.db.schema import EMBEDDING_DIM
+
+            emb = [0.01 * i for i in range(EMBEDDING_DIM)]
+            insert_document_chunks(conn, seeded_project["doc_a"], [
+                ChunkInput(text="paged chunk", embedding=emb, chunk_index=9,
+                           section_heading=None, page_number=7, content_type="text"),
+            ])
+            cited = [cur.execute(
+                "SELECT chunk_id FROM chunks WHERE source_kind='document' "
+                "AND source_id=? AND chunk_index=9",
+                (seeded_project["doc_a"],),
+            ).fetchone()[0]]
+        else:
+            cited = [r[0] for r in cur.execute(
+                "SELECT chunk_id FROM chunks WHERE source_kind='document' "
+                "AND source_id = ? ORDER BY chunk_index LIMIT 2",
+                (seeded_project["doc_a"],),
+            ).fetchall()]
+    finally:
+        conn.close()
+
+    body = "# Finding\n\n" + " ".join(f"Claim[^{c}]." for c in cited)
+    body_file = tmp_path / "body.md"
+    body_file.write_text(body, encoding="utf-8")
+    save_finding.main([
+        "--project", seeded_project["project"],
+        "--title", "Air quality gaps",
+        "--description", "Where PM2.5 monitoring is thin.",
+        "--body-file", str(body_file),
+    ])
+    return json.loads(capsys.readouterr().out)
+
+
+def test_export_writes_front_matter_and_inert_citations(
+    seeded_project, tmp_path, capsys
+):
+    saved = _save_a_finding(seeded_project, tmp_path, capsys, with_page=True)
+    out_path = tmp_path / "artifact.md"
+    finding_cmd.export(
+        finding_id=saved["finding_id"],
+        project=seeded_project["project"],
+        out=str(out_path),
+    )
+    text = out_path.read_text(encoding="utf-8")
+
+    # YAML front-matter carries title/description + provenance.
+    parsed = finding_cmd.parse_artifact(text)
+    assert parsed["title"] == "Air quality gaps"
+    assert parsed["description"] == "Where PM2.5 monitoring is thin."
+    assert parsed["provenance"]["source_corpus"] == seeded_project["project"]
+    assert parsed["provenance"]["source_finding_id"] == saved["finding_id"]
+    assert parsed["provenance"]["exported_on"]
+
+    # The live [^N] chunk marker is gone, replaced by an inert file · page marker.
+    assert "[^" not in parsed["body"]
+    assert "[corpus: alpha.pdf · p.7]" in parsed["body"]
+
+
+def test_round_trip_import_into_fresh_corpus(seeded_project, tmp_path, capsys):
+    saved = _save_a_finding(seeded_project, tmp_path, capsys)
+    out_path = tmp_path / "artifact.md"
+    finding_cmd.export(
+        finding_id=saved["finding_id"],
+        project=seeded_project["project"],
+        out=str(out_path),
+    )
+    capsys.readouterr()
+
+    # A *fresh* corpus with none of the source chunk_ids.
+    bartleby.project.create_project("fresh")
+    finding_cmd.import_(path=str(out_path), project="fresh")
+
+    conn = open_db("fresh")
+    try:
+        cur = conn.cursor()
+        rows = cur.execute(
+            "SELECT finding_id, title, description, body FROM findings"
+        ).fetchall()
+        assert len(rows) == 1
+        finding_id, title, description, body = rows[0]
+        assert title == "Air quality gaps"
+        assert description == "Where PM2.5 monitoring is thin."
+
+        # Provenance baked into the body text (no schema column for it).
+        assert "Imported from" in body
+        assert f"orig. finding #{saved['finding_id']}" in body
+        assert f"corpus `{seeded_project['project']}`" in body
+
+        # Corpus citations are inert markers carrying file metadata, NOT live
+        # [^N] chunk links, and no live citation rows were written.
+        assert "[corpus: alpha.pdf]" in body
+        assert "[^" not in body
+        n_cites = cur.execute(
+            "SELECT COUNT(*) FROM finding_citations WHERE finding_id = ?",
+            (finding_id,),
+        ).fetchone()[0]
+        assert n_cites == 0
+
+        # The body was chunked + embedded like any local finding.
+        n_chunks = cur.execute(
+            "SELECT COUNT(*) FROM chunks WHERE source_kind='finding' "
+            "AND source_id = ?",
+            (finding_id,),
+        ).fetchone()[0]
+        assert n_chunks >= 1
+    finally:
+        conn.close()
+
+
+def test_imported_finding_reads_back_like_a_local_one(
+    seeded_project, tmp_path, capsys
+):
+    """An imported finding is reachable through the normal read path."""
+    from bartleby.skill_scripts import read_finding
+
+    saved = _save_a_finding(seeded_project, tmp_path, capsys)
+    out_path = tmp_path / "artifact.md"
+    finding_cmd.export(
+        finding_id=saved["finding_id"], project=seeded_project["project"],
+        out=str(out_path),
+    )
+    capsys.readouterr()
+
+    bartleby.project.create_project("fresh")
+    finding_cmd.import_(path=str(out_path), project="fresh")
+    capsys.readouterr()
+
+    conn = open_db("fresh")
+    try:
+        new_id = conn.cursor().execute("SELECT finding_id FROM findings").fetchone()[0]
+    finally:
+        conn.close()
+
+    read_finding.main(["--project", "fresh", "--finding", str(new_id)])
+    read_out = json.loads(capsys.readouterr().out)
+    assert read_out["title"] == "Air quality gaps"
+    assert "Imported from" in read_out["body"]
+    # No live citations resolved (the corpus markers are inert).
+    assert read_out["citations"] == []
+
+
+def test_export_missing_finding_errors(seeded_project, capsys):
+    with pytest.raises(SystemExit) as exc:
+        finding_cmd.export(finding_id=999999, project=seeded_project["project"],
+                           out=None)
+    assert exc.value.code == 1
+
+
+def test_import_rejects_non_artifact(seeded_project, tmp_path, capsys):
+    bad = tmp_path / "plain.md"
+    bad.write_text("# just markdown, no front matter\n", encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        finding_cmd.import_(path=str(bad), project=seeded_project["project"])
+    assert exc.value.code == 1
+
+
+def test_export_default_filename_slug(seeded_project, tmp_path, capsys, monkeypatch):
+    """Omitting --out writes <slug>.md in the cwd, mirroring the web download."""
+    saved = _save_a_finding(seeded_project, tmp_path, capsys)
+    monkeypatch.chdir(tmp_path)
+    finding_cmd.export(finding_id=saved["finding_id"],
+                       project=seeded_project["project"], out=None)
+    assert (tmp_path / "air-quality-gaps.md").is_file()
+
+
+def test_finding_to_finding_citation_inlines_title(
+    seeded_project, tmp_path, capsys
+):
+    """A [^N] citing a finding-kind chunk degrades to a titled inert marker."""
+    # First finding (cites a document chunk).
+    first = _save_a_finding(seeded_project, tmp_path, capsys)
+    conn = open_db(seeded_project["project"])
+    try:
+        finding_chunk = conn.cursor().execute(
+            "SELECT chunk_id FROM chunks WHERE source_kind='finding' "
+            "AND source_id = ? LIMIT 1",
+            (first["finding_id"],),
+        ).fetchone()[0]
+        doc_chunk = conn.cursor().execute(
+            "SELECT chunk_id FROM chunks WHERE source_kind='document' "
+            "AND source_id = ? ORDER BY chunk_index LIMIT 1",
+            (seeded_project["doc_a"],),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    # Second finding cites both a document chunk (required) and the first
+    # finding's chunk.
+    body = f"Builds on prior work[^{finding_chunk}], grounded in evidence[^{doc_chunk}]."
+    body_file = tmp_path / "second.md"
+    body_file.write_text(body, encoding="utf-8")
+    save_finding.main([
+        "--project", seeded_project["project"],
+        "--title", "Second finding", "--description", "d",
+        "--body-file", str(body_file),
+    ])
+    second = json.loads(capsys.readouterr().out)
+
+    out_path = tmp_path / "second.artifact.md"
+    finding_cmd.export(finding_id=second["finding_id"],
+                       project=seeded_project["project"], out=str(out_path))
+    artifact = out_path.read_text(encoding="utf-8")
+    assert "[corpus: finding · Air quality gaps]" in artifact
+    assert "[^" not in finding_cmd.parse_artifact(artifact)["body"]


### PR DESCRIPTION
Adds a `bartleby finding` CLI command group for sharing a single finding out of band as a self-describing Markdown artifact (builds on #494).

## What this does
- **`bartleby finding export <finding-id> [--out PATH] [--project P]`** — writes a self-describing `.md`: a YAML front-matter block (title, description, and baked-in provenance: source corpus, original finding id, export date) followed by the body. Corpus `[^N]` chunk citations are rewritten **inline** as inert `[corpus: <file> · p.<N>]` markers (finding-to-finding citations carry the cited finding's title) so the artifact stands alone on a machine without the corpus. External `[^url:…]`/`[^doc:…]` markers are left verbatim. Default filename mirrors the web viewer's title-slug logic.
- **`bartleby finding import <path> [--project P]`** — parses the artifact and writes it into a corpus through the same finding write path `save_finding` uses (chunk + embed the body via the typed `bartleby.db.chunks` helpers). Provenance is **baked into the body** as a header line, since `findings` has no author/origin column — **no schema change, no `SCHEMA_VERSION` bump**.

## Citation handling (B1, B2 deferred)
Imported corpus citations stay **inert `[corpus: …]` markers carrying human `file · page` metadata** (B1). They are deliberately **not** re-resolved to local chunk ids — a raw chunk_id is meaningless across machines, and the cross-machine natural-key resolver (B2) is a deferred follow-up. No live `finding_citations` rows are written for them. The read-only web viewer is unchanged: an imported finding renders like any other local finding.

## Tests
`tests/test_finding_export_import.py` (7 tests): front-matter + inert-citation rewrite on export; full round-trip export → import into a **fresh** corpus (asserts provenance lands in the body, corpus citations degrade to inert `file · page` markers, zero live citation rows, body chunked/embedded); imported finding reads back via `read_finding`; finding-to-finding citation inlines the title; default-filename slug; and error paths (missing finding, non-artifact import).

`uv run pytest`: **1180 passed, 2 skipped**. simplify-refactor pass applied (deduped open-db guard, dropped a no-op citation clear, hoisted an import).

Part of #574.