### PR TITLE
B1 · Mobile nav overflow — responsive wrap at ≤480px

### DIFF
--- a/bartleby/web/src/routes/+layout.svelte
+++ b/bartleby/web/src/routes/+layout.svelte
@@ -124,4 +124,43 @@
        slide under it; the horizontal value is the shared page gutter. */
     padding: 4rem var(--space-lg) var(--space-2xl);
   }
+
+  /* =========================================================================
+     B1 · Mobile nav — responsive wrap at ≤480px (#595)
+     Strategy: wrap .bar to two lines so every nav destination stays reachable
+     at 375px with no page-level horizontal scroll.
+       Row 1: wordmark (.brand) + project badge (.project, right-aligned)
+       Row 2: nav links (.links), spanning full width
+     No JS, no hamburger — all four links stay visible and tappable.
+     NOTE: R3 (#592) will add Pixelarticons; keep link markup clean.
+     ========================================================================= */
+  @media (max-width: 480px) {
+    .bar {
+      flex-wrap: wrap;
+      gap: var(--space-sm) var(--space-lg);
+      /* Reduce vertical padding so the two-line header doesn't consume too
+         much of the small viewport. */
+      padding: var(--space-sm) var(--space-md);
+    }
+    /* Row 1: brand fills available space; .project stays at the right end via
+       margin-left:auto inherited from the default rule above. */
+    .brand {
+      /* Let the wordmark shrink but keep it above the dot-matrix floor so
+         Doto characters stay legible (--text-display-floor = 1.25rem). */
+      font-size: var(--text-display-floor);
+    }
+    /* Row 2: links row takes the full bar width, baseline-aligns with smaller
+       gaps so all four items fit across 375px. */
+    .links {
+      width: 100%;
+      gap: var(--space-md);
+    }
+    .links a {
+      font-size: var(--text-sm);
+    }
+    main {
+      /* Taller offset: two-line header is ~3rem taller at mobile. */
+      padding-top: 6.5rem;
+    }
+  }
 </style>


### PR DESCRIPTION
Part of #589.

Closes #595.

## Problem

At 375 px the single-row nav bar overflowed to ~462 px (scrollWidth), pushing **Tags** and the project badge off-screen with no scroll affordance.

## Fix

`@media (max-width: 480px)` block added to `+layout.svelte`'s scoped `<style>`:

- `.bar { flex-wrap: wrap }` — wraps to two rows
- **Row 1:** wordmark (`.brand` at `--text-display-floor` so Doto stays legible) + project badge (`.project` inherits `margin-left: auto`, stays right-aligned)
- **Row 2:** `.links { width: 100% }` — all four nav destinations (Search / Findings / Documents / Tags) span the full bar, reduced gap/font for the narrower width
- `main { padding-top: 6.5rem }` — compensates for the taller two-line header

No JS, no hamburger — pure CSS flex-wrap. Markup left clean for R3 (#592) Pixelarticons addition.

## Approach: wrap (not menu, not scroll)

Wrapping to two rows was chosen over a hamburger menu (adds JS + state) or horizontal scroll (no scroll affordance, unreachable items) because it keeps all four destinations persistently visible, requires zero JS, and is stylistically consistent with the "dark console" aesthetic.

## Playwright verification

| Metric | Before | After |
|---|---|---|
| `nav.scrollWidth` at 375 px | 462 px | **375 px** |
| `flexWrap` at 375 px | `nowrap` | **`wrap`** |
| Desktop 1280 px `flexWrap` | `nowrap` | `nowrap` (unchanged) |

## Coordination note

Rules added in a clearly-labelled section below the existing nav rules. Did **not** touch R1's `:root` tokens or the two-grounds rules. No new global class names — all selectors are `.bar`, `.brand`, `.links`, `.project`, `main` (already-existing scoped names).

## Screenshots

**Before (375 px) — Tags and project badge clipped:**

The nav overflows: only Search/Findings/Documents visible, Tags cut off.

**After (375 px) — all four links reachable:**

Row 1: `Bartleby` wordmark + `demo` badge. Row 2: `Search · Findings · Documents · Tags`.