### PR TITLE
Add vision_temperature knob threaded through captioning (#223)

### DIFF
--- a/bartleby/commands/config.py
+++ b/bartleby/commands/config.py
@@ -96,8 +96,7 @@ def _prompt_api_key(provider: str, existing: dict, *, help_text: str | None = No
     return entered or None
 
 
-def _prompt_temperature(existing: dict, *, help_text: str) -> float:
-    default = float(existing.get("temperature", DEFAULT_TEMPERATURE))
+def _prompt_temperature(default: float, *, help_text: str) -> float:
     _help(help_text)
     while True:
         t = FloatPrompt.ask("Temperature", default=default)
@@ -225,7 +224,7 @@ def main():
         config["summary_depth"] = depth
         if depth == "one-shot":
             config["temperature"] = _prompt_temperature(
-                existing,
+                float(existing.get("temperature", DEFAULT_TEMPERATURE)),
                 help_text="0 = deterministic, repeatable summaries; higher = "
                 "more varied wording.\nLeave at 0 unless summaries feel too rigid.",
             )
@@ -340,6 +339,17 @@ def main():
             help_text="Tesseract average confidence (0-100); pages scoring below "
             "this fall back to the VLM.\nHigher = trust OCR less, use the VLM more "
             "(0 = always trust OCR).",
+        )
+        # Captioning temperature, defaulting to the summarize temperature so an
+        # unconfigured corpus keeps one knob (#223). Prefer a value already set
+        # this run, then the existing vision_temperature, then summarize temperature.
+        summarize_temp = float(
+            config.get("temperature", existing.get("temperature", DEFAULT_TEMPERATURE))
+        )
+        config["vision_temperature"] = _prompt_temperature(
+            float(existing.get("vision_temperature", summarize_temp)),
+            help_text="0 = deterministic, repeatable captions; higher = more "
+            "varied wording.\nDefaults to the summarize temperature above.",
         )
         if vprovider != "ollama":
             # Ollama serializes (OLLAMA_NUM_PARALLEL=1), so caption workers

--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -200,6 +200,10 @@ def main(
         timings=timings,
     )
     temperature = float(config.get("temperature", DEFAULT_TEMPERATURE))
+    # Vision captioning gets its own temperature knob, defaulting to the
+    # summarizer temperature when unset (#223) — so a corpus that wants
+    # deterministic summaries but more varied captions can have both.
+    vision_temperature = float(config.get("vision_temperature", temperature))
     # Validate the configured reasoning_effort once, here, before any summarize
     # call reaches a provider. The wizard constrains this value, but a config can
     # be hand-edited — an out-of-enum effort would otherwise crash mid-ingest with
@@ -314,6 +318,7 @@ def main(
             caption._caption_all(
                 writer, units,
                 vision_provider=vision_provider, vision_model=vision_model,
+                vision_temperature=vision_temperature,
                 vision_enabled=parse_config.vision_enabled,
                 caption_workers=caption_workers, timings=timings,
                 phase=progress.phase("caption"),

--- a/bartleby/ingest/caption.py
+++ b/bartleby/ingest/caption.py
@@ -31,6 +31,7 @@ def _analyze_image(
     *,
     vision_provider: Provider,
     vision_model: str,
+    vision_temperature: float,
 ) -> image_pipeline.ImageAnalysis:
     """Run the §7 image pipeline (Tesseract → VLM) on one recorded image row.
 
@@ -45,7 +46,10 @@ def _analyze_image(
         width=pending.width,
         height=pending.height,
     )
-    return image_pipeline.analyze(vision_provider, prepared, model=vision_model)
+    return image_pipeline.analyze(
+        vision_provider, prepared,
+        model=vision_model, temperature=vision_temperature,
+    )
 
 def _caption_from_analysis(
     pending: PendingImage,
@@ -71,6 +75,7 @@ def _caption_all(
     *,
     vision_provider: Provider | None,
     vision_model: str | None,
+    vision_temperature: float,
     vision_enabled: bool,
     caption_workers: int,
     timings: bool,
@@ -155,6 +160,7 @@ def _caption_all(
             phase.lane(threading.get_ident(), owner[image_id].file_name, "captioning")
         return _analyze_image(
             pi, vision_provider=vision_provider, vision_model=vision_model,
+            vision_temperature=vision_temperature,
         )
 
     if caption_workers <= 1:

--- a/bartleby/ingest/images.py
+++ b/bartleby/ingest/images.py
@@ -121,6 +121,7 @@ def analyze(
     prepared: PreparedImage,
     *,
     model: str,
+    temperature: float,
 ) -> ImageAnalysis:
     """Decide text-image vs scene-image and produce the merged analysis.
 
@@ -151,7 +152,8 @@ def analyze(
             notes="",
         )
     vlm = provider.analyze_image(
-        prepared.jpeg_bytes, model=model, media_type="image/jpeg",
+        prepared.jpeg_bytes, model=model, temperature=temperature,
+        media_type="image/jpeg",
     )
     return ImageAnalysis(
         kind="scene",

--- a/bartleby/providers/anthropic.py
+++ b/bartleby/providers/anthropic.py
@@ -167,12 +167,14 @@ class AnthropicProvider:
         image_bytes: bytes,
         *,
         model: str,
+        temperature: float,
         media_type: str = "image/jpeg",
     ) -> VlmDescription:
         b64 = base64.standard_b64encode(image_bytes).decode("ascii")
-        response = self._client.messages.create(
+        kwargs: dict = dict(
             model=model,
             max_tokens=2048,
+            temperature=temperature,
             messages=[{
                 "role": "user",
                 "content": [
@@ -194,6 +196,12 @@ class AnthropicProvider:
             }],
             tool_choice={"type": "tool", "name": _IMAGE_TOOL},
         )
+        # Temperature-rejecting vision models (Opus 4.7+, Fable 5, future) 400 on
+        # temperature just like the summarizer path — drop it wherever it would 400.
+        if _drops_temperature(model):
+            _warn_dropped_temperature(temperature, model)
+            del kwargs["temperature"]
+        response = self._client.messages.create(**kwargs)
         return _extract_tool_input(response, _IMAGE_TOOL, VlmDescription)
 
 

--- a/bartleby/providers/base.py
+++ b/bartleby/providers/base.py
@@ -117,6 +117,7 @@ class Provider(Protocol):
         image_bytes: bytes,
         *,
         model: str,
+        temperature: float,
         media_type: str = "image/jpeg",
     ) -> VlmDescription: ...
 

--- a/bartleby/providers/ollama.py
+++ b/bartleby/providers/ollama.py
@@ -59,6 +59,7 @@ class OllamaProvider:
         image_bytes: bytes,
         *,
         model: str,
+        temperature: float,
         media_type: str = "image/jpeg",
     ) -> VlmDescription:
         # Ollama's chat API takes raw image bytes (or paths) via `images=`.
@@ -70,6 +71,7 @@ class OllamaProvider:
                 "images": [image_bytes],
             }],
             format=VlmDescription.model_json_schema(),
+            options={"temperature": temperature},
         )
         return _validate(response.message.content, VlmDescription)
 

