### PR TITLE
R2 · Dot-matrix LED readout panels

### DIFF
--- a/bartleby/web/src/routes/+page.svelte
+++ b/bartleby/web/src/routes/+page.svelte
@@ -7,6 +7,32 @@
 
   const fmt = (n) => (n ?? 0).toLocaleString("en-US");
 
+  // Count-up action for the LED readout numerals (#591): on mount, ramp the
+  // displayed figure from 0 → target so the panel reads as a screen powering
+  // on. Honours prefers-reduced-motion (and SSR / no-rAF) by snapping straight
+  // to the final value, so the number is always correct without JS.
+  function countUp(node, target) {
+    const final = Number(target) || 0;
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduce || typeof requestAnimationFrame === "undefined" || final === 0) {
+      node.textContent = fmt(final);
+      return;
+    }
+    const duration = 700;
+    const start = performance.now();
+    const tick = (now) => {
+      const t = Math.min(1, (now - start) / duration);
+      // Ease-out so it decelerates into the final reading like a settling dial.
+      const eased = 1 - Math.pow(1 - t, 3);
+      node.textContent = fmt(Math.round(final * eased));
+      if (t < 1) requestAnimationFrame(tick);
+    };
+    node.textContent = fmt(0);
+    requestAnimationFrame(tick);
+  }
+
   // Tallest bar in the year histogram, floored at 1 so an empty corpus doesn't
   // divide by zero.
   $: maxYear = corpus
@@ -49,11 +75,11 @@
     <div class="overview">
       <div class="stat-strip">
         <div class="stat">
-          <span class="stat-value">{fmt(corpus.chunk_count)}</span>
+          <span class="stat-value" use:countUp={corpus.chunk_count}>{fmt(corpus.chunk_count)}</span>
           <span class="stat-label">chunks</span>
         </div>
         <div class="stat">
-          <span class="stat-value">{fmt(corpus.token_count)}</span>
+          <span class="stat-value" use:countUp={corpus.token_count}>{fmt(corpus.token_count)}</span>
           <span class="stat-label">tokens</span>
         </div>
         <div class="stat">
@@ -73,7 +99,7 @@
           </span>
         </div>
         <div class="stat">
-          <span class="stat-value">{fmt(corpus.summary_coverage.summarized)}</span>
+          <span class="stat-value" use:countUp={corpus.summary_coverage.summarized}>{fmt(corpus.summary_coverage.summarized)}</span>
           <span class="stat-label">
             summarized{#if corpus.summary_coverage.unsummarized} · {fmt(corpus.summary_coverage.unsummarized)} without{/if}
           </span>
@@ -210,38 +236,89 @@
     font-family: var(--font-sans);
   }
 
-  /* The status strip is a dark LED readout band on the shell — a raised
-     near-black panel with amber dot-matrix figures and sage labels, framed by
-     dark rules top and bottom. (R2 grows the full LED-panel idiom from here.) */
+  /* ──────────────────────────────────────────────────────────────────────
+     R2 · Dot-matrix LED readout panel (#591)
+     Grows R1's seeded stat band into a glowing dark "screen" distinct from
+     the paper cards: a recessed near-black readout with amber Doto numerals
+     (soft glow), a green dot-matrix date readout, muted-green caps labels,
+     framing rules, an inset shadow, and a faint scanline overlay. Numerals
+     count up on load. All selectors here are owned by this issue; the only
+     shared tokens consumed are R1's :root vars (read-only).
+     ────────────────────────────────────────────────────────────────────── */
+
+  /* Local readout palette, derived from R1 tokens — kept here so the panel
+     can be tuned without touching the foundation :root. */
   .stat-strip {
+    --led-amber: var(--color-token-dark);
+    --led-green: var(--color-off-light);
+    --led-glow-amber: rgba(255, 189, 8, 0.45);
+    --led-glow-green: rgba(219, 250, 235, 0.3);
+
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-lg) var(--space-3xl);
-    padding: var(--space-lg) var(--space-xl);
-    background: var(--color-shell-raised);
+    padding: var(--space-xl);
+    position: relative;
+    /* A touch darker than the shell so the readout reads as a recessed screen
+       rather than a raised card; the inset shadow seals the "behind glass" feel. */
+    background:
+      linear-gradient(180deg, rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0)) ,
+      var(--color-shell);
     border-top: 1px solid var(--color-shell-rule);
     border-bottom: 1px solid var(--color-shell-rule);
