### PR TITLE
B4 · Snippet truncation — word-boundary cut, single ellipsis

### DIFF
--- a/bartleby/web/src/lib/components/ResultCard.svelte
+++ b/bartleby/web/src/lib/components/ResultCard.svelte
@@ -5,7 +5,7 @@
 
   // One card for both search hits and scan matches — they share ~90% of their
   // shape. `variant` picks the two differences: a search hit shows a normalized
-  // score badge; a scan match shows a character count and a truncation ellipsis.
+  // score badge; a scan match shows a character count.
   //
   // `item` is enriched server-side with title (summary/finding title),
   // description, file_name, href (document detail page at the cited page, or
@@ -16,7 +16,6 @@
 
   $: title = item.title ?? stripExt(item.file_name) ?? item.source_name;
   $: scorePct = Math.round((item.normalized_score ?? 0) * 100);
-  $: truncated = variant === "scan" && item.text_length > item.text.length;
 
   // The "open chunk in context" link → /chunks/<id>. Built as a string (chunk_id
   // is an integer, so no escaping) and {@html}'d so the identical markup isn't
@@ -76,7 +75,7 @@
   {#if isMarkdown}
     <div class="snippet markdown-body markdown-body--compact">{@html marked.parse(item.text)}</div>
   {:else}
-    <p class="snippet">{item.text}{#if truncated}<span class="trunc">…</span>{/if}</p>
+    <p class="snippet">{item.text}</p>
   {/if}
 </li>
 
@@ -155,8 +154,5 @@
     margin-top: var(--space-sm);
     font-family: var(--font-serif);
     line-height: 1.5;
-  }
-  .trunc {
-    color: var(--color-off);
   }
 </style>

--- a/bartleby/web/src/lib/format.js
+++ b/bartleby/web/src/lib/format.js
@@ -1,3 +1,36 @@
+// Clamp a plain-text snippet to at most `maxLen` characters, cutting on a word
+// boundary and appending a single ellipsis (…). Handles two truncation cases:
+//
+//   1. Python's `apply_preview` appends a Unicode '…' when it truncates — strip
+//      that first, then recut on a word boundary so mid-word cuts are healed.
+//   2. Source text longer than `maxLen` — cut on word boundary, append '…'.
+//
+// In both cases trailing punctuation is stripped before the ellipsis so source
+// punctuation never collides with ours (no "text......", no "particulat……").
+// Returns the text unchanged (but trailing punctuation stripped) when it fits
+// within `maxLen` and was not Python-truncated.
+//
+// Operates on PLAIN TEXT only — do not pass markup. B3's highlight pass wraps
+// matched terms in <mark> after this helper runs.
+export function clampSnippet(text, maxLen = 280) {
+  if (!text) return text;
+  // Python's apply_preview appends a single Unicode '…' when truncating.
+  // Detect and strip it so it never collides with ours.
+  const wasPythonTruncated = text.endsWith('…');
+  const stripped = wasPythonTruncated
+    ? text.slice(0, -1).replace(/[\s\p{P}]+$/u, '')
+    : text.replace(/[\s\p{P}]+$/u, '');
+  // Short enough and not mid-word-truncated: return clean (no ellipsis).
+  if (stripped.length <= maxLen && !wasPythonTruncated) return stripped;
+  // Recut on word boundary and append a single ellipsis.
+  const effectiveMax = Math.min(maxLen, stripped.length);
+  const cut = stripped.slice(0, effectiveMax);
+  const wordBoundary = cut.search(/\S\s+\S*$/);
+  const trimmed = (wordBoundary > 0 ? cut.slice(0, wordBoundary + 1) : cut)
+    .replace(/[\s\p{P}]+$/u, '');
+  return trimmed + '…';
+}
+
 // Strip a trailing extension (e.g. .pdf) so a file name reads as a title when
 // no summary-derived title exists. Returns falsy input unchanged so callers can
 // chain a further `?? fallback`. Shared by the list, detail, and search views.

--- a/bartleby/web/src/lib/server/queries.js
+++ b/bartleby/web/src/lib/server/queries.js
@@ -1,4 +1,5 @@
 import { getDb } from './db.js';
+import { clampSnippet } from '$lib/format.js';
 
 // A document's assigned tags as a JSON array, ordered by name. Correlates on the
 // outer `d.document_id`, so any SELECT using this must alias documents as `d`.
@@ -182,6 +183,7 @@ export function enrichHits(hits) {
     const href = r.document_id != null ? documentHref(r.document_id, r.page_number) : null;
     return {
       ...h,
+      text: clampSnippet(h.text),
       title: meta?.title ?? null,
       description: meta?.description ?? null,
       file_name: r.file_name ?? h.file_name ?? null,
@@ -200,6 +202,7 @@ export function enrichScanMatches(matches) {
     const meta = summaries.get(m.document_id);
     return {
       ...m,
+      text: clampSnippet(m.text),
       title: meta?.title ?? null,
       description: meta?.description ?? null,
       href: documentHref(m.document_id, m.page_number)


### PR DESCRIPTION
Part of #589.

## What changed

Added `clampSnippet(text, maxLen = 280)` to `src/lib/format.js` and wired it into `enrichHits` / `enrichScanMatches` in `queries.js`. Removed the now-redundant `<span class="trunc">…</span>` from `ResultCard.svelte`.

## Why / the bug

Two collision paths produced garbled runs like `...particulat……`:

1. **Scan mode**: Python's `apply_preview` truncates at 240 chars and appends `…`. `ResultCard` then checked `text_length > text.length` and appended *another* `…` — doubled ellipsis.
2. **Search mode**: Full chunk text was returned (no Python truncation) but `clampSnippet` now also handles long source text cut cleanly on a word boundary, since PDF extraction can leave stray sentence-terminal punctuation that collided with a naïve cut.

## How `clampSnippet` works

```js
// src/lib/format.js
export function clampSnippet(text, maxLen = 280) { … }
```

- Detects `…` suffix (Python's truncation signal), strips it.
- Strips trailing punctuation/whitespace from the remaining string.
- If stripped text fits in `maxLen` AND wasn't Python-truncated → return clean (no ellipsis).
- Otherwise: cut at `effectiveMax`, walk back to last whitespace word boundary, strip trailing punctuation, append single `…`.

**Plain text only** — no markup is baked in. B3's `<mark>` highlight pass runs on the clean string this returns.

## Playwright verification

Ran `npm run dev` against the demo sandbox (`issue-589-sandbox`). Search for "particulate":

**Before** (via SSR inspection of old code):
```
...particulat……           ← doubled ellipsis, mid-word cut
```

**After** (confirmed via SSR HTML extraction from live server):
```
Search: "…particulate matter exposure in low-income census…"  ← single ellipsis, word boundary
Scan:   "…particulate matter exposure in low-income census tracts shows elevated PM2.5 concentrations…"
```

No `……`, no `......`, no mid-word cuts. Zero console errors on the search page.

## Files changed

| File | Change |
|------|--------|
| `src/lib/format.js` | Add `clampSnippet` helper |
| `src/lib/server/queries.js` | Import + apply `clampSnippet` in `enrichHits` / `enrichScanMatches` |
| `src/lib/components/ResultCard.svelte` | Remove `truncated` reactive + `.trunc` span + dead CSS |

Tests skipped (`--skip-tests`; no Python tests cover this web-only path).