--- a/bartleby/providers/openai.py
+++ b/bartleby/providers/openai.py
@@ -78,8 +78,10 @@ class OpenAIProvider:
         image_bytes: bytes,
         *,
         model: str,
+        temperature: float,
         media_type: str = "image/jpeg",
     ) -> VlmDescription:
+        _drop_temperature(temperature)
         b64 = base64.standard_b64encode(image_bytes).decode("ascii")
         response = self._client.chat.completions.parse(
             model=model,

--- a/bartleby/providers/wsjpt.py
+++ b/bartleby/providers/wsjpt.py
@@ -81,8 +81,11 @@ class WsjptProvider:
         image_bytes: bytes,
         *,
         model: str,
+        temperature: float,
         media_type: str = "image/jpeg",
     ) -> VlmDescription:
+        # temperature intentionally ignored (see summarize) — wsjpt owns model
+        # settings centrally so callers can't drift from the toolkit defaults.
         jpt = self._Jpt(
             VlmDescription,
             model_config=self._model_config(model),

--- a/docs/decisions/GH-0223-vision-temperature-knob-0001.md
+++ b/docs/decisions/GH-0223-vision-temperature-knob-0001.md
@@ -1,0 +1,15 @@
+# Separate `vision_temperature` knob, defaulting to summarize `temperature` (issue #223)
+
+> Source: [#223](https://github.com/jswest/bartleby/issues/223)
+
+Captioning previously rode the model's *default* temperature: `analyze_image` never sent the parameter at all, so a corpus that set `temperature` for deterministic summaries had no say over caption determinism. #223 adds a dedicated `vision_temperature` config key threaded the same way `temperature` is threaded through summarization. **Additive, non-schema** — no `SCHEMA_VERSION` bump, no re-ingest; the value is read at ingest time and never persisted to a column.
+
+**Default-to-summarize, resolved at one point.** When `vision_temperature` is unset it falls back to the summarize `temperature` (then to `DEFAULT_TEMPERATURE`): `config.get("vision_temperature", config.get("temperature", DEFAULT_TEMPERATURE))`. The resolution lives in `commands/scribe.py` alongside the existing `temperature` resolution — the single point where ingest config becomes runtime values — and is threaded down through `caption._caption_all` → `caption._analyze_image` → `images.analyze` → `provider.analyze_image`. One knob keeps an unconfigured corpus behaving exactly as before (caption temperature == summarize temperature) while letting a corpus that wants deterministic summaries but more varied captions split the two.
+
+**Provider parity with the summarize path, not new policy.** `analyze_image` gained a required `temperature: float` on the `Provider` protocol. The per-provider handling deliberately *reuses the summarize-path rules* rather than inventing vision-specific ones, because the temperature-acceptance quirks are properties of the model, not of the call:
+- **anthropic** reuses the existing `_drops_temperature` / `_warn_dropped_temperature` helpers — Opus 4.7+/Fable-5 (and future models) 400 on `temperature`, so it's dropped there and forwarded on the older deny-listed models, identical to `summarize`/`classify`.
+- **openai** reuses `_drop_temperature` — GPT-5 models accept only the default (1.0); we never send it and warn once.
+- **ollama** forwards it via `options={"temperature": ...}`, as `summarize` does.
+- **wsjpt** accepts the param but **ignores** it (kept out of the signature would break the protocol). wsjpt owns model settings centrally, so callers can't drift from toolkit defaults — same stance it already takes for `summarize`/`classify`.
+
+No separate "vision temperature can be a different range" validation — the wizard's `_prompt_temperature` (now taking an explicit default rather than reaching into `existing`) already bounds it to [0, 1], and the vision prompt offers the just-chosen summarize temperature as its default so the common case is a single confirmation. The temperature-drop *warnings* are shared module-level once-flags with the summarize path; a config that drops temperature for summaries will already have warned, so captioning doesn't double-warn.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -203,6 +203,7 @@ def test_config_with_vision_writes_vision_keys(isolated_config, monkeypatch):
         "1024",                # vision_max_dimension
         "32",                  # vision_min_dimension
         "30",                  # ocr_min_confidence
+        "0.4",                 # vision_temperature
         "4",                   # caption_workers
         "50000",               # max_read_tokens
     ])
