### PR TITLE
docs(pi-vm): note manual cleanup when a build fails

### DIFF
--- a/docs/pi-vm-runbook.md
+++ b/docs/pi-vm-runbook.md
@@ -352,9 +352,28 @@ running VM and no stopped containers pile up. Two things *do* accumulate, and
    Set **`KEEP_BUILD_CACHE=1`** to keep it for fast incremental rebuilds while
    you're iterating on the `Containerfile`.
 
-So in normal use, repeated `build.sh` runs no longer stack up ghosts. To inspect
-or reclaim by hand (note: `container image` is **singular** — `container images`
-is not a valid verb):
+So in normal use, repeated `build.sh` runs no longer stack up ghosts.
+
+### If a build fails
+
+When `container build` dies under `set -euo pipefail`, the script aborts between
+the two cleanup steps: the prior `:latest` image is already deleted (step 1 runs
+up front), the new image never finished, and the post-build cache reset never
+runs (step 2 is skipped). A failed build therefore leaves you with **no working
+image and an un-reset BuildKit cache** — and repeated failures let that cache
+accumulate just like it did before `build.sh` was self-cleaning.
+
+**Recovery:** once you've fixed the underlying cause (network/GitHub flake,
+decant `main` broken, flaky `ollama pull`), just re-run `build.sh` — a
+successful build resets the cache. If you're seeing persistent failures and
+want to reclaim space in the meantime, use the manual commands below
+(`container builder delete` for the cache, `container image ls` /
+`container image delete` for images, and `du` to actually see the invisible
+builder cache).
+
+### To inspect or reclaim by hand
+
+(Note: `container image` is **singular** — `container images` is not a valid verb.)
 
 ```bash
 container system df                          # images/containers/volumes usage…

--- a/scripts/pi-vm/build.sh
+++ b/scripts/pi-vm/build.sh
@@ -8,7 +8,9 @@
 # Self-cleaning so it can't silently bloat your disk (see "Disk & cleanup" in the
 # runbook): deletes the prior image before building and resets the BuildKit cache
 # afterward. During development that cache grew to 75 GB — and it's invisible to
-# `container system df`, so nothing warns you.
+# `container system df`, so nothing warns you. NOTE: a FAILED build skips the
+# post-build cache reset (set -e aborts mid-script), so on persistent failures you
+# may need to clean up by hand — see "Disk & cleanup" in docs/pi-vm-runbook.md.
 #
 # Env:
 #   IMAGE             image tag                   (default: bartleby-pi:latest)


### PR DESCRIPTION
## Summary

- Adds a `### If a build fails` subsection in the **Disk & cleanup** section of `docs/pi-vm-runbook.md`, explaining that a failed build under `set -euo pipefail` skips the post-build cache reset and may have already deleted the prior image — and pointing at the existing manual reclaim commands for recovery rather than duplicating them.
- Adds a one-sentence NOTE comment to the header block in `scripts/pi-vm/build.sh` flagging the same failure mode and cross-referencing the runbook. No executable code changed.

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)