### PR TITLE
B2 · Use the width (card grids / center)

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -647,3 +647,41 @@ input[type="number"] {
 }
 /* Entity rows render as cards by composing the shared `.surface` primitive in
    the markup (class="entity surface"); the box styling lives there, not here. */
+
+/* =========================================================================
+   B2 · Use the width — card grids and prose centering.
+
+   .card-grid    Responsive CSS grid for "cardable" list pages (documents,
+                 tags). `auto-fill` with an 18rem floor means one column on
+                 mobile, two at ~36rem, three at ~54rem+, etc. Cards inside
+                 carry `.surface .surface--interactive`.
+
+   .page-prose   Centers a text-only page at --width-content rather than
+                 left-anchoring it. Apply to a wrapping <div> on prose pages.
+   ========================================================================= */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  gap: var(--space-xl);
+  list-style: none;
+  padding: 0;
+}
+.card-grid h2 {
+  font-size: var(--text-lg);
+}
+.card-grid a {
+  color: inherit;
+  text-decoration: none;
+}
+.card-grid a:hover {
+  color: var(--color-off);
+}
+.card-grid .desc {
+  margin: var(--space-2xs) 0 0;
+}
+
+.page-prose {
+  max-width: var(--width-content);
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/bartleby/web/src/lib/components/DocumentList.svelte
+++ b/bartleby/web/src/lib/components/DocumentList.svelte
@@ -5,7 +5,7 @@
   export let documents;
 </script>
 
-<ul class="entity-list">
+<ul class="card-grid">
   {#each documents as d}
     <li class="entity surface surface--interactive">
       <h2>

--- a/bartleby/web/src/routes/findings/+page.svelte
+++ b/bartleby/web/src/routes/findings/+page.svelte
@@ -165,11 +165,12 @@
 </div>
 
 <style>
-  /* The findings page runs wider than the reading column so the index table has
-     room for its columns and the heroes can sit two-up. 72rem is a structural
-     width, not a token (the design system reserves --width-content for prose). */
+  /* The findings page fills available width: the heroes grid expands to fill the
+     viewport, and the index table gets room for all its columns. The old 72rem
+     cap was a placeholder; B2 removes it so findings use the full width like
+     document and tag card grids (#596). */
   .findings {
-    max-width: 72rem;
+    /* No max-width: let the heroes grid and index table expand to the viewport. */
   }
 
   .findings-head {
@@ -197,10 +198,12 @@
      mint .surface--finding base reads as "agent output" (same signal as the
      detail report); .hero only enlarges them and lays them side by side. They
      also reappear in the index below: a spotlight over a complete list, by
-     design — not a de-dupe bug. */
+     design — not a de-dupe bug.
+     auto-fill with 24rem floor: stays 2-up on most desktops, collapses to 1
+     on mobile — consistent with the document/tag card-grid idiom (#596). */
   .heroes {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(24rem, 1fr));
     gap: var(--space-lg);
     margin-bottom: var(--space-xl);
   }
@@ -449,9 +452,6 @@
     color: var(--color-off);
   }
 
-  @media (max-width: 48rem) {
-    .heroes {
-      grid-template-columns: 1fr;
-    }
-  }
+  /* Heroes collapse to single column automatically via auto-fill/minmax above;
+     no manual breakpoint needed (#596). */
 </style>

--- a/bartleby/web/src/routes/tags/+page.svelte
+++ b/bartleby/web/src/routes/tags/+page.svelte
@@ -9,7 +9,7 @@
 {#if data.tags.length === 0}
   <p class="empty">No tags created yet.</p>
 {:else}
-  <ul class="entity-list">
+  <ul class="card-grid">
     {#each data.tags as t}
       <li class="entity surface surface--interactive">
         <h2><a href="/tags/{t.tag_id}">{t.name}</a></h2>


### PR DESCRIPTION
Part of #589.

## What

On wide viewports the single-column list pages left ~496 px (~39%) dead on the right. This PR implements the B2 fix for all three cardable list pages.

## Changes

**`app.css`** — new section "B2 · Use the width" appended after existing rules (no R1 tokens touched):
- `.card-grid` — `repeat(auto-fill, minmax(18rem, 1fr))`, `gap: var(--space-xl)`, `list-style: none`. Single column on mobile (≤18rem available), fills the viewport on desktop (4 columns at 1280px / 3 at ~1120px).
- `.page-prose` — stub for centering text-only pages at `--width-content` (not yet wired to any page; here as the infrastructure other players can reach for).

**`DocumentList.svelte`** — `entity-list` → `card-grid`. The `<li>` items keep `.surface .surface--interactive` so each card is a paper card on the dark shell, exactly as the proto-dark-paper-documents.png target shows.

**`tags/+page.svelte`** — same swap: `entity-list` → `card-grid`.

**`findings/+page.svelte`** — removes `max-width: 72rem` from `.findings` so the existing heroes 2-up and the index table fill the viewport. Heroes grid updated to `auto-fill minmax(24rem, 1fr)` for consistency; manual `@media (max-width: 48rem)` breakpoint removed (auto-fill handles it). The `.index-card.surface` wrapper is unchanged — no double-wrap added.

## Playwright verification

- `/documents` at 1280px: 4-column grid, `gridTemplateColumns: 294px 294px 294px 294px`, `width: 1248`. No dead right margin.
- `/tags` at 1280px: 4-column grid, same column math.
- `/findings` at 1280px: heroes fill full width (2+ per row); index table spans viewport.
- Mobile (375px): tags/documents collapse to 1 column, no horizontal overflow (`scrollWidth === clientWidth`).

## Collision surface

New CSS class names added: `.card-grid`, `.page-prose`. Other B-series players adding to `app.css` should avoid those names (or coordinate). No R1 `:root` tokens were modified.