@@ -213,6 +214,7 @@ def test_config_with_vision_writes_vision_keys(isolated_config, monkeypatch):
     assert cfg["vision_max_dimension"] == 1024
     assert cfg["vision_min_dimension"] == 32
     assert cfg["ocr_min_confidence"] == 30
+    assert cfg["vision_temperature"] == 0.4
     assert cfg["caption_workers"] == 4
     # openai_api_key already set from the LLM block; no double prompt.
     assert cfg["openai_api_key"] == "sk-openai"
@@ -242,6 +244,7 @@ def test_config_vision_with_different_provider_prompts_for_fresh_key(
         "1024",
         "32",
         "30",
+        "0",                   # vision_temperature
         "4",                   # caption_workers
         "50000",
     ])
@@ -278,6 +281,7 @@ def test_config_ollama_vision_skips_caption_workers_prompt(
         "1024",                # vision_max_dimension
         "32",                  # vision_min_dimension
         "30",                  # ocr_min_confidence
+        "0",                   # vision_temperature
         # No "Caption workers" prompt — Ollama auto-clamps to 1.
         "50000",               # max_read_tokens
     ])

--- a/tests/test_ingest_images.py
+++ b/tests/test_ingest_images.py
@@ -150,7 +150,9 @@ def test_analyze_routes_text_image_via_tesseract_only(monkeypatch):
         lambda b: ocr_module.OcrResult(text="X" * 500, avg_confidence=80.0),
     )
     prepared = img_pipeline.prepare_image(_png_bytes(50, 50), max_dimension=1024)
