### PR TITLE
B6 · Collapse identical date ranges

### DIFF
--- a/bartleby/web/src/lib/format.js
+++ b/bartleby/web/src/lib/format.js
@@ -31,6 +31,17 @@ export function clampSnippet(text, maxLen = 280) {
   return trimmed + '…';
 }
 
+// Render a date range as "YYYY-MM-DD – YYYY-MM-DD", collapsing to a single
+// date when start == end (e.g. a one-day corpus or a single-day session span).
+// Accepts either two separate strings or a single object with `.min`/`.max`.
+// Returns null when `a` is falsy so callers can use {#if formatDateRange(...)}.
+export function formatDateRange(a, b) {
+  const lo = typeof a === 'object' && a !== null ? a.min : a;
+  const hi = typeof a === 'object' && a !== null ? a.max : b;
+  if (!lo) return null;
+  return lo === hi ? lo : `${lo} – ${hi}`;
+}
+
 // Strip a trailing extension (e.g. .pdf) so a file name reads as a title when
 // no summary-derived title exists. Returns falsy input unchanged so callers can
 // chain a further `?? fallback`. Shared by the list, detail, and search views.

--- a/bartleby/web/src/routes/+page.svelte
+++ b/bartleby/web/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pluralize, stripExt } from "$lib/format.js";
+  import { formatDateRange, pluralize, stripExt } from "$lib/format.js";
   import StatusBanner from "$lib/components/StatusBanner.svelte";
   export let data;
 
@@ -84,8 +84,8 @@
         </div>
         <div class="stat">
           <span class="stat-value stat-value--text">
-            {#if corpus.authored_date.min}
-              {corpus.authored_date.min} – {corpus.authored_date.max}
+            {#if formatDateRange(corpus.authored_date)}
+              {formatDateRange(corpus.authored_date)}
             {:else}
               no dated documents
             {/if}

--- a/bartleby/web/src/routes/findings/+page.svelte
+++ b/bartleby/web/src/routes/findings/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pluralize } from "$lib/format.js";
+  import { formatDateRange, pluralize } from "$lib/format.js";
 
   export let data;
 
@@ -37,7 +37,7 @@
       // All findings in one session share its run, so the model is the first
       // item's — the axis the multi-model comparison cares about (#547).
       const model = modelLabel(items[0]);
-      return { name, items, total, model, span: lo === hi ? hi : `${lo} – ${hi}` };
+      return { name, items, total, model, span: formatDateRange(lo, hi) };
     });
   })();
 


### PR DESCRIPTION
Part of #589.

## What

When a date range's start == end (e.g. a single-day corpus or a one-day session span), show a single date instead of `2024-03-12 – 2024-03-12`.

## How

Added `formatDateRange(a, b)` to `bartleby/web/src/lib/format.js` (alongside `clampSnippet` from B4). The helper:
- Accepts either two separate strings (`lo, hi`) or a single object with `.min`/`.max` (the corpus stat shape)
- Returns the single date when `lo === hi`, the `lo – hi` range otherwise, and `null` when there's no date (so callers can use `{#if formatDateRange(...)}`)

Applied at both render sites:
- **Home page** (`+page.svelte`): R2's green LED dot-matrix readout — was `{corpus.authored_date.min} – {corpus.authored_date.max}`, now `{formatDateRange(corpus.authored_date)}`
- **Findings grouped-by-session** (`findings/+page.svelte`): replaced the pre-existing inline ternary `lo === hi ? hi : \`${lo} – ${hi}\`` with the shared helper

## Verification

Playwright against the sandbox (port 5192):
- Home page stat shows `2024-03-12` (single date) — demo corpus has only 2024 docs, all same date ✓
- Findings grouped view shows `2026-06-15` (single date) for the demo session ✓
- No console errors introduced ✓

Tests skipped (web-only change, `--skip-tests` per ship config).