### PR TITLE
feat(#3): capture vector figures via shapely proximity-merge

### DIFF
--- a/bartleby/commands/scribe.py
+++ b/bartleby/commands/scribe.py
@@ -62,6 +62,7 @@ from bartleby.lib.consts import (
     DEFAULT_SPARSE_TEXT_THRESHOLD,
     DEFAULT_SUMMARIZE_WORKERS,
     DEFAULT_TEMPERATURE,
+    DEFAULT_VECTOR_INK_THRESHOLD,
     DEFAULT_VISION_MAX_DIMENSION,
     DEFAULT_VISION_MIN_DIMENSION,
 )
@@ -195,6 +196,9 @@ def main(
         ),
         vision_min_dimension=int(
             config.get("vision_min_dimension", DEFAULT_VISION_MIN_DIMENSION)
+        ),
+        vector_ink_threshold=int(
+            config.get("vector_ink_threshold", DEFAULT_VECTOR_INK_THRESHOLD)
         ),
         archive_root=archive_root,
         timings=timings,

--- a/bartleby/ingest/parsers.py
+++ b/bartleby/ingest/parsers.py
@@ -318,6 +318,7 @@ def _parse_pdf_pdfplumber(
         archived,
         sparse_text_threshold=config.sparse_text_threshold,
         ocr_min_confidence=config.ocr_min_confidence,
+        vector_ink_threshold=config.vector_ink_threshold,
     )
 
     doc_rows: list[ChunkRow] = []
@@ -495,6 +496,7 @@ class ParseConfig:
     vision_enabled: bool
     vision_max_dimension: int
     vision_min_dimension: int
+    vector_ink_threshold: int
     archive_root: Path
     timings: bool = False
 

--- a/bartleby/ingest/pdfplumber.py
+++ b/bartleby/ingest/pdfplumber.py
@@ -10,6 +10,8 @@ Returns enough information for ``scribe`` to:
   - pump embedded images through the image pipeline
   - fall back to Tesseract or the VLM on sparse pages (using the saved page
     render bytes — no second render needed)
+  - crop vector figure regions (charts, diagrams drawn as PDF path operators)
+    that never appear in page.images but are visible in the page render
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ from pathlib import Path
 
 import pdfplumber
 from PIL import Image
+from shapely import box, unary_union
 
 from bartleby.ingest import ocr as ocr_module
 from bartleby.lib import console
@@ -80,6 +83,13 @@ PAGE_SUBSTRATE_AREA_RATIO = 0.9
 MIN_EMBEDDED_IMAGE_LONG_EDGE_PX = 128
 MIN_EMBEDDED_IMAGE_AREA_PX = 5000
 
+# Vector figure detection: proximity-merge tolerance (PDF points) and minimum
+# merged-cluster area (PDF points²). tol=3 bridges small gaps between adjacent
+# path primitives in the same figure; min_area=2500 (~50×50 pt) drops slivers,
+# hairlines, and decoration that form isolated clusters too small to be figures.
+_VECTOR_MERGE_TOL = 3.0
+_VECTOR_MIN_AREA = 2500
+
 
 @dataclass
 class EmbeddedImage:
@@ -108,12 +118,17 @@ def convert(
     *,
     sparse_text_threshold: int,
     ocr_min_confidence: int,
+    vector_ink_threshold: int = 0,
 ) -> PdfResult:
     """Extract text + embedded images from a PDF, with OCR fallback for sparse pages.
 
     OCR runs inline per-page so each page is fully resolved before the caller
     sees it — the page is never reported done while Tesseract grinds in the
     background.
+
+    ``vector_ink_threshold``: pages with fewer than this many vector primitives
+    (curves + lines + rects combined) skip the vector-figure pass entirely.
+    0 (the default) never skips.
     """
     pages: list[PdfPage] = []
     full_text_parts: list[str] = []
@@ -130,12 +145,23 @@ def convert(
             page_render_png = None
             embedded_images: list[EmbeddedImage] = []
 
-            if is_sparse or page.images:
+            # Decide upfront whether this page has enough vector ink to bother
+            # running the proximity-merge pass. The threshold is an ink-primitive
+            # count, not a figure count — it gates the shapely work only.
+            ink_count = len(page.curves) + len(page.lines) + len(page.rects)
+            has_vector_ink = ink_count >= vector_ink_threshold and ink_count > 0
+
+            needs_render = is_sparse or page.images or has_vector_ink
+            rendered = None
+            if needs_render:
                 rendered = page.to_image(resolution=PAGE_RENDER_DPI).original
                 if is_sparse:
                     page_render_png = _to_png_bytes(rendered)
                 if page.images:
                     embedded_images = _crop_embedded_images(rendered, page)
+                if has_vector_ink:
+                    vector_crops = _crop_vector_figures(rendered, page)
+                    embedded_images.extend(vector_crops)
 
             ocr_result: ocr_module.OcrResult | None = None
             if is_sparse:
@@ -191,6 +217,30 @@ def _to_png_bytes(img: Image.Image) -> bytes:
     return buf.getvalue()
 
 
+def _crop_pdf_bbox(
+    rendered: Image.Image, x0: float, top: float, x1: float, bottom: float,
+    scale: float,
+) -> Image.Image | None:
+    """Crop a PDF-point bbox from a rendered page, returning None if the crop
+    is degenerate (zero dimension) or too small to be meaningful.
+
+    Used by both raster-embed and vector-figure croppers so the pixel-coord
+    computation and size-filter constants live in one place.
+    """
+    page_w, page_h = rendered.size
+    ix0 = max(0, int(x0 * scale))
+    iy0 = max(0, int(top * scale))
+    ix1 = min(page_w, int(x1 * scale))
+    iy1 = min(page_h, int(bottom * scale))
+    crop_w, crop_h = ix1 - ix0, iy1 - iy0
+    if crop_w < 1 or crop_h < 1:
+        return None
+    if (max(crop_w, crop_h) < MIN_EMBEDDED_IMAGE_LONG_EDGE_PX
+            or crop_w * crop_h < MIN_EMBEDDED_IMAGE_AREA_PX):
+        return None
+    return rendered.crop((ix0, iy0, ix1, iy1))
+
+
 def _crop_embedded_images(rendered: Image.Image, page) -> list[EmbeddedImage]:
     """Crop each pdfplumber `page.images` entry out of the rendered page.
 
@@ -200,31 +250,93 @@ def _crop_embedded_images(rendered: Image.Image, page) -> list[EmbeddedImage]:
     ``PAGE_SUBSTRATE_AREA_RATIO``.
     """
     scale = PAGE_RENDER_DPI / 72.0
-    page_w, page_h = rendered.size
     page_area_pt = max(1.0, page.width * page.height)
     out: list[EmbeddedImage] = []
     for i, im in enumerate(page.images):
         bbox_area_pt = max(0.0, im["x1"] - im["x0"]) * max(0.0, im["bottom"] - im["top"])
         if bbox_area_pt / page_area_pt >= PAGE_SUBSTRATE_AREA_RATIO:
             continue
-        # Truncate to integer pixel coords (PIL crop does this anyway). Skip
-        # crops that degenerate to zero in either dimension — happens when
-        # pdfplumber registers a thin horizontal/vertical PDF rule as an
-        # "image" with a sub-pixel bbox, and downstream JPEG encoding bails
-        # with "cannot write empty image."
-        ix0 = max(0, int(im["x0"] * scale))
-        iy0 = max(0, int(im["top"] * scale))
-        ix1 = min(page_w, int(im["x1"] * scale))
-        iy1 = min(page_h, int(im["bottom"] * scale))
-        crop_w, crop_h = ix1 - ix0, iy1 - iy0
-        if crop_w < 1 or crop_h < 1:
+        crop = _crop_pdf_bbox(rendered, im["x0"], im["top"], im["x1"], im["bottom"], scale)
+        if crop is None:
             continue
-        if (max(crop_w, crop_h) < MIN_EMBEDDED_IMAGE_LONG_EDGE_PX
-                or crop_w * crop_h < MIN_EMBEDDED_IMAGE_AREA_PX):
-            continue
-        crop = rendered.crop((ix0, iy0, ix1, iy1))
         out.append(EmbeddedImage(
             image_index_on_page=i + 1,
+            png_bytes=_to_png_bytes(crop),
+        ))
+    return out
+
+
+def _vector_figure_bboxes(page, tol: float = _VECTOR_MERGE_TOL,
+                          min_area: float = _VECTOR_MIN_AREA) -> list[tuple]:
+    """Return figure bounding boxes derived from vector ink via proximity-merge.
+
+    Uses shapely to buffer-and-union all curves/lines/rects into clusters, then
+    subtracts table bboxes (table gridlines are rects/lines but are not figures).
+    Returns bboxes as (x0, top, x1, bottom) tuples in PDF point coordinates.
+
+    Never includes ``page.chars`` — text is never vector ink for this purpose.
+    """
+    prims = page.curves + page.lines + page.rects
+    if not prims:
+        return []
+
+    merged = unary_union([
+        box(p["x0"], p["top"], p["x1"], p["bottom"]).buffer(tol / 2)
+        for p in prims
+    ])
+    geoms = merged.geoms if merged.geom_type == "MultiPolygon" else [merged]
+
+    # Collect table bboxes to exclude table-gridline clusters. find_tables()
+    # is pdfplumber's purpose-built table detector — the right tool here rather
+    # than rolling a heuristic.
+    table_boxes = [box(*tbl.bbox) for tbl in page.find_tables()]
+
+    results = []
+    for g in geoms:
+        if g.area < min_area:
+            continue
+        # Drop clusters that substantially overlap a table bbox. A cluster is
+        # "table-like" when its centroid falls inside any table bbox — simpler
+        # and cheaper than a full intersection-over-union check, and correct for
+        # the common case where the table gridlines form a cluster fully inside
+        # the table bbox.
+        cx, cy = g.centroid.x, g.centroid.y
+        is_table = any(
+            tb.bounds[0] <= cx <= tb.bounds[2] and tb.bounds[1] <= cy <= tb.bounds[3]
+            for tb in table_boxes
+        )
+        if is_table:
+            continue
+        b = g.bounds   # (minx, miny, maxx, maxy) = (x0, top, x1, bottom)
+        results.append((b[0], b[1], b[2], b[3]))
+
+    return results
+
+
+def _crop_vector_figures(rendered: Image.Image, page) -> list[EmbeddedImage]:
+    """Crop vector figure regions from the rendered page.
+
+    Vector figures (matplotlib/Illustrator charts drawn as PDF path operators)
+    never appear in page.images but are visible in the rendered raster. This
+    crops each proximity-merged cluster from the EXISTING render — no second
+    render needed.
+
+    image_index_on_page uses a high base (1000 + cluster_index) to avoid
+    colliding with raster-embed indices (which are 1-indexed from page.images).
+    """
+    bboxes = _vector_figure_bboxes(page)
+    if not bboxes:
+        return []
+
+    scale = PAGE_RENDER_DPI / 72.0
+    out: list[EmbeddedImage] = []
+    for cluster_idx, (x0, top, x1, bottom) in enumerate(bboxes):
+        crop = _crop_pdf_bbox(rendered, x0, top, x1, bottom, scale)
+        if crop is None:
+            continue
+        out.append(EmbeddedImage(
+            # High base avoids collision with raster-embed indices (1-indexed).
+            image_index_on_page=1000 + cluster_idx,
             png_bytes=_to_png_bytes(crop),
         ))
     return out

--- a/bartleby/ingest/pdfplumber.py
+++ b/bartleby/ingest/pdfplumber.py
@@ -307,8 +307,8 @@ def _vector_figure_bboxes(page, tol: float = _VECTOR_MERGE_TOL,
         )
         if is_table:
             continue
-        b = g.bounds   # (minx, miny, maxx, maxy) = (x0, top, x1, bottom)
-        results.append((b[0], b[1], b[2], b[3]))
+        # shapely bounds (minx, miny, maxx, maxy) maps directly to (x0, top, x1, bottom)
+        results.append(g.bounds)
 
     return results
 

--- a/bartleby/lib/consts.py
+++ b/bartleby/lib/consts.py
@@ -64,6 +64,14 @@ DEFAULT_VISION_MAX_DIMENSION = 768
 # noisier corpora.
 DEFAULT_VISION_MIN_DIMENSION = 64
 
+# Vector figure detection (#3). Pages with fewer vector ink primitives
+# (curves + lines + rects combined) than this threshold skip the shapely
+# proximity-merge pass entirely. 0 means "never skip" — any page with at
+# least one primitive gets a figure pass. Raise it on corpora where pages
+# routinely carry decorative rules or borders that aren't real figures, so
+# the merge pass only fires on pages with meaningful vector content.
+DEFAULT_VECTOR_INK_THRESHOLD = 0
+
 # Parse-pool sizing (#165). When `max_workers` is unset, scribe auto-picks
 # min(cpu_count - RESERVED_CORES, free_ram_gb // PER_WORKER_GB), floored at 1 —
 # so a box that's CPU-rich but RAM-poor doesn't launch more parse workers than

--- a/docs/decisions/GH-0003-vector-figures-shapely-proximity-merge-0001.md
+++ b/docs/decisions/GH-0003-vector-figures-shapely-proximity-merge-0001.md
@@ -1,0 +1,31 @@
+# Shapely proximity-merge for vector figure detection (issue #3)
+
+> Source: [#3](https://github.com/jswest/bartleby/issues/3)
+
+Vector figures (matplotlib/Illustrator charts drawn as PDF path operators) never appear in `page.images`, so the VLM never sees them under the existing raster-embed path. The fix crops each vector-figure region from the **existing** page render — no second render needed.
+
+## Settled design: shapely proximity-merge
+
+The issue body explored several approaches (whole-page render, `len(page.images)==0` gating, single-bbox heuristic, PyMuPDF). The final accepted design is:
+
+1. Collect `page.curves + page.lines + page.rects` (vector ink only — never `page.chars`).
+2. Buffer each primitive by `tol/2` points and `unary_union` into merged clusters.
+3. Subtract clusters whose centroid falls inside a `page.find_tables()` bbox — table gridlines are rects/lines and would otherwise produce false-positive figure crops. `find_tables()` is pdfplumber's purpose-built detector; no heuristic is needed.
+4. Drop clusters below `min_area` (slivers and hairlines).
+5. Crop each surviving cluster from the already-rendered raster.
+
+## Runs alongside raster-embed cropping, never gated on it
+
+A page with both a vector chart and a raster photo produces both a vector-region crop and a raster crop. The `vector_ink_threshold` config key (default 0, meaning "never skip") gates whether a page has enough vector primitives to bother running the shapely pass. This is cheap: the primitive count is already available from pdfplumber before any render.
+
+## Index space for vector crops
+
+Vector crop `EmbeddedImage` entries use `image_index_on_page = 1000 + cluster_index` to avoid colliding with raster-embed indices (which are 1-indexed from `page.images`). Downstream — `_ImageRoute`, `ParsedImage`, chunk source naming, and page-render-hash dedup — requires no changes because the index field is already an opaque integer at every layer.
+
+## Table exclusion method
+
+We use centroid-in-bbox rather than intersection-over-union: a cluster is excluded when its centroid falls inside any table bbox returned by `find_tables()`. This is correct for the common case (compact grid tables whose gridlines form a cluster fully inside the table bbox) and cheaper than IOU. A vector annotation that straddles a table boundary might escape exclusion, but that is an acceptable v1 trade-off.
+
+## Non-schema, additive change
+
+`vector_ink_threshold` is read at ingest time and never persisted. No `SCHEMA_VERSION` bump, no re-ingest required. Threaded through `ParseConfig` (alongside `vision_min_dimension` and `vision_max_dimension`) → `pdfplumber_pipeline.convert()`.

--- a/tests/test_ingest_pdfplumber.py
+++ b/tests/test_ingest_pdfplumber.py
@@ -284,3 +284,119 @@ def test_reject_if_html_passes_a_real_pdf(tmp_path):
     _text_pdf(src, ["A genuine PDF with plenty of text. " * 4])
     # A valid PDF starts with %PDF — no exception.
     pp.reject_if_html(src)
+
+
+# ---------------------------------------------------------------------------
+# Vector figure detection tests (#3)
+# ---------------------------------------------------------------------------
+
+def _pdf_with_vector_figure_and_raster(path, image: Image.Image) -> None:
+    """One page: a vector chart (axes + diagonal lines + bezier) plus a raster
+    image. The chart uses non-crossing lines so pdfplumber's table detector
+    does not claim the cluster."""
+    from reportlab.lib import colors as rl_colors
+    c = canvas.Canvas(str(path), pagesize=letter)
+    # Enough text so the page stays out of the sparse path.
+    t = c.beginText(72, 750)
+    for _ in range(4):
+        t.textLine("Text to clear the sparse threshold and keep page content_type='text'.")
+    c.drawText(t)
+    # Vector chart: two axes + a diagonal data line + a bezier curve.
+    c.setStrokeColor(rl_colors.black)
+    c.setLineWidth(1)
+    c.line(100, 200, 100, 400)       # Y axis
+    c.line(100, 200, 400, 200)       # X axis
+    c.line(100, 200, 400, 400)       # data line (diagonal — no grid)
+    c.bezier(100, 300, 200, 380, 300, 320, 400, 400)   # trend curve
+    # Raster image in a different region of the page.
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    buf.seek(0)
+    c.drawImage(ImageReader(buf), 100, 450, width=200, height=100)
+    c.showPage()
+    c.save()
+
+
+def _pdf_with_table_only(path) -> None:
+    """One page: a proper grid table (4 rows × 5 cols) — no other vector ink.
+    pdfplumber's find_tables() should claim the cluster so no figure bbox
+    survives table exclusion."""
+    from reportlab.lib import colors as rl_colors
+    c = canvas.Canvas(str(path), pagesize=letter)
+    # Add text so content_type is 'text'.
+    t = c.beginText(72, 750)
+    for _ in range(4):
+        t.textLine("Text to clear the sparse threshold.")
+    c.drawText(t)
+    c.setStrokeColor(rl_colors.black)
+    c.setLineWidth(1)
+    # 4 horizontal + 5 vertical lines → a 3×4 grid pdfplumber recognises.
+    for row in range(4):
+        y = 600 - row * 30
+        c.line(100, y, 400, y)
+    for col in range(5):
+        x = 100 + col * 75
+        c.line(x, 600, x, 510)
+    c.showPage()
+    c.save()
+
+
+def test_vector_figure_and_raster_both_captured(tmp_path):
+    """(a) A page with a vector chart AND a raster image must produce BOTH a
+    vector-region crop (image_index_on_page >= 1000) and a raster crop
+    (image_index_on_page < 1000). The two run concurrently, not gated on each
+    other."""
+    src = tmp_path / "vector_and_raster.pdf"
+    _pdf_with_vector_figure_and_raster(src, _png_image())
+    result = pp.convert(src, sparse_text_threshold=100, ocr_min_confidence=30)
+
+    assert result.page_count == 1
+    page = result.pages[0]
+    assert page.content_type == "text"
+
+    indices = [e.image_index_on_page for e in page.embedded_images]
+    # At least one raster-embed crop (index 1-based from page.images).
+    raster_crops = [i for i in indices if i < 1000]
+    assert raster_crops, (
+        f"Expected at least one raster-embed crop (index < 1000), got indices {indices}"
+    )
+    # At least one vector-figure crop (index >= 1000).
+    vector_crops = [i for i in indices if i >= 1000]
+    assert vector_crops, (
+        f"Expected at least one vector-figure crop (index >= 1000), got indices {indices}"
+    )
+    # Every crop is a valid PNG that Pillow can open.
+    for emb in page.embedded_images:
+        decoded = Image.open(io.BytesIO(emb.png_bytes))
+        assert decoded.size[0] > 0 and decoded.size[1] > 0
+
+
+def test_table_only_page_produces_no_vector_crop(tmp_path):
+    """(b) A page whose only vector ink forms a proper table grid must produce
+    NO vector-figure crop — the table exclusion pass strips the cluster."""
+    src = tmp_path / "table_only.pdf"
+    _pdf_with_table_only(src)
+    result = pp.convert(src, sparse_text_threshold=100, ocr_min_confidence=30)
+
+    assert result.page_count == 1
+    page = result.pages[0]
+    vector_crops = [
+        e for e in page.embedded_images if e.image_index_on_page >= 1000
+    ]
+    assert vector_crops == [], (
+        f"Table-only page should have no vector crops, got {len(vector_crops)}"
+    )
+
+
+def test_text_only_page_produces_no_vector_crop(tmp_path):
+    """(c) A page with only text (no vector primitives) must produce no
+    vector-figure crop. The ink threshold short-circuits the shapely pass."""
+    src = tmp_path / "text_only.pdf"
+    _text_pdf(src, ["A page of plain text with no charts or figures. " * 6])
+    result = pp.convert(src, sparse_text_threshold=100, ocr_min_confidence=30)
+
+    assert result.page_count == 1
+    page = result.pages[0]
+    assert page.embedded_images == [], (
+        f"Text-only page should have no embedded images, got {page.embedded_images}"
+    )

--- a/tests/test_scribe.py
+++ b/tests/test_scribe.py
@@ -40,7 +40,8 @@ def _parse_config(archive_root, *, vision_enabled=False, vision_min_dimension=32
         pdf_converter="pdfplumber", html_converter="docling",
         sparse_text_threshold=100, ocr_min_confidence=30,
         vision_enabled=vision_enabled, vision_max_dimension=1024,
-        vision_min_dimension=vision_min_dimension, archive_root=archive_root,
+        vision_min_dimension=vision_min_dimension,
+        vector_ink_threshold=0, archive_root=archive_root,
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `_vector_figure_bboxes()` to `bartleby/ingest/pdfplumber.py`: buffers `page.curves + page.lines + page.rects` with shapely, unions into clusters, subtracts `page.find_tables()` bboxes to strip table gridlines, and drops slivers below `min_area`.
- Adds `_crop_vector_figures()` which crops each surviving cluster from the page render that already exists for raster-embed processing — no second render.
- Runs alongside (not gated on) the existing raster-embed path: a page with both a vector chart and a raster photo produces both crop types. Vector crop `image_index_on_page` uses a 1000+ base to avoid colliding with raster-embed indices.
- New `vector_ink_threshold` config key (default 0 = never skip) gates the shapely pass. Threaded through `ParseConfig` → `pdfplumber_pipeline.convert()`. Non-schema, additive change — no re-ingest required.

## Test plan

- [x] `test_vector_figure_and_raster_both_captured` — page with vector chart + raster image produces both a vector crop (index ≥ 1000) and a raster crop (index < 1000)
- [x] `test_table_only_page_produces_no_vector_crop` — table-grid page produces no vector crop (table exclusion verified)
- [x] `test_text_only_page_produces_no_vector_crop` — text-only page produces no crops at all
- [x] Full suite: 1172 passed, 2 skipped (pre-existing skips)

Decision recorded: `docs/decisions/GH-0003-vector-figures-shapely-proximity-merge-0001.md`

Part of #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)