-    out = img_pipeline.analyze(_FakeProvider(), prepared, model="fake-vl:1")
+    out = img_pipeline.analyze(
+        _FakeProvider(), prepared, model="fake-vl:1", temperature=0.0,
+    )
     assert out.kind == "text"
     assert out.text == "X" * 500
     assert out.description == ""
@@ -163,9 +165,10 @@ def test_analyze_routes_scene_image_via_vlm(monkeypatch):
 
     class _FakeProvider:
         name = "fake"
-        def analyze_image(self, image_bytes, *, model, media_type="image/jpeg"):
+        def analyze_image(self, image_bytes, *, model, temperature, media_type="image/jpeg"):
             seen["bytes"] = image_bytes
             seen["model"] = model
+            seen["temperature"] = temperature
             return VlmDescription(description="A red square.", notes="")
         def summarize(self, *a, **k):
             raise NotImplementedError
@@ -175,12 +178,16 @@ def test_analyze_routes_scene_image_via_vlm(monkeypatch):
         lambda b: ocr_module.OcrResult(text="hi", avg_confidence=10.0),
     )
     prepared = img_pipeline.prepare_image(_png_bytes(50, 50), max_dimension=1024)
-    out = img_pipeline.analyze(_FakeProvider(), prepared, model="fake-vl:1")
+    out = img_pipeline.analyze(
+        _FakeProvider(), prepared, model="fake-vl:1", temperature=0.4,
+    )
     assert out.kind == "scene"
     assert out.text == ""
     assert out.description == "A red square."
     assert seen["bytes"] == prepared.jpeg_bytes
     assert seen["model"] == "fake-vl:1"
+    # analyze() threads the configured vision temperature to the provider.
+    assert seen["temperature"] == 0.4
 
 
 def test_analyze_falls_back_to_vlm_when_ocr_raises(monkeypatch):
@@ -190,7 +197,7 @@ def test_analyze_falls_back_to_vlm_when_ocr_raises(monkeypatch):
 
     class _FakeProvider:
         name = "fake"
-        def analyze_image(self, image_bytes, *, model, media_type="image/jpeg"):
+        def analyze_image(self, image_bytes, *, model, temperature, media_type="image/jpeg"):
             seen["called"] = True
             return VlmDescription(description="A red square.", notes="")
         def summarize(self, *a, **k):
@@ -201,7 +208,9 @@ def test_analyze_falls_back_to_vlm_when_ocr_raises(monkeypatch):
 
     monkeypatch.setattr(ocr_module, "run", _boom)
     prepared = img_pipeline.prepare_image(_png_bytes(50, 50), max_dimension=1024)
-    out = img_pipeline.analyze(_FakeProvider(), prepared, model="fake-vl:1")
+    out = img_pipeline.analyze(
+        _FakeProvider(), prepared, model="fake-vl:1", temperature=0.0,
+    )
     assert seen["called"]   # VLM ran despite OCR crashing
     assert out.kind == "scene"
     assert out.description == "A red square."

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -217,7 +217,7 @@ def test_anthropic_analyze_image_validates_tool_input(monkeypatch):
 
     from bartleby.providers.anthropic import AnthropicProvider
     p = AnthropicProvider()
