### PR TITLE
R5 · Boot/loading flourish

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -647,3 +647,63 @@ input[type="number"] {
 }
 /* Entity rows render as cards by composing the shared `.surface` primitive in
    the markup (class="entity surface"); the box styling lives there, not here. */
+
+/* =========================================================================
+   R5 · Boot/loading flourish (#594) — dot-matrix cursor + terminal empties.
+
+   A restrained retro affordance for the search route. Two pieces, both loose
+   on the dark shell:
+     - `.cursor`  a blinking Doto block, shown while a search/scan is in flight
+                  (a console "working…" tick). Honours the display floor.
+     - `.empty--terminal`  a console-prompt empty state ("> no results …").
+                  A modifier on the shared `.empty`; the base `.empty` (used by
+                  documents/findings/tags/source-viewer) is left untouched so
+                  this stays scoped to search and clear of B5 (#599).
+   ========================================================================= */
+
+/* The block tick. Doto, so it reads as one lit dot-matrix cell; held at the
+   display floor so the dots never turn to mud. Sits inline at the end of the
+   line it follows (busy banner copy, terminal-empty prompt). */
+@keyframes r5-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+.cursor {
+  font-family: var(--font-display);
+  font-size: max(var(--text-display-floor), 1em);
+  /* The lit cell. A filled block glyph reads as a terminal cursor at any size. */
+  line-height: 0;
+  /* No layout shift: the cell reserves its width and only its opacity animates. */
+  animation: r5-blink 1.06s steps(1, end) infinite;
+}
+/* Respect reduced-motion: hold the cursor lit rather than blinking it. */
+@media (prefers-reduced-motion: reduce) {
+  .cursor {
+    animation: none;
+  }
+}
+
+/* Terminal-prompt empty state. Iosevka (UI chrome, not prose), a lit amber
+   prompt mark, and a trailing blinking cursor — a console waiting for input
+   with nothing to show. Overrides the base `.empty` (inherited serif + its
+   italic); equal specificity, wins on declaration order (defined after it). */
+.empty--terminal {
+  font-family: var(--font-sans);
+  font-style: normal;
+  color: var(--color-shell-text-soft);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+/* The amber `>` prompt mark that opens the line. */
+.empty--terminal::before {
+  content: ">";
+  color: var(--color-token-dark);
+  font-weight: 500;
+}

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -27,7 +27,8 @@
 
 {#if busy}
   <StatusBanner variant="busy">
-    Searching… <span class="hint">semantic queries load the embedding model and can take a few seconds.</span>
+    Searching<span class="cursor" aria-hidden="true">█</span>
+    <span class="hint">semantic queries load the embedding model and can take a few seconds.</span>
   </StatusBanner>
 {/if}
 
@@ -38,10 +39,12 @@
       {#if error.code}<span class="code">({error.code})</span>{/if}
     </StatusBanner>
   {:else if !params.q}
-    <p class="empty">Enter a query to search the corpus.</p>
+    <p class="empty empty--terminal">
+      awaiting query<span class="cursor" aria-hidden="true">█</span>
+    </p>
   {:else if params.mode === "scan"}
     {#if result.matches.length === 0}
-      <p class="empty">No chunks match “{result.query}”.</p>
+      <p class="empty empty--terminal">no chunks match “{result.query}”</p>
     {:else}
       <p class="summary">
         {pluralize(result.total, "match", "matches")} for the
@@ -67,7 +70,7 @@
     {/if}
   {:else}
     {#if result.results.length === 0}
-      <p class="empty">No results for “{result.query}”.</p>
+      <p class="empty empty--terminal">no results for “{result.query}”</p>
     {:else}
       <p class="summary">
         {pluralize(result.results.length, "result")}


### PR DESCRIPTION
Part of #589 — R5 of the retro redesign, built on the R1 foundation (#590).

A restrained retro delight for the search route's loading and empty states. Doto/Iosevka used per their R1 roles; all new CSS in its own commented R5 section. R1 `:root` tokens, `@font-face`/`fonts.css`, and the two-grounds rules are untouched.

## What changed
- **Dot-matrix cursor** (`app.css`): new `@keyframes r5-blink` + `.cursor` — a blinking Doto block (held at `--text-display-floor`), shown trailing the in-flight busy banner ("Searching█") and the awaiting-query prompt. Reduced-motion holds it lit instead of blinking.
- **Terminal empty states** (`app.css` + `routes/search/+page.svelte`): new `.empty--terminal` modifier on the shared `.empty` — an amber `>` prompt mark (`::before`), Iosevka chrome, and console copy:
  - no query → `> awaiting query█` (waiting, so it carries the trailing cursor)
  - scan, 0 matches → `> no chunks match "…"`
  - search, 0 results → `> no results for "…"`
  - The settled no-result lines get only the `>` prompt; only the waiting state gets the trailing cursor — a deliberate asymmetry.

## Scoping / collision notes
- `.empty--terminal` is a **modifier**, not a mutation of the shared `.empty` (used by documents/findings/tags and the source-viewer). This keeps the change scoped to search and clear of **B5 #599** (source-viewer empty-state frame).
- **New CSS classes other issues might touch:** `.cursor`, `.empty--terminal`, and the `r5-blink` keyframe (all prefixed/sectioned under an `R5` comment block in `app.css`).
- Decorative `█` glyphs are `aria-hidden`; opacity-only animation → no layout shift.

## Verification
Exercised against the throwaway issue-589 sandbox (`BARTLEBY_HOME=…/issue-589-sandbox BARTLEBY_PROJECT=demo`), per the redline — never a live corpus.
- Desktop 1280: scan no-result renders `> no chunks match "…"` (amber prompt, Iosevka, no italic/serif, no layout shift).
- Mobile 375: awaiting-query renders `> awaiting query` with the trailing cursor.
- Cursor verified live via computed style: `font-family: Doto`, `animation-name: r5-blink`, `1.06s`. No console errors.
- The in-flight busy-banner cursor is a transient state; markup + CSS verified by reading and by the shared `.cursor` computed-style check (couldn't freeze a clean screenshot of it — the shared Playwright browser was heavily contended by the parallel R-series players).

**Tests:** skipped this ship (web-only, CSS/Svelte markup only; `--skip-tests`).

Part of #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)