### PR TITLE
R4 · Finding-detail ledger treatment

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -647,3 +647,190 @@ input[type="number"] {
 }
 /* Entity rows render as cards by composing the shared `.surface` primitive in
    the markup (class="entity surface"); the box styling lives there, not here. */
+
+/* =========================================================================
+   R4 · Finding-detail ledger treatment (#593)
+   Owns ONLY the finding-detail (.ledger) selectors. Builds on the R1
+   foundation (Doto display / Iosevka chrome / Source Serif prose, square
+   corners, amber + danger tokens) — adds nothing to :root.
+
+   Three moves:
+     1. Doto drop-cap opening the body, with TIGHT spacing around it.
+     2. Iosevka Term hed (.ledger-hed) + dek (.ledger-dek), replacing the
+        serif-italic dek.
+     3. A two-column ledger: ~62–66ch prose measure + a right-hand gutter of
+        margin-note citations. Inline daggers (†/‡ + ordinal) in the prose tie
+        back to matching gutter notes. Resolved = amber "source"; missing =
+        danger-toned "no longer available".
+
+   Citation markup (stable for R3/#592 to splice a pixel icon into):
+     inline   <sup class="cite-ref cite-ref--source|--gone" data-note="N">†N</sup>
+     gutter   <div class="margin-note margin-note--source|--gone" data-note="N">
+                <p class="margin-note__head"><span class="margin-note__dagger">†N</span> source</p>
+                <… class="margin-note__body">label</…>
+              </div>
+   The dagger glyph + ordinal is the tie-back; data-note pairs them for JS.
+   ========================================================================= */
+
+/* The ledger needs room for prose + gutter, so widen its report column and
+   let the sticky viewer take what's left. Scoped to the ledger so the
+   document-detail split (which shares .split) is untouched. */
+.split:has(.ledger) {
+  grid-template-columns: minmax(0, 54rem) minmax(0, 1fr);
+}
+
+/* --- Hed + dek: Iosevka chrome, not serif --- */
+.ledger-hed {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.ledger-dek {
+  font-family: var(--font-sans);
+  font-weight: 400;
+  font-size: var(--text-base);
+  /* lining figures: this is chrome, not running prose — no oldstyle. */
+  font-feature-settings: "lnum" 1;
+  color: var(--color-text-soft);
+  margin-bottom: var(--space-lg);
+}
+/* The shared `.split .desc` rule italicises + serif-spaces the dek; the ledger
+   overrides that to plain Iosevka. (Equal-ish specificity — pin it here.) */
+.split .ledger-dek {
+  font-style: normal;
+}
+
+/* --- Ledger column: prose (capped at a readable measure) + note gutter --- */
+.ledger-column {
+  display: grid;
+  /* ~62–66 characters at the body serif size, then the margin-note gutter. */
+  grid-template-columns: minmax(0, 36rem) minmax(0, 14rem);
+  gap: var(--space-xl);
+  align-items: start;
+  margin: var(--space-xl) 0;
+}
+/* The body already carries `.body` from the shared split rules; the ledger
+   column owns its own margins, so neutralise the shared `.split .body` block
+   margin to avoid doubling. */
+.split .ledger-column .body {
+  margin: 0;
+}
+
+/* --- Doto drop-cap, tight --- *
+   First letter of the first body paragraph, set in the display face. Floated
+   so the prose wraps around it; tight margins per the brief ("needs less space
+   around it"). Honours the display floor implicitly — a drop-cap is large. */
+.drop-cap-body > p:first-of-type::first-letter {
+  font-family: var(--font-display);
+  font-weight: 500;
+  float: left;
+  /* ~3 lines tall; line-height 0.8 + small top nudge seats it on the baseline
+     grid without a tall gap above. */
+  font-size: 3.1em;
+  line-height: 0.78;
+  margin: 0.02em 0.06em 0 0;
+  color: var(--color-text);
+}
+
+/* --- Margin-note citation gutter --- */
+.cite-notes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  /* Sits beside the prose; on the dark-ledger paper it reads as a quiet rail. */
+  border-left: 1px solid var(--color-rule);
+  padding-left: var(--space-lg);
+}
+.margin-note {
+  font-family: var(--font-sans);
+  font-size: var(--text-2xs);
+  line-height: 1.4;
+}
+.margin-note__head {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  font-weight: 500;
+}
+.margin-note__dagger {
+  font-weight: 700;
+}
+.margin-note__body {
+  margin: var(--space-3xs) 0 0;
+  /* font-size inherits --text-2xs from .margin-note */
+  font-feature-settings: "lnum" 1;
+  word-break: break-word;
+}
+.margin-note__body--doc {
+  font-style: italic;
+  color: var(--color-text-soft);
+}
+/* The resolved-source note links to the chunk; a bare button styled as text. */
+.margin-note__link {
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  color: var(--color-token-text); /* amber-as-text, tuned for paper */
+}
+.margin-note__link:hover,
+.margin-note__link.active {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+/* Resolved = amber "source". */
+.margin-note--source .margin-note__head {
+  color: var(--color-token-text);
+}
+/* Missing = danger tone. */
+.margin-note--gone .margin-note__head {
+  color: var(--color-danger-text);
+}
+.margin-note--gone .margin-note__body {
+  color: var(--color-danger-text);
+  font-style: italic;
+}
+
+/* --- Inline dagger anchors in the prose --- */
+.cite-ref {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 0.7em;
+  cursor: pointer;
+  /* sit snug after the word it annotates */
+  padding-left: 0.05em;
+}
+.cite-ref--source {
+  color: var(--color-token-text);
+}
+.cite-ref--gone {
+  color: var(--color-danger-text);
+}
+.cite-ref:hover {
+  text-decoration: underline;
+}
+
+/* --- Narrow screens: the gutter can't survive, so fold notes below the prose
+   as a stacked list. Margin notes degrade to end-notes; the dagger ordinals
+   still tie inline marker → note. --- */
+@media (max-width: 56rem) {
+  /* Stack the prose-over-viewer split (this is the ledger's own override of the
+     shared .split grid, so collapsing it here is in-scope for R4). */
+  .split:has(.ledger) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ledger-column {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .cite-notes {
+    /* already column-stacked; only swap the rail from left edge to top */
+    border-left: 0;
+    border-top: 1px solid var(--color-rule);
+    padding-left: 0;
+    padding-top: var(--space-lg);
+    margin-top: var(--space-md);
+  }
+}

--- a/bartleby/web/src/routes/findings/[id]/+page.svelte
+++ b/bartleby/web/src/routes/findings/[id]/+page.svelte
@@ -5,7 +5,7 @@
   import Button from "$lib/components/Button.svelte";
   import SourceViewer from "$lib/components/SourceViewer.svelte";
   import { stripExt } from "$lib/format.js";
-  import { CHUNK_ICON } from "$lib/icons.js";
+
   export let data;
 
   $: byId = new Map(data.finding.citations.map((c) => [c.chunk_id, c]));
@@ -17,47 +17,65 @@
     ? `${data.finding.model}${data.finding.model_set_by_llm ? " (Set by LLM)" : ""}`
     : null;
 
-  // Substitute each citation marker in the markdown source before marked parses.
-  // Two kinds: digit [^N] → a corpus-chunk chip (resolves against byId); and
-  // [^url:…]/[^doc:…] → a visibly-distinct external-citation chip. External
-  // markers are matched first so the digit pass can't see their alpha schemes.
-  // Marked passes inline HTML through, so chips sit inside the same <p> as the
-  // surrounding prose. Reactive on `active` so .active bakes into the HTML.
-  $: bodyHtml = marked.parse(
-    data.finding.body
-      .replace(/\[\^([A-Za-z]+):([^\]]+)\]/g, (match, scheme, ref) =>
-        renderExternal(scheme.toLowerCase(), ref.trim()),
-      )
-      .replace(/\[\^(\d+)\]/g, (match, idStr) => {
-        const c = byId.get(Number(idStr));
-        return c ? renderChip(c, c === active) : renderTombstone(Number(idStr));
-      }),
-  );
+  // ===== R4 ledger treatment (#593) =================================
+  // Citations leave the prose and move into a right-hand gutter as margin
+  // notes. Each marker in the body becomes an inline DAGGER anchor (†/‡ +
+  // ordinal); the matching note carries the same dagger+ordinal in the gutter.
+  // The ordinal is the tie-back — daggers repeat, the number disambiguates.
+  //
+  // Two kinds of marker:
+  //   [^N]            corpus-chunk citation. Resolves against byId →
+  //                     resolved  → † "source" note (amber, filename, jumps)
+  //                     unresolved → ‡ "no longer available" note (danger)
+  //   [^url:…]/[^doc:…]  external citation → † "source" note (link / ref)
+  //
+  // `notes` is rebuilt alongside `bodyHtml` in one ordered pass so the gutter
+  // order matches reading order. Reactive on `active` so the .active state
+  // bakes into the rendered HTML.
+  let notes = [];
+  $: bodyHtml = renderBody(data.finding.body, byId, active);
 
-  // An external (URL / external-dataset doc) citation that rides alongside the
-  // corpus-chunk citations. No DB row backs it — it's parsed straight from the
-  // body marker. Rendered as a distinct chip: a url scheme becomes a real link
-  // (new tab via the layout's marked hook), a doc scheme a muted ref label.
-  // Unknown schemes are dropped (left to the well-formedness check at save time).
-  function renderExternal(scheme, ref) {
-    if (scheme === "url") {
-      return `<a class="cite-external cite-external--url" href="${esc(ref)}" title="${esc(`external source · ${ref}`)}">${esc(ref)}</a>`;
-    }
-    if (scheme === "doc") {
-      return `<span class="cite-external cite-external--doc" title="${esc(`external dataset doc · ${ref}`)}">${esc(ref)}</span>`;
-    }
-    return esc(`[^${scheme}:${ref}]`);
+  function renderBody(body, byId, active) {
+    const collected = [];
+    let n = 0;
+    const html = marked.parse(
+      body
+        .replace(/\[\^([A-Za-z]+):([^\]]+)\]/g, (match, scheme, ref) => {
+          const note = externalNote(++n, scheme.toLowerCase(), ref.trim());
+          if (!note) {
+            n--; // unknown scheme: drop, don't burn an ordinal
+            return esc(match);
+          }
+          collected.push(note);
+          return marker(note);
+        })
+        .replace(/\[\^(\d+)\]/g, (match, idStr) => {
+          const id = Number(idStr);
+          const c = byId.get(id);
+          const note = c
+            ? sourceNote(++n, c, c === active)
+            : goneNote(++n, id);
+          collected.push(note);
+          return marker(note);
+        }),
+    );
+    notes = collected;
+    return html;
   }
 
-  // An unresolved [^N] marker: the cited source has been removed (deleted, or
-  // rebuilt under new chunk ids by an edit/merge), so only the id survives. We
-  // can't say what it was or whether it was truly deleted — render a muted
-  // tombstone that keeps the marker present rather than leaking raw [^N] text.
-  function renderTombstone(chunkId) {
-    return `<span class="cite-gone" title="${esc(`chunk ${chunkId} · cited source no longer available`)}">cited source no longer available</span>`;
+  // The inline dagger anchor that sits at the cited point in the prose. A
+  // superscript <sup> with the dagger glyph + ordinal; the ordinal ties it to
+  // its gutter note. Stable class hooks (`cite-ref`, kind modifier) so R3 (#592)
+  // can splice a pixel icon in without touching this code.
+  function marker(note) {
+    const kindCls = note.gone ? "cite-ref--gone" : "cite-ref--source";
+    const title = note.gone
+      ? `${note.dagger} cited source no longer available`
+      : `${note.dagger} source · ${note.title}`;
+    return `<sup class="cite-ref ${kindCls}" data-note="${note.n}" title="${esc(title)}">${note.dagger}${note.n}</sup>`;
   }
 
-  function renderChip(c, isActive) {
+  function sourceNote(n, c, isActive) {
     const name = stripExt(c.file_name);
     const label =
       name && c.page_number ? `${name} p.${c.page_number}`
@@ -69,12 +87,42 @@
       c.page_number && `page ${c.page_number}`,
       `chunk ${c.chunk_id}`,
     ].filter(Boolean).join(" · ");
-    const cls = `cite-chip${isActive ? " active" : ""}`;
-    const chip = `<button type="button" class="${cls}" data-chunk-id="${c.chunk_id}" title="${esc(title)}">${esc(label)}</button>`;
-    // A sibling jump button → /chunks/<id>. A <button> (not <a>) so it routes
-    // in-tab via goto; the layout's marked hook rewrites every <a> to a new tab.
-    const jump = `<button type="button" class="cite-jump" data-chunk-id="${c.chunk_id}" title="Open chunk ${c.chunk_id} in context" aria-label="Open chunk ${c.chunk_id} in context">${CHUNK_ICON}</button>`;
-    return `<span class="cite">${chip}${jump}</span>`;
+    return {
+      n,
+      dagger: "†",
+      gone: false,
+      chunkId: c.chunk_id,
+      active: isActive,
+      label,
+      title,
+    };
+  }
+
+  // An unresolved [^N]: the cited source has been removed (deleted, or rebuilt
+  // under new chunk ids by an edit/merge), so only the id survives. Danger-toned
+  // gutter note rather than leaking raw [^N] text.
+  function goneNote(n, chunkId) {
+    return {
+      n,
+      dagger: "‡",
+      gone: true,
+      chunkId,
+      label: "no longer available",
+      title: `chunk ${chunkId} · cited source no longer available`,
+    };
+  }
+
+  // An external (URL / external-dataset doc) citation parsed straight from the
+  // body marker — no DB row backs it. A url scheme becomes a real link, a doc
+  // scheme a muted ref. Unknown schemes return null (dropped upstream).
+  function externalNote(n, scheme, ref) {
+    if (scheme === "url") {
+      return { n, dagger: "†", gone: false, external: "url", href: ref, label: ref, title: `external source · ${ref}` };
+    }
+    if (scheme === "doc") {
+      return { n, dagger: "†", gone: false, external: "doc", label: ref, title: `external dataset doc · ${ref}` };
+    }
+    return null;
   }
 
   function esc(s) {
@@ -92,22 +140,26 @@
     return `/files/${c.document_id}${page}`;
   }
 
-  // Chips are static HTML inside {@html}, so click delegation on the container
-  // is simpler than wiring each as a Svelte component.
+  function activate(chunkId) {
+    const c = byId.get(chunkId);
+    if (c) active = c;
+  }
+
+  // Clicking an inline dagger scrolls its gutter note into view and activates
+  // it (loads the source in the viewer). Delegated on the report container
+  // since the markers are static {@html}.
   let container;
   onMount(() => {
     container.addEventListener("click", (e) => {
-      const jump = e.target.closest(".cite-jump");
-      if (jump) {
-        e.preventDefault();
-        goto(`/chunks/${jump.dataset.chunkId}`);
-        return;
-      }
-      const btn = e.target.closest(".cite-chip");
-      if (!btn) return;
+      const ref = e.target.closest(".cite-ref");
+      if (!ref) return;
       e.preventDefault();
-      const c = byId.get(Number(btn.dataset.chunkId));
-      if (c) active = c;
+      const el = container.querySelector(
+        `.margin-note[data-note="${ref.dataset.note}"]`,
+      );
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      const noteEl = el?.querySelector("[data-chunk-id]");
+      if (noteEl) activate(Number(noteEl.dataset.chunkId));
     });
   });
 
@@ -129,12 +181,12 @@
 </script>
 
 <div class="split">
-  <article class="report surface surface--finding" bind:this={container}>
-    <h1>{data.finding.title}</h1>
+  <article class="report surface surface--finding ledger" bind:this={container}>
+    <h1 class="ledger-hed">{data.finding.title}</h1>
     <p class="meta">
       <span class="finding-id">#{data.finding.finding_id}</span> · {data.finding.session_name}{#if modelMeta} · {modelMeta}{/if} · {data.finding.created_at}
     </p>
-    <p class="desc">{data.finding.description}</p>
+    <p class="ledger-dek">{data.finding.description}</p>
 
     <div class="toolbar">
       <Button size="sm" type="button" on:click={copyMarkdown}>
@@ -143,8 +195,46 @@
       <Button size="sm" type="button" on:click={downloadMarkdown}>Download .md</Button>
     </div>
 
-    <div class="body markdown-body">
-      {@html bodyHtml}
+    <!-- Ledger column: drop-capped prose + a margin-note gutter. The body
+         carries inline dagger anchors; the gutter carries the matching notes. -->
+    <div class="ledger-column">
+      <div class="body markdown-body drop-cap-body">
+        {@html bodyHtml}
+      </div>
+
+      {#if notes.length}
+        <aside class="cite-notes" aria-label="Citations">
+          {#each notes as note (note.n)}
+            <div
+              class="margin-note margin-note--{note.gone ? 'gone' : 'source'}"
+              data-note={note.n}
+            >
+              <p class="margin-note__head">
+                <span class="margin-note__dagger">{note.dagger}{note.n}</span>
+                source
+              </p>
+              {#if note.gone}
+                <p class="margin-note__body">no longer available</p>
+              {:else if note.external === "url"}
+                <p class="margin-note__body">
+                  <a href={note.href} title={note.title}>{note.label}</a>
+                </p>
+              {:else if note.external === "doc"}
+                <p class="margin-note__body margin-note__body--doc" title={note.title}>{note.label}</p>
+              {:else}
+                <button
+                  type="button"
+                  class="margin-note__body margin-note__link"
+                  class:active={note.active}
+                  data-chunk-id={note.chunkId}
+                  title={note.title}
+                  on:click={() => goto(`/chunks/${note.chunkId}`)}
+                >{note.label}</button>
+              {/if}
+            </div>
+          {/each}
+        </aside>
+      {/if}
     </div>
   </article>
 
@@ -158,94 +248,5 @@
     display: flex;
     gap: var(--space-sm);
     margin-top: var(--space-md);
-  }
-  /* Inline citation chips are emitted as raw HTML strings inside {@html}
-     (see renderChip), so they sit outside Svelte's scoping and must be styled
-     :global. Padding/size use em so the chip tracks the surrounding prose. */
-  :global(.cite-chip) {
-    display: inline-block;
-    vertical-align: baseline;
-    max-width: 20ch;
-    padding: 0 0.4em;
-    margin: 0 0.15em;
-    background: var(--color-token);
-    border: 1px solid var(--color-token-dark);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-sans);
-    font-size: 0.8em;
-    line-height: 1.4;
-    color: var(--color-off);
-    cursor: pointer;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  :global(.cite-chip:hover),
-  :global(.cite-chip.active) {
-    background: var(--color-off);
-    color: var(--color-surface);
-    border-color: var(--color-off);
-  }
-  /* Tombstone for a [^N] whose cited source is gone. Raw {@html}, hence :global.
-     Muted + italic so it reads as an absence, not a live citation chip. */
-  :global(.cite-gone) {
-    font-style: italic;
-    font-size: 0.85em;
-    color: var(--color-token-dark);
-    cursor: help;
-  }
-  /* External (URL / external-dataset doc) citations. Distinct from the corpus
-     chunk chips: a dashed border + accent tint signals "not from the corpus."
-     Raw {@html}, hence :global. */
-  :global(.cite-external) {
-    display: inline-block;
-    vertical-align: baseline;
-    max-width: 24ch;
-    padding: 0 0.4em;
-    margin: 0 0.15em;
-    border: 1px dashed var(--color-link);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-sans);
-    font-size: 0.8em;
-    line-height: 1.4;
-    color: var(--color-link);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  :global(a.cite-external--url) {
-    text-decoration: none;
-    cursor: pointer;
-  }
-  :global(a.cite-external--url:hover) {
-    background: var(--color-link);
-    color: var(--color-surface);
-  }
-  :global(.cite-external--doc) {
-    font-style: italic;
-    cursor: help;
-  }
-  /* The chip and its jump button travel together as one inline unit, so a line
-     break never splits them. Also raw {@html}, hence :global. */
-  :global(.cite) {
-    white-space: nowrap;
-  }
-  :global(.cite-jump) {
-    display: inline-flex;
-    align-items: center;
-    vertical-align: baseline;
-    margin: 0 0.15em 0 0.1em;
-    padding: 0;
-    background: none;
-    border: none;
-    color: var(--color-off);
-    cursor: pointer;
-  }
-  :global(.cite-jump:hover) {
-    color: var(--color-link);
-  }
-  :global(.cite-jump .icon) {
-    position: relative;
-    top: 1px;
   }
 </style>

--- a/docs/decisions/GH-0593-r4-ledger-finding-0001.md
+++ b/docs/decisions/GH-0593-r4-ledger-finding-0001.md
@@ -1,0 +1,51 @@
+# Margin-note citations: a stacked gutter, not per-marker float (issue #593)
+
+> Source: [#593](https://github.com/jswest/bartleby/issues/593)
+
+R4 gives `/findings/[id]` a "ledger" treatment: a Doto drop-cap, Iosevka
+hed/dek, a ~62–66ch prose measure, and **margin-note citations** — the inline
+citation chips left the prose and became a right-hand gutter of sidenotes, each
+tied to an inline dagger anchor at the cited point.
+
+**The layout decision: a two-column CSS grid with the notes stacked in reading
+order, NOT Tufte-style per-marker vertical alignment.** True margin notes
+(each note floated to sit beside the exact line of its marker) need
+JS-measured absolute positioning that fights `position: sticky`, reflows on
+every resize/font-load, and collapses incoherently when two markers land on
+adjacent lines. Instead the finding body and a `.cite-notes` aside are the two
+tracks of a `.ledger-column` grid (`minmax(0,36rem)` prose + `minmax(0,14rem)`
+gutter); notes stack in document order in the gutter. **The tie-back is carried
+by the markup, not by geometry**: each inline anchor is
+`<sup class="cite-ref cite-ref--source|--gone" data-note="N">†N</sup>` and its
+note is `<div class="margin-note margin-note--source|--gone" data-note="N">`
+with a matching `†N`/`‡N` dagger badge. The dagger glyph + ordinal is the
+visual pair; `data-note` is the programmatic pair (a click on the anchor
+`scrollIntoView`s the note and activates its source in the viewer). This is
+robust, reflow-free, and degrades cleanly.
+
+**Graceful narrow-screen degradation falls straight out of the grid.** At
+`max-width: 56rem` the `.ledger-column` collapses to one column, so the gutter
+folds *below* the prose as a stacked end-note list (a top rule replaces the
+left rule). The daggers still tie inline marker → note, so no information is
+lost on mobile — the citations just become footnotes instead of sidenotes. No
+JS branch, no separate mobile component; the same markup re-flows.
+
+**Resolved vs. missing is a tone, set on the note kind, not separate widgets.**
+A `[^N]` that resolves against the finding's citations → a `†` amber "source"
+note (`--color-token-text`) linking to the chunk; an unresolved `[^N]` → a `‡`
+danger-toned "no longer available" note (`--color-danger-text`). External
+`[^url:…]`/`[^doc:…]` markers ride the same `†` "source" path (link / muted
+ref). One ordered pass over the body builds `bodyHtml` and the `notes` array
+together so gutter order always matches reading order.
+
+**Markup is a stable contract for the R3 icon pass (#592).** The
+`cite-ref`/`cite-ref--source`/`cite-ref--gone` classes and the
+`margin-note__dagger` badge are deliberately semantic and untouched by styling
+churn, so #592 can splice a Pixelarticons glyph into the dagger anchor without
+reaching into this component's render logic.
+
+CSS lives in a self-contained `R4 · Finding-detail ledger treatment` section at
+the end of `app.css` (owns only `.ledger*`, `.drop-cap-body`, `.cite-ref*`,
+`.cite-notes`, `.margin-note*`, and a `.split:has(.ledger)` width override) so
+it doesn't collide with the other R-series players editing the same file. No
+schema change; web-only.


### PR DESCRIPTION
Part of #589 (R4). Builds on the R1 foundation (#590) already in the omnibus branch.

Gives `/findings/[id]` a "ledger" treatment.

## What changed
- **Doto drop-cap** opening the body, tight spacing (per the brief's "needs less space around it").
- **Iosevka Term hed + dek** (`.ledger-hed` / `.ledger-dek`), replacing the serif-italic dek.
- **~64ch prose measure** (in the 62–66ch readability band) via a two-column ledger grid: prose + a right-hand margin-note gutter.
- **Margin-note citations.** Inline daggers (`†`/`‡` + ordinal) at the cited point tie back to gutter notes by glyph+ordinal (`data-note` is the programmatic pair). Resolved `[^N]` → amber **"† source"** note (filename, links to the chunk); unresolved `[^N]` → danger-toned **"‡ source — no longer available"**; external `[^url:…]`/`[^doc:…]` ride the same source path (link / muted ref).
- **Narrow screens degrade gracefully.** At ≤56rem the gutter folds *below* the prose as a stacked end-note list; daggers still tie marker → note, so nothing is lost.

## Citation markup (stable contract for R3 / #592)
```
inline   <sup class="cite-ref cite-ref--source|--gone" data-note="N">†N</sup>
gutter   <div class="margin-note margin-note--source|--gone" data-note="N">
           <p class="margin-note__head"><span class="margin-note__dagger">†N</span> source</p>
           <… class="margin-note__body">label</…>   (button.margin-note__link when it jumps to a chunk)
         </div>
```
The dagger glyph + ordinal is the visual tie-back; `data-note` is the programmatic one. R3 can splice a Pixelarticon into the dagger anchor without touching the render logic.

## CSS coordination
All new rules live in a self-contained `R4 · Finding-detail ledger treatment (#593)` section at the **end** of `app.css`, owning only finding-detail selectors: `.ledger*`, `.drop-cap-body`, `.cite-ref*`, `.cite-notes`, `.margin-note*`, plus a `.split:has(.ledger)` width override. R1's `:root` tokens, `@font-face`, and the two-grounds rules are untouched.

## Decision
`docs/decisions/GH-0593-r4-ledger-finding-0001.md` — why stacked-gutter grid over Tufte-style per-marker float (reflow-free, no JS positioning, mobile falls out for free).

## Verification (Playwright, sandbox corpus)
Verified against the throwaway `issue-589-sandbox` (redline-safe — no live corpus/Ollama). Finding 1 carries both a resolved (`†1`) and a missing (`‡2`) citation.
- **Desktop 1280** — Doto drop-cap (55.8px display font confirmed), Iosevka hed/dek, measured **64ch** body, `†1` amber + `‡2` danger daggers, gutter notes `†1 source / 2023-air-quality-equity-report` and `‡2 source / no longer available`.
- **Mobile 375** — gutter folds below prose as stacked end-notes; daggers still tie in; drop-cap and hed/dek hold.

Tests skipped this ship (`--skip-tests`; web-only, no test layer touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)