-    result = p.analyze_image(b"\xff\xd8\xff", model="claude-haiku-4-5")
+    result = p.analyze_image(b"\xff\xd8\xff", model="claude-haiku-4-5", temperature=0.4)
 
     assert isinstance(result, VlmDescription)
     assert result.description == "A cat sitting."
@@ -225,6 +225,22 @@ def test_anthropic_analyze_image_validates_tool_input(monkeypatch):
     content = fake.last_call["messages"][0]["content"]
     assert any(b.get("type") == "image" for b in content)
     assert fake.last_call["tool_choice"]["name"] == "save_image_description"
+    # Haiku 4.5 accepts temperature, so the configured vision temperature is sent.
+    assert fake.last_call["temperature"] == 0.4
+
+
+def test_anthropic_analyze_image_drops_temperature_on_47plus(monkeypatch):
+    # Opus 4.7+ / Fable 5 reject temperature outright (a 400) — analyze_image must
+    # drop it just like summarize, or every caption call on a current model fails.
+    from bartleby.providers import anthropic as mod
+    monkeypatch.setattr(mod, "_temperature_warned", False)
+    response = _FakeAnthropicResponse([
+        _block("tool_use", name="save_image_description", input_=_VLM_INPUT),
+    ])
+    fake = _install_anthropic(monkeypatch, response)
+    p = mod.AnthropicProvider()
+    p.analyze_image(b"\xff\xd8\xff", model="claude-opus-4-8", temperature=0.4)
+    assert "temperature" not in fake.last_call
 
 
 def test_anthropic_missing_tool_use_raises(monkeypatch):
@@ -233,7 +249,7 @@ def test_anthropic_missing_tool_use_raises(monkeypatch):
     from bartleby.providers.anthropic import AnthropicProvider
     p = AnthropicProvider()
     with pytest.raises(RuntimeError, match="did not include"):
-        p.analyze_image(b"\x00", model="m")
+        p.analyze_image(b"\x00", model="m", temperature=0.0)
 
 
 def test_anthropic_max_tokens_truncation_raises_named_error(monkeypatch):
@@ -246,7 +262,7 @@ def test_anthropic_max_tokens_truncation_raises_named_error(monkeypatch):
     from bartleby.providers.anthropic import AnthropicProvider
     p = AnthropicProvider()
     with pytest.raises(RuntimeError, match="max_tokens") as exc:
-        p.analyze_image(b"\x00", model="m")
+        p.analyze_image(b"\x00", model="m", temperature=0.0)
     assert "did not include" not in str(exc.value)
 
 
@@ -259,7 +275,7 @@ def test_anthropic_invalid_tool_input_raises(monkeypatch):
     from bartleby.providers.anthropic import AnthropicProvider
     p = AnthropicProvider()
     with pytest.raises(RuntimeError, match="failed schema validation"):
-        p.analyze_image(b"\x00", model="m")
+        p.analyze_image(b"\x00", model="m", temperature=0.0)
 
 
 # ---------- OpenAI ----------
@@ -369,7 +385,7 @@ def test_openai_analyze_image_returns_parsed_pydantic(monkeypatch):
     fake = _install_openai(monkeypatch, _FakeOpenAIResponse(parsed=parsed))
     from bartleby.providers.openai import OpenAIProvider
     p = OpenAIProvider()
-    result = p.analyze_image(b"\xff\xd8\xff", model="gpt-5-mini")
+    result = p.analyze_image(b"\xff\xd8\xff", model="gpt-5-mini", temperature=0.0)
     assert result is parsed
     assert fake.last_call["response_format"] is VlmDescription
     # Image is passed as a data URL in the content blocks.
@@ -384,7 +400,7 @@ def test_openai_refusal_raises(monkeypatch):
     from bartleby.providers.openai import OpenAIProvider
     p = OpenAIProvider()
     with pytest.raises(RuntimeError, match="refusal='nope'"):
-        p.analyze_image(b"\x00", model="m")
+        p.analyze_image(b"\x00", model="m", temperature=0.0)
 
 
 # ---------- Ollama ----------
