### PR TITLE
project import --from <local-path>: local/file:// transport (Part of #574)

### DIFF
--- a/bartleby/cli.py
+++ b/bartleby/cli.py
@@ -86,12 +86,14 @@ def main():
     )
     pimp = project_sub.add_parser(
         "import",
-        help="Import a published corpus from S3 as a new local project",
+        help="Import a published corpus (from S3 or a local/file:// path) "
+             "as a new local project",
     )
     pimp.add_argument("name", type=str)
     pimp.add_argument(
-        "--from", required=True, metavar="S3_URL", dest="from_url",
-        help="Source S3 URL, e.g. s3://my-bucket/corpora/acme",
+        "--from", required=True, metavar="SOURCE", dest="from_url",
+        help="Source: an s3:// URL (s3://my-bucket/corpora/acme), a local "
+             "directory, or a file:// URL pointing at a published artifact",
     )
     pimp.add_argument(
         "--without-tags", action="store_true",

--- a/bartleby/commands/project.py
+++ b/bartleby/commands/project.py
@@ -248,12 +248,14 @@ def publish(*, name: str, to: str) -> None:
 
 
 def import_(*, name: str, from_url: str, without_tags: bool, yes: bool) -> None:
-    """Import a published corpus from an S3 URL as a fresh local project.
+    """Import a published corpus as a fresh local project.
 
-    Downloads the published ``.db`` + originals, verifies schema and embedding
-    model BEFORE trusting the corpus (a compatibility mismatch — or a missing
-    embedding-model key — is an unconditional hard refuse), then adopts the
-    ``.db`` as-is and rewrites local file paths by ``file_hash``.
+    ``from_url`` is either an ``s3://`` URL or a local directory / ``file://``
+    URL holding the same artifact ``publish`` produces. Fetches the published
+    ``.db`` + originals, verifies schema and embedding model BEFORE trusting the
+    corpus (a compatibility mismatch — or a missing embedding-model key — is an
+    unconditional hard refuse), then adopts the ``.db`` as-is and rewrites local
+    file paths by ``file_hash``.
     ``--without-tags`` drops the adopted tag definitions and assignments.
     Overwriting an existing project of the same name (which drops its local
     findings) is gated like ``project delete``: it prompts for confirmation

--- a/bartleby/share/__init__.py
+++ b/bartleby/share/__init__.py
@@ -1,8 +1,12 @@
-"""Corpus sharing: publish a findings-free copy of a corpus to S3.
+"""Corpus sharing: publish a findings-free copy of a corpus, and import it back.
 
-``bartleby project publish <name> --to <s3-url>`` lives here. The package is
-two thin pieces: :mod:`bartleby.share.s3` (a put/get wrapper over a real boto3
-client) and :mod:`bartleby.share.publish` (the VACUUM-INTO copy, the bounded
-session-layer strip on that copy, and the upload of the ``.db`` plus the
-content-addressed original files). The source corpus is never mutated.
+``bartleby project publish <name> --to <s3-url>`` and
+``bartleby project import <name> --from <source>`` live here. The pieces:
+:mod:`bartleby.share.s3` (a put/get wrapper over a real boto3 client),
+:mod:`bartleby.share.publish` (the VACUUM-INTO copy, the bounded session-layer
+strip on that copy, and the upload of the ``.db`` plus the content-addressed
+original files), :mod:`bartleby.share.source` (the artifact-fetch seam — S3 or a
+local directory / ``file://`` URL — that import runs against), and
+:mod:`bartleby.share.import_` (verify + adopt + land, transport-agnostic). The
+source corpus is never mutated.
 """

--- a/bartleby/share/import_.py
+++ b/bartleby/share/import_.py
@@ -1,11 +1,17 @@
-"""Import a published corpus from S3 as a fresh local project.
+"""Import a published corpus as a fresh local project (S3 or local / file://).
 
 The mirror of :mod:`bartleby.share.publish`. ``import`` pulls the published
-``.db`` plus the content-addressed originals down from an ``s3://bucket/prefix``
-URL and adopts the ``.db`` **as-is** — no id rekeying, no merge into an existing
-id space (that incremental-merge machinery is deliberately out of scope). The
-imported corpus is raw material: publish already stripped the session layer, so
-there is nothing findings-related to clean up here.
+``.db`` plus the content-addressed originals from a source — an
+``s3://bucket/prefix`` URL, or a local directory / ``file://`` URL holding the
+same artifact — and adopts the ``.db`` **as-is** — no id rekeying, no merge into
+an existing id space (that incremental-merge machinery is deliberately out of
+scope). The imported corpus is raw material: publish already stripped the
+session layer, so there is nothing findings-related to clean up here.
+
+The transport is the only thing that varies: a single :class:`ArtifactSource`
+seam (:mod:`bartleby.share.source`) answers "give me the bytes of artifact
+``X``", and the entire verify + register + land path below runs against it
+identically regardless of where those bytes came from.
 
 Two compatibility gates run **before** the corpus is registered or trusted, both
 hard-refuse with no ``--force`` override:
@@ -35,7 +41,6 @@ import shutil
 from pathlib import Path
 
 import apsw
-from botocore.exceptions import ClientError
 
 from bartleby.db.connection import _attach, project_db_path
 from bartleby.db.schema import SCHEMA_VERSION
@@ -47,6 +52,14 @@ from bartleby.project import (
 )
 from bartleby.share import s3
 from bartleby.share.publish import PUBLISHED_DB_NAME
+from bartleby.share.source import (
+    ArtifactSource,
+    LocalSource,
+    MissingArtifact,
+    S3Source,
+    is_s3_url,
+    local_root_from_url,
+)
 
 
 class ImportRefused(Exception):
@@ -116,30 +129,31 @@ def _verify_compatible(db_path: Path) -> None:
         )
 
 
-def _land_files(conn: apsw.Connection, target: s3.S3Target, archive: Path,
-                client) -> int:
-    """Download each original by ``file_hash`` and rewrite its ``file_path``.
+def _land_files(conn: apsw.Connection, source: ArtifactSource,
+                archive: Path) -> int:
+    """Fetch each original by ``file_hash`` and rewrite its ``file_path``.
 
-    For every ``documents``/``images`` row, derives the published S3 key
+    For every ``documents``/``images`` row, derives the artifact name
     ``files/<file_hash><ext>`` from the recorded ``file_path``'s suffix, pulls
-    the bytes, writes them into the project ``archive`` at a path derived from
-    the stable ``file_hash``, and rewrites the row's ``file_path`` to that
-    landed path. Idempotent: the landing path depends only on ``file_hash`` (and
-    suffix), so a re-import overwrites in place to identical bytes.
+    the bytes from ``source``, writes them into the project ``archive`` at a path
+    derived from the stable ``file_hash``, and rewrites the row's ``file_path``
+    to that landed path. Idempotent: the landing path depends only on
+    ``file_hash`` (and suffix), so a re-import overwrites in place to identical
+    bytes.
 
     Error handling is deliberately strict: a row whose ``file_path`` is NOT
     rewritten still points at the *publisher's* absolute path, which is dangling
     on this machine — and the web view and search trust that column. So:
 
-    * A genuinely-absent object (boto3 ``NoSuchKey``/404 ``ClientError``) is
-      itself a sign of a corrupt artifact: publish only uploads files it
-      actually found on disk, so a published artifact missing a file it
-      advertised is broken. We refuse the whole import rather than silently
-      leave a dangling row.
+    * A genuinely-absent artifact (:class:`MissingArtifact`, which both the S3
+      and local sources raise for a not-found object) is itself a sign of a
+      corrupt artifact: publish only uploads files it actually found on disk, so
+      a published artifact missing a file it advertised is broken. We refuse the
+      whole import rather than silently leave a dangling row.
     * Any other failure (a transient S3 error, throttling, expired credentials,
-      or a disk-write failure — all brought inside the protected region) aborts
-      the import by re-raising, so the CLI maps it to a non-zero exit and the
-      half-built project is cleaned up.
+      or a disk read/write failure — all brought inside the protected region)
+      aborts the import by re-raising, so the CLI maps it to a non-zero exit and
+      the half-built project is cleaned up.
 
     Returns the count of files landed (every row, on success).
     """
@@ -153,36 +167,24 @@ def _land_files(conn: apsw.Connection, target: s3.S3Target, archive: Path,
             ext = Path(file_path).suffix
             name = f"files/{file_hash}{ext}"
             try:
-                data = s3.get_bytes(client, target, name)
-                if subdir is None:
-                    dest_dir = archive / file_hash
-                else:
-                    dest_dir = archive / subdir
-                dest_dir.mkdir(parents=True, exist_ok=True)
-                dest = dest_dir / f"{file_hash}{ext}"
-                dest.write_bytes(data)
-            except ClientError as e:
-                if _is_missing_key(e):
-                    raise ImportRefused(
-                        f"Published artifact is missing a file it advertised "
-                        f"(object {name!r} for {table} file_hash {file_hash}). "
-                        "The artifact is corrupt — refusing to import a corpus "
-                        "with dangling file references."
-                    ) from e
-                raise
+                data = source.get_bytes(name)
+            except MissingArtifact as e:
+                raise ImportRefused(
+                    f"Published artifact is missing a file it advertised "
+                    f"(object {name!r} for {table} file_hash {file_hash}). "
+                    "The artifact is corrupt — refusing to import a corpus "
+                    "with dangling file references."
+                ) from e
+            dest_dir = archive / (subdir or file_hash)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            dest = dest_dir / f"{file_hash}{ext}"
+            dest.write_bytes(data)
             cur.execute(
                 f"UPDATE {table} SET file_path = ? WHERE file_hash = ?",
                 (str(dest), file_hash),
             )
             landed += 1
     return landed
-
-
-def _is_missing_key(err: ClientError) -> bool:
-    """True if a boto3 ``ClientError`` is an absent-object (NoSuchKey / 404)."""
-    error = err.response.get("Error", {}) if hasattr(err, "response") else {}
-    code = str(error.get("Code", ""))
-    return code in ("NoSuchKey", "404", "NoSuchBucket")
 
 
 def _drop_tags(conn: apsw.Connection) -> None:
@@ -199,26 +201,42 @@ def _drop_tags(conn: apsw.Connection) -> None:
         cur.execute("DELETE FROM tags")
 
 
+def _make_source(from_url: str, client) -> ArtifactSource:
+    """Build the right :class:`ArtifactSource` for ``from_url``.
+
+    Decides the transport by inspecting the value: an ``s3://`` URL → S3 (using
+    the injected/real client); a ``file://`` URL or a plain local path → a local
+    directory. Raises ``ValueError`` on a value that is neither.
+    """
+    if is_s3_url(from_url):
+        target = s3.parse_s3_url(from_url)
+        if client is None:
+            client = s3._client()
+        return S3Source(target, client)
+    return LocalSource(local_root_from_url(from_url))
+
+
 def import_project(name: str, from_url: str, *, client=None,
                    without_tags: bool = False, force: bool = False) -> dict:
     """Import the corpus published at ``from_url`` as local project ``name``.
 
-    Downloads the published ``.db`` + originals from the ``s3://bucket/prefix``
-    URL, verifies schema + embedding-model compatibility **before** registering
-    anything, then adopts the ``.db`` as a fresh project, lands the originals by
-    ``file_hash``, and rewrites their ``file_path``s. ``client`` is injectable so
-    tests pass a stubbed boto3 client; production builds a real one.
+    ``from_url`` is either an ``s3://bucket/prefix`` URL or a local directory /
+    ``file://`` URL holding the same artifact ``publish`` produces. Fetches the
+    published ``.db`` + originals from that source, verifies schema +
+    embedding-model compatibility **before** registering anything, then adopts
+    the ``.db`` as a fresh project, lands the originals by ``file_hash``, and
+    rewrites their ``file_path``s. ``client`` is injectable so tests pass a
+    stubbed boto3 client (it is only consulted for an ``s3://`` source);
+    production builds a real one on demand.
 
     Raises :class:`ImportRefused` on a failed compatibility gate (no side
     effects), or when ``name`` already exists and ``force`` is not set (a
     same-name overwrite is opt-in because it drops the existing project's local
-    findings); ``ValueError`` on a bad name/URL. With ``force``, re-importing an
-    existing project overwrites it idempotently.
+    findings); ``ValueError`` on a bad name/URL/path. With ``force``,
+    re-importing an existing project overwrites it idempotently.
     """
     validate_project_name(name)
-    target = s3.parse_s3_url(from_url)
-    if client is None:
-        client = s3._client()
+    source = _make_source(from_url, client)
 
     project_dir = get_project_dir(name)
     # Whether this project already existed before the import. A re-import
@@ -238,12 +256,18 @@ def import_project(name: str, from_url: str, *, client=None,
             f"Pass --yes to overwrite, or import under a different name."
         )
 
-    # Download + verify in scratch first, so a refused import touches nothing.
+    # Fetch + verify in scratch first, so a refused import touches nothing.
     scratch = project_dir.parent / f".import-tmp-{name}"
     scratch.mkdir(parents=True, exist_ok=True)
     staged_db = scratch / PUBLISHED_DB_NAME
     try:
-        staged_db.write_bytes(s3.get_bytes(client, target, PUBLISHED_DB_NAME))
+        try:
+            staged_db.write_bytes(source.get_bytes(PUBLISHED_DB_NAME))
+        except MissingArtifact as e:
+            raise ImportRefused(
+                f"Import source has no {PUBLISHED_DB_NAME} — not a published "
+                "Bartleby artifact (or the wrong location). Refusing to import."
+            ) from e
         _verify_compatible(staged_db)
 
         # Gates passed — register the project. A re-import overwrites the prior
@@ -277,7 +301,7 @@ def import_project(name: str, from_url: str, *, client=None,
             if without_tags:
                 _drop_tags(conn)
             with conn:
-                file_count = _land_files(conn, target, archive, client)
+                file_count = _land_files(conn, source, archive)
         finally:
             conn.close()
     except BaseException:

--- a/bartleby/share/source.py
+++ b/bartleby/share/source.py
@@ -104,7 +104,7 @@ def local_root_from_url(from_url: str) -> Path:
                 "file:///absolute/path (an empty or localhost host)."
             )
         root = Path(unquote(parsed.path))
-    elif parsed.scheme in ("", None) and not from_url.startswith("s3://"):
+    elif parsed.scheme == "":
         root = Path(from_url)
     else:
         raise ValueError(

--- a/bartleby/share/source.py
+++ b/bartleby/share/source.py
@@ -1,0 +1,125 @@
+"""The artifact-fetch seam shared by every ``project import`` transport.
+
+``import`` adopts the same artifact ``publish`` produces: a ``bartleby.db`` at
+the prefix root plus the content-addressed originals under
+``files/<file_hash><ext>``. The only thing that varies between transports is
+*where those named blobs come from* — S3, or a local directory / ``file://``
+URL. Everything downstream (the schema + embedding-model gates, the ``.db``
+adoption, the ``file_path`` rewrite by ``file_hash``, ``--without-tags``) is
+identical, so it runs against this one narrow seam.
+
+An :class:`ArtifactSource` answers a single question: "give me the bytes of the
+artifact named ``X``". A genuinely-absent artifact raises :class:`MissingArtifact`
+(both transports normalize their own not-found signal to it) so the import layer
+can treat "the artifact advertised a file it doesn't actually hold" uniformly as
+a corrupt-artifact refusal. Any other failure (a transient S3 error, a disk
+read error) propagates unchanged so the import aborts and tears down.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import unquote, urlparse
+
+from botocore.exceptions import ClientError
+
+from bartleby.share import s3
+
+
+class MissingArtifact(Exception):
+    """The source does not hold an artifact it was asked for (absent object)."""
+
+
+class ArtifactSource(Protocol):
+    """Fetch a published artifact's bytes by its name within the artifact set.
+
+    ``name`` is the same relative name on every transport: ``bartleby.db`` for
+    the database, ``files/<file_hash><ext>`` for an original.
+    """
+
+    def get_bytes(self, name: str) -> bytes:
+        """Return the bytes of artifact ``name``; raise :class:`MissingArtifact`
+        if it is genuinely absent."""
+        ...
+
+
+class S3Source:
+    """An :class:`ArtifactSource` backed by an ``s3://bucket/prefix`` artifact."""
+
+    def __init__(self, target: s3.S3Target, client):
+        self._target = target
+        self._client = client
+
+    def get_bytes(self, name: str) -> bytes:
+        try:
+            return s3.get_bytes(self._client, self._target, name)
+        except ClientError as e:
+            if _is_missing_key(e):
+                raise MissingArtifact(name) from e
+            raise
+
+
+class LocalSource:
+    """An :class:`ArtifactSource` backed by a local directory of artifacts.
+
+    Points straight at a directory holding what ``publish`` produces
+    (``bartleby.db`` + ``files/<file_hash><ext>``). No download — the bytes are
+    read off disk — but the same name-keyed contract as :class:`S3Source`, so
+    the import path is identical.
+    """
+
+    def __init__(self, root: Path):
+        self._root = root
+
+    def get_bytes(self, name: str) -> bytes:
+        path = self._root / name
+        try:
+            return path.read_bytes()
+        except FileNotFoundError as e:
+            raise MissingArtifact(name) from e
+
+
+def _is_missing_key(err: ClientError) -> bool:
+    """True if a boto3 ``ClientError`` is an absent-object (NoSuchKey / 404)."""
+    code = str(err.response.get("Error", {}).get("Code", ""))
+    return code in ("NoSuchKey", "404", "NoSuchBucket")
+
+
+def local_root_from_url(from_url: str) -> Path:
+    """Resolve a ``--from`` value to a local artifact directory, or raise.
+
+    Accepts a plain local path (``/path/to/artifact-dir``) or a ``file://`` URL
+    (``file:///path/to/artifact-dir``). Raises ``ValueError`` if the value is an
+    ``s3://`` URL (the caller routes those to S3), or if the resolved directory
+    does not exist / is not a directory.
+    """
+    parsed = urlparse(from_url)
+    if parsed.scheme == "file":
+        # file:///abs/path -> netloc empty, path is the absolute path; a
+        # file://host/path form is not a local path we can read.
+        if parsed.netloc not in ("", "localhost"):
+            raise ValueError(
+                f"Unsupported file:// host in {from_url!r}; expected "
+                "file:///absolute/path (an empty or localhost host)."
+            )
+        root = Path(unquote(parsed.path))
+    elif parsed.scheme in ("", None) and not from_url.startswith("s3://"):
+        root = Path(from_url)
+    else:
+        raise ValueError(
+            f"Not a local path or file:// URL: {from_url!r}."
+        )
+    root = root.expanduser()
+    if not root.is_dir():
+        raise ValueError(
+            f"Local import source is not a directory: {root}. Expected a "
+            "directory holding bartleby.db and files/<file_hash><ext> (what "
+            "`project publish` produces)."
+        )
+    return root
+
+
+def is_s3_url(from_url: str) -> bool:
+    """True if ``from_url`` should be routed to the S3 transport."""
+    return urlparse(from_url).scheme == "s3"

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -597,6 +597,161 @@ def test_publish_command_handler_maps_boto3_error_to_exit(tmp_path, monkeypatch)
     assert exc.value.code == 1
 
 
+# --------------------------------------------------------------------------- #
+# #521 — local / file:// import transport. The same published artifact, fetched
+# from a local directory instead of S3, runs the identical verify + adopt + land
+# path. We materialize the artifact a publish produced (the stub's objects) into
+# a local dir laid out exactly as publish writes it (bartleby.db at the root,
+# files/<file_hash><ext>), then import --from that dir and from a file:// URL.
+# --------------------------------------------------------------------------- #
+
+from bartleby.share import source as source_mod  # noqa: E402
+
+
+def _materialize_artifact_dir(client: FakeS3Client, bucket: str, prefix: str,
+                              dest: Path) -> Path:
+    """Write the stub's objects under ``prefix`` into ``dest`` (publish layout)."""
+    dest.mkdir(parents=True, exist_ok=True)
+    plen = len(prefix.rstrip("/")) + 1
+    for (b, key), data in client.objects.items():
+        if b != bucket or not key.startswith(prefix.rstrip("/") + "/"):
+            continue
+        rel = key[plen:]
+        out = dest / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(data)
+    return dest
+
+
+def _local_artifact(published_corpus, tmp_path) -> Path:
+    """Publish ``pub`` to a stub, then lay the artifact out on local disk."""
+    client = _publish_to_stub("pub", "s3://bucket/corpora/pub")
+    return _materialize_artifact_dir(
+        client, "bucket", "corpora/pub", tmp_path / "artifact"
+    )
+
+
+def test_import_from_local_directory(published_corpus, tmp_path):
+    artifact = _local_artifact(published_corpus, tmp_path)
+
+    result = import_mod.import_project("from-local", str(artifact))
+
+    assert result["project"] == "from-local"
+    assert result["source"] == str(artifact)
+    assert result["file_count"] == 2
+    assert bartleby.project.get_active_project() == "from-local"
+
+    archive = import_mod.get_project_dir("from-local") / "archive"
+    conn = open_db("from-local")
+    try:
+        cur = conn.cursor()
+        assert cur.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 2
+        # file_path rewritten under the imported archive, keyed by file_hash.
+        for file_hash, file_path in cur.execute(
+            "SELECT file_hash, file_path FROM documents"
+        ).fetchall():
+            assert str(archive) in file_path
+            assert file_hash in file_path
+            assert Path(file_path).is_file()
+    finally:
+        conn.close()
+
+
+def test_import_from_file_url(published_corpus, tmp_path):
+    artifact = _local_artifact(published_corpus, tmp_path)
+    file_url = artifact.as_uri()  # file:///abs/path
+    assert file_url.startswith("file://")
+
+    result = import_mod.import_project("from-file-url", file_url)
+
+    assert result["file_count"] == 2
+    conn = open_db("from-file-url")
+    try:
+        n = conn.cursor().execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 2
+
+
+def test_import_local_without_tags(published_corpus, tmp_path):
+    artifact = _local_artifact(published_corpus, tmp_path)
+
+    import_mod.import_project("local-no-tags", str(artifact), without_tags=True)
+    conn = open_db("local-no-tags")
+    try:
+        cur = conn.cursor()
+        assert cur.execute("SELECT COUNT(*) FROM tags").fetchone()[0] == 0
+        assert cur.execute("SELECT COUNT(*) FROM document_tags").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_import_local_refuses_embedding_model_mismatch(published_corpus, tmp_path):
+    artifact = _local_artifact(published_corpus, tmp_path)
+    # Mutate the on-disk .db so its embedding model no longer matches.
+    db = artifact / "bartleby.db"
+    conn = apsw.Connection(str(db))
+    try:
+        with conn:
+            conn.cursor().execute(
+                "UPDATE meta SET value = 'some/other-model' "
+                "WHERE key = 'embedding_model'"
+            )
+    finally:
+        conn.close()
+
+    with pytest.raises(import_mod.ImportRefused):
+        import_mod.import_project("nope", str(artifact))
+    assert not import_mod.get_project_dir("nope").exists()
+
+
+def test_import_local_refuses_missing_db(tmp_path):
+    empty = tmp_path / "empty-artifact"
+    empty.mkdir()
+    with pytest.raises(import_mod.ImportRefused):
+        import_mod.import_project("nope", str(empty))
+    assert not import_mod.get_project_dir("nope").exists()
+
+
+def test_import_local_refuses_missing_advertised_file(published_corpus, tmp_path):
+    artifact = _local_artifact(published_corpus, tmp_path)
+    # Delete one advertised original from the local artifact -> corrupt.
+    for f in (artifact / "files").iterdir():
+        f.unlink()
+        break
+
+    with pytest.raises(import_mod.ImportRefused):
+        import_mod.import_project("nope", str(artifact))
+    assert not import_mod.get_project_dir("nope").exists()
+
+
+def test_import_nonexistent_local_path_is_value_error(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(ValueError):
+        import_mod.import_project("nope", str(missing))
+
+
+def test_local_root_from_url_forms(tmp_path):
+    d = tmp_path / "art"
+    d.mkdir()
+    assert source_mod.local_root_from_url(str(d)) == d
+    assert source_mod.local_root_from_url(d.as_uri()) == d
+    # An s3:// URL is not a local source.
+    with pytest.raises(ValueError):
+        source_mod.local_root_from_url("s3://bucket/prefix")
+    # A non-directory path refuses.
+    with pytest.raises(ValueError):
+        source_mod.local_root_from_url(str(tmp_path / "nope"))
+
+
+def test_make_source_routes_by_value(tmp_path):
+    d = tmp_path / "art"
+    d.mkdir()
+    assert source_mod.is_s3_url("s3://bucket/prefix")
+    assert not source_mod.is_s3_url(str(d))
+    assert not source_mod.is_s3_url(d.as_uri())
+
+
 def test_import_without_tags_drops_tags(published_corpus, tmp_path):
     client = _publish_to_stub("pub", "s3://bucket/corpora/pub")
 


### PR DESCRIPTION
Widens `bartleby project import <name> --from <src>` to accept a **local directory or `file://` URL** holding the same artifact `project publish` produces, in addition to the existing `s3://` source. `--from` stays a bare path flag.

**#520 did not already have a fetch-to-local seam** — the S3 download was entangled with the verify/register/land logic (`s3.get_bytes` calls interleaved through `import_project` and `_land_files`). So this **factors out that seam** (the point of the issue): a new `bartleby/share/source.py` with an `ArtifactSource` protocol (`get_bytes(name) -> bytes`), an `S3Source` and a `LocalSource`, both normalizing their own not-found signal to a shared `MissingArtifact`. The entire downstream path — schema + embedding-model compatibility gates, adopt-`.db`-as-new-project, `file_path` rewrite by `file_hash`, `--without-tags`, and the strict "artifact missing an advertised file -> corrupt -> refuse" handling — now runs against that one seam, identical across transports. **S3 behavior is unchanged** (all pre-existing S3 tests pass untouched).

**Source-type detection** is by inspecting the `--from` value: an `s3://` URL routes to S3; a `file://` URL or an existing local directory routes to local (`is_s3_url` / `local_root_from_url`). A bad/non-directory path is a clean `ValueError`; a local artifact with no `bartleby.db` is a clean `ImportRefused`.

**Test coverage** (added to `tests/test_share.py`, reusing the existing publish-to-stub scaffolding to materialize a real artifact on local disk in publish layout): import from a local dir and from a `file://` URL end-to-end — new project registers, `file_path`s rewritten under the imported archive by `file_hash`, `--without-tags` drops tags; plus refusals for embedding-model mismatch, missing `bartleby.db`, a missing advertised file, and a nonexistent path; and unit coverage of `local_root_from_url` / `is_s3_url`.

No schema change, no SCHEMA_VERSION bump, no re-ingest. No new id flags (`--from` is a path → stays bare, forward-compatible with #573).

`uv run pytest`: 1189 passed, 2 skipped.

Part of #574.