### PR TITLE
B5 · Source-viewer empty/error state

### DIFF
--- a/bartleby/web/src/lib/components/SourceViewer.svelte
+++ b/bartleby/web/src/lib/components/SourceViewer.svelte
@@ -92,9 +92,15 @@
 
 {#if isMarkdown}
   {#if errorMsg}
-    <p class="status">Couldn't load source: {errorMsg}</p>
+    <div class="placeholder placeholder--error">
+      <span class="placeholder__icon" aria-hidden="true">⚠</span>
+      <p class="placeholder__msg">Source unavailable</p>
+      <p class="placeholder__detail">{errorMsg}</p>
+    </div>
   {:else if loading}
-    <p class="status">Loading source…</p>
+    <div class="placeholder">
+      <p class="placeholder__msg">Loading source…</p>
+    </div>
   {:else if srcdoc}
     <iframe title="Rendered markdown source" {srcdoc} sandbox=""></iframe>
   {/if}
@@ -103,11 +109,61 @@
     <iframe title="Source document" {src} sandbox={isPdf ? undefined : ""}></iframe>
   {/key}
 {:else}
-  <p class="empty">Click an inline citation to view the source here.</p>
+  <div class="placeholder">
+    <span class="placeholder__icon" aria-hidden="true">◧</span>
+    <p class="placeholder__msg">No source selected</p>
+    <p class="placeholder__detail">Click an inline citation to view the source here.</p>
+  </div>
 {/if}
 
 <style>
-  .status {
-    padding: var(--space-lg);
+  /* B5 — SourceViewer empty/error placeholder.
+     The viewer panel sits on the dark shell (not a paper card), so these states
+     use shell-chrome tokens throughout. The placeholder sizes to its own content
+     (no fixed height here — the .split .viewer container owns the height) and is
+     centred vertically within whatever space the viewer gives it. */
+  .placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-xs);
+    height: 100%;
+    min-height: 8rem;
+    padding: var(--space-2xl);
+    color: var(--color-shell-text-soft);
+    font-family: var(--font-sans);
+    text-align: center;
+  }
+  .placeholder__icon {
+    font-size: var(--text-2xl);
+    line-height: 1;
+    opacity: 0.45;
+    margin-bottom: var(--space-xs);
+  }
+  .placeholder__msg {
+    font-size: var(--text-sm);
+    color: var(--color-shell-text-soft);
+    font-family: var(--font-sans);
+  }
+  .placeholder__detail {
+    font-size: var(--text-xs);
+    color: var(--color-shell-text-soft);
+    opacity: 0.7;
+    font-family: var(--font-sans);
+    max-width: 22ch;
+    line-height: 1.4;
+  }
+  .placeholder--error .placeholder__icon {
+    color: var(--color-token-dark);
+    opacity: 0.8;
+  }
+  .placeholder--error .placeholder__msg {
+    color: var(--color-shell-text);
+  }
+  .placeholder--error .placeholder__detail {
+    color: var(--color-shell-text-soft);
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
   }
 </style>


### PR DESCRIPTION
Part of #589.

## What changed

Replaces the bare `<p>` empty/error states in `SourceViewer.svelte` with a proper `.placeholder` block that fills the sticky viewer pane (via `height: 100%`) and centres its content vertically with flexbox.

Three states handled:
- **Idle** (no citation selected): `◧` icon + "No source selected" + helper text
- **Loading** (markdown fetch in progress): "Loading source…"
- **Error** (markdown fetch failed): `⚠` icon in amber (`--color-token-dark`), "Source unavailable" + raw error message in mono

All states use `--color-shell-*` tokens — the viewer panel sits on the dark shell, not a paper card.

## Before / After

Before: a small `<p>` floated in the upper-left of a `calc(100vh - 6rem)` tall box — an oversized dead frame with no context.

After: the placeholder fills the viewer height, centres the message vertically, and gives the user an actionable hint ("Click an inline citation…") or the error reason.

## Files changed

- `bartleby/web/src/lib/components/SourceViewer.svelte` — only file touched; `app.css` is unchanged.

## New CSS classes (collision surface for other issues)

All new selectors are Svelte-scoped inside `SourceViewer.svelte`:
- `.placeholder`, `.placeholder--error`, `.placeholder__icon`, `.placeholder__msg`, `.placeholder__detail`

No global classes added to `app.css`. No collision risk for R4 (#593) or other parallel players.

## Tests

`--skip-tests` (web-only issue, no Python tests to run). Verified the compiled output serves `.placeholder` markup via the dev server at port 5173.

## Playwright note

The shared Playwright MCP browser was under heavy contention from 6+ parallel ship agents during verification. The dev server at port 5173 responded correctly with the new markup (confirmed via curl). Visual screenshots were blocked by other agents continuously redirecting the browser.