@@ -427,12 +443,14 @@ def test_ollama_analyze_image_passes_bytes(monkeypatch):
                            _FakeOllamaResponse(content=json.dumps(_VLM_INPUT)))
     from bartleby.providers.ollama import OllamaProvider
     p = OllamaProvider(base_url="http://test:11434")
-    result = p.analyze_image(b"\xff\xd8\xff", model="qwen2.5-vl:7b")
+    result = p.analyze_image(b"\xff\xd8\xff", model="qwen2.5-vl:7b", temperature=0.3)
     assert isinstance(result, VlmDescription)
     assert result.description == "A cat sitting."
     msg = fake.last_call["messages"][0]
     assert msg["images"] == [b"\xff\xd8\xff"]
     assert fake.last_call["format"] == VlmDescription.model_json_schema()
+    # The configured vision temperature is forwarded via Ollama's options.
+    assert fake.last_call["options"]["temperature"] == 0.3
 
 
 def test_ollama_empty_content_raises(monkeypatch):
@@ -440,7 +458,7 @@ def test_ollama_empty_content_raises(monkeypatch):
     from bartleby.providers.ollama import OllamaProvider
     p = OllamaProvider(base_url="http://test:11434")
     with pytest.raises(RuntimeError, match="empty response"):
-        p.analyze_image(b"\x00", model="m")
+        p.analyze_image(b"\x00", model="m", temperature=0.0)
 
 
 def test_ollama_malformed_json_raises(monkeypatch):
@@ -448,7 +466,7 @@ def test_ollama_malformed_json_raises(monkeypatch):
     from bartleby.providers.ollama import OllamaProvider
     p = OllamaProvider(base_url="http://test:11434")
     with pytest.raises(RuntimeError, match="failed .* validation"):
-        p.analyze_image(b"\x00", model="m")
+        p.analyze_image(b"\x00", model="m", temperature=0.0)
 
 
 # ---------- wsjpt ----------

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -110,12 +110,14 @@ class _StubVisionProvider:
             description="A test image.", notes="",
         )
         self.calls = 0
+        self.temperatures: list[float] = []
 
     def summarize(self, *a, **k):  # protocol completeness
         raise NotImplementedError
 
-    def analyze_image(self, image_bytes, *, model, media_type="image/jpeg"):
+    def analyze_image(self, image_bytes, *, model, temperature, media_type="image/jpeg"):
         self.calls += 1
+        self.temperatures.append(temperature)
         return self.description
 
 