+    box-shadow:
+      inset 0 1px 0 rgba(0, 0, 0, 0.5),
+      inset 0 12px 24px -12px rgba(0, 0, 0, 0.7);
+    overflow: hidden;
+  }
+  /* Faint horizontal scanlines drawn over the panel — a repeating 1px dark
+     line every 3px. Sits above the background but below the figures (the
+     readout content stays at the default stacking, this layer is z-index:0
+     and pointer-events:none so it never intercepts clicks). */
+  .stat-strip::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.18) 0,
+      rgba(0, 0, 0, 0.18) 1px,
+      transparent 1px,
+      transparent 3px
+    );
+    z-index: 0;
   }
   .stat {
     display: flex;
     flex-direction: column;
     gap: var(--space-3xs);
+    position: relative;
+    z-index: 1; /* float the figures above the scanline overlay */
   }
   .stat-value {
     font-family: var(--font-display);
-    font-size: var(--text-xl);
+    /* Honour the dot-matrix size floor (--text-display-floor: 1.25rem) — bumped
+       above R1's --text-xl so the LED figures read crisp, never muddy. */
+    font-size: var(--text-2xl);
     line-height: 1;
-    /* Amber dot-matrix readout — the glowing-LED figure on the dark panel. */
-    color: var(--color-token-dark);
+    /* Amber dot-matrix readout with a soft LED glow. */
+    color: var(--led-amber);
+    text-shadow: 0 0 6px var(--led-glow-amber);
+    font-variant-numeric: tabular-nums;
   }
-  /* The authored-date range is text, not a metric — render it in readable sans
-     instead of the pixel display face, which mangles a long date string. The
-     mint reads as a lit readout where dark paper text would vanish on the band. */
+  /* The authored-date range is text, not a metric, but on the LED panel it
+     becomes the green dot-matrix readout from the prototype — Doto, sized at
+     the display floor, glowing green where amber marks the metrics. */
   .stat-value--text {
-    font-family: var(--font-sans);
-    font-size: var(--text-base);
-    font-weight: 600;
-    color: var(--color-off-light);
+    font-family: var(--font-display);
+    font-size: var(--text-display-floor);
+    line-height: 1;
+    color: var(--led-green);
+    text-shadow: 0 0 6px var(--led-glow-green);
+    /* The range is a single token visually — keep it on one line and let it
+       drive its own column width rather than wrapping mid-date. */
+    white-space: nowrap;
   }
   .stat-label {
     font-size: var(--text-2xs);


### PR DESCRIPTION
Part of #589 (retro redesign omnibus). Builds on R1 (#590).

Grows R1's seeded home stat band into a glowing dark **LED readout panel** — a "screen" distinct from the paper cards around it.

## What changed
- **Amber Doto numerals** (chunks / tokens / summarized) at `--text-2xl` with a soft amber `text-shadow` glow and tabular figures.
- **Green dot-matrix date readout** — the authored-date range now renders in Doto at `--text-display-floor` with a green glow (matching the prototype), replacing R1's white sans.
- **Scanline overlay** (`.stat-strip::after`, `pointer-events:none`, z-indexed below the figures) + inset shadow and a slightly darker gradient ground → recessed "behind glass" feel.
- **Count-up animation**: a `use:countUp` action ramps the three numeric figures 0→target on mount, easing out into the final reading. Honours `prefers-reduced-motion` / SSR / no-`requestAnimationFrame` by snapping to the final value, so the number is always correct without JS.

Doto is kept at or above `--text-display-floor` everywhere, so it never renders muddy.

## Scope / coordination
- Only the `.stat-strip` / `.stat` / `.stat-value` / `.stat-value--text` / `.stat-label` selectors — all **component-scoped in `routes/+page.svelte`**, not `app.css`. No collision surface for the other parallel `app.css` editors.
- R1's `:root` tokens, `@font-face`/`fonts.css`, and two-grounds rules are untouched. The local readout palette (`--led-amber`, `--led-green`, `--led-glow-*`) is scoped to `.stat-strip`, derived from R1 tokens.
- No new global CSS classes or tokens; nothing other issues can collide with.

## Verification
Playwright (connected MCP) against the throwaway sandbox corpus, desktop **1280** + mobile **375**. Both render the band as a glowing dark display with legible figures; 0 console errors (only the two pre-existing `params` SvelteKit warnings, present before this change). No tests run — web-only CSS/markup change (`--skip-tests`).

Before (R1) → After (R2): desktop and mobile screenshots captured locally under `.claude/scratch/issue-591-*.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)