@@ -658,6 +660,47 @@ def test_scribe_captions_many_images_concurrently_in_one_run(
         conn.close()
 
 
+def test_scribe_threads_configured_vision_temperature_to_provider(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """#223: an explicit ``vision_temperature`` is resolved and handed to the VLM,
+    independent of the summarize ``temperature``."""
+    config = _vision_pdf_config()
+    config["temperature"] = 0.0
+    config["vision_temperature"] = 0.7
+    monkeypatch.setattr("bartleby.commands.scribe.load_config", lambda: config)
+    vision = _StubVisionProvider()
+    monkeypatch.setattr(
+        "bartleby.ingest.resolve.get_provider", lambda name, **k: vision,
+    )
+
+    pdf = tmp_path / "doc.pdf"
+    _pdf_with_image(pdf, _png_bytes(), text="Body of the document. " * 12)
+    scribe.main(project="test_proj", files=[str(pdf)])
+
+    assert vision.temperatures == [0.7]
+
+
+def test_scribe_vision_temperature_defaults_to_summarize_temperature(
+    isolated_project, tmp_path, mock_embed, monkeypatch
+):
+    """#223: with no ``vision_temperature`` set, captioning inherits the summarize
+    ``temperature`` so an unconfigured corpus keeps one knob."""
+    config = _vision_pdf_config()
+    config["temperature"] = 0.3  # no vision_temperature → falls back to this
+    monkeypatch.setattr("bartleby.commands.scribe.load_config", lambda: config)
+    vision = _StubVisionProvider()
+    monkeypatch.setattr(
+        "bartleby.ingest.resolve.get_provider", lambda name, **k: vision,
+    )
+
+    pdf = tmp_path / "doc.pdf"
+    _pdf_with_image(pdf, _png_bytes(), text="Body of the document. " * 12)
+    scribe.main(project="test_proj", files=[str(pdf)])
+
+    assert vision.temperatures == [0.3]
+
+
 def test_scribe_dedupes_shared_image_within_one_run(
     isolated_project, tmp_path, mock_embed, monkeypatch
 ):
@@ -715,7 +758,7 @@ def test_scribe_one_caption_failure_does_not_block_the_rest(
         def summarize(self, *a, **k):  # protocol completeness
             raise NotImplementedError
 
-        def analyze_image(self, image_bytes, *, model, media_type="image/jpeg"):
+        def analyze_image(self, image_bytes, *, model, temperature, media_type="image/jpeg"):
             # Lock so the "first call fails" rule is deterministic under the pool.
             with self._lock:
                 self.calls += 1
@@ -1357,6 +1400,7 @@ def test_caption_all_progress_callback_fires_per_image(
             writer,
             [parse.DocUnit(document_id, "img.pdf", "h")],
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",
+            vision_temperature=0.0,
             vision_enabled=True, caption_workers=1, timings=False,
             phase=phase,
         )
@@ -1394,6 +1438,7 @@ def test_caption_all_zero_work_reveals_a_zero_total(
             writer,
             [parse.DocUnit(document_id, "doc.txt", "h")],
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",
+            vision_temperature=0.0,
             vision_enabled=True, caption_workers=1, timings=False,
             phase=phase,
         )
@@ -1433,6 +1478,7 @@ def test_caption_all_lane_callback_reports_owning_document(
             writer,
             [parse.DocUnit(document_id, "img.pdf", "h")],
             vision_provider=_StubVisionProvider(), vision_model="stub-vl:1",
+            vision_temperature=0.0,
             vision_enabled=True, caption_workers=1, timings=False,
             phase=phase,
         )
@@ -2220,7 +2266,7 @@ class _FlakyVisionProvider:
     def summarize(self, *a, **k):  # protocol completeness
         raise NotImplementedError
 
-    def analyze_image(self, image_bytes, *, model, media_type="image/jpeg"):
+    def analyze_image(self, image_bytes, *, model, temperature, media_type="image/jpeg"):
         self.calls += 1
         if self.calls <= self.fail_times:
             raise RuntimeError("VLM unavailable")


### PR DESCRIPTION
## What

Adds a dedicated `vision_temperature` config key, threaded through image captioning the same way `temperature` is threaded through summarization. Until now `analyze_image` never sent a temperature at all, so captioning always rode the model's default — a corpus tuned for deterministic summaries had no say over caption determinism.

- **Config:** new `vision_temperature` key, defaulting to the summarize `temperature` when unset (`config.get("vision_temperature", temperature)`), resolved in `scribe.py`.
- **Provider protocol:** `analyze_image` gains a required `temperature: float`.
- **Providers:** `anthropic` / `openai` / `ollama` wire it in, **reusing each provider's existing summarize-path temperature handling** (drop on temperature-rejecting models like Opus 4.7+/GPT-5, warn once). `wsjpt` accepts but ignores it — it owns model settings centrally.
- **Pipeline:** `images.analyze()` and `caption._caption_all` / `_analyze_image` thread the value down to the provider call.
- **Wizard:** prompts for it in the vision block, offering the summarize temperature as the default.

Additive, non-schema: read at ingest time, never persisted to a column. **No `SCHEMA_VERSION` bump, no re-ingest.**

## Tests

New + extended coverage: provider-level (anthropic forwards on a keeping model / drops on a 4.7+ model; ollama forwards via `options`), pipeline-level (`images.analyze` threads the value), end-to-end scribe (explicit `vision_temperature` used; falls back to `temperature`), and wizard prompt round-trips. Full suite passes (the pre-existing `test_ultraship` collection error and `test_skill_drift[ultraship]` failure are environmental — the ultraship skill was never pressed into this worktree, unrelated to this change).

Decision doc: `docs/decisions/GH-0223-vision-temperature-knob-0001.md`.

Part of #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)