### PR TITLE
B3 · Highlight matched terms in search/scan results

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -896,6 +896,34 @@ input[type="number"] {
 }
 
 /* =========================================================================
+   B3 · Highlight matched terms in search/scan result snippets (#597).
+
+   <mark> inside .snippet wraps the exact token(s) the query matched, rendered
+   client-side by ResultCard as a {#each} over {text, highlight} segments — no
+   raw-HTML injection, no XSS surface. Markdown snippets are left untouched
+   (they go through `marked`; injecting <mark> mid-parse would corrupt the AST).
+
+   Snippets render on PAPER cards (.surface, light ground), so the highlight
+   color must read on a light background. We use --color-token (pale amber fill)
+   with --color-token-dark as the underline accent — consistent with the tag
+   chips and the amber design language throughout.
+   ========================================================================= */
+
+/* Reset browser's default <mark> yellow and use the design-system amber wash. */
+.snippet mark {
+  background: var(--color-token);        /* pale amber fill, legible on paper */
+  color: inherit;                        /* keep the serif text color */
+  border-radius: 0;                      /* square corners, per the R1 radius reset */
+  padding: 0 0.1em;
+  /* A hairline amber underline gives the highlight a second visual anchor
+     beyond fill alone — visible even in printed / high-contrast contexts. */
+  text-decoration: underline;
+  text-decoration-color: var(--color-token-dark);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+/* =========================================================================
    B2 · Use the width — card grids for "cardable" list pages.
 
    .card-grid    Responsive CSS grid for documents and tags. `auto-fill` with

--- a/bartleby/web/src/lib/components/ResultCard.svelte
+++ b/bartleby/web/src/lib/components/ResultCard.svelte
@@ -1,6 +1,6 @@
 <script>
   import { marked } from "marked";
-  import { pluralize, stripExt, isMarkdownChunk } from "$lib/format.js";
+  import { pluralize, stripExt, isMarkdownChunk, highlightTerms } from "$lib/format.js";
   import { CHUNK_ICON as chunkIcon } from "$lib/icons.js";
 
   // One card for both search hits and scan matches — they share ~90% of their
@@ -11,8 +11,11 @@
   // description, file_name, href (document detail page at the cited page, or
   // finding page), page_number, section_heading, content_type, chunk_id, text.
   // Search adds normalized_score + source_kind + source_id; scan adds text_length.
+  // `query` (the raw query string) is passed through so matched terms can be
+  // wrapped in <mark> on the client — no raw HTML injection, just Svelte {#each}.
   export let item;
   export let variant = "search"; // "search" | "scan"
+  export let query = "";
 
   $: title = item.title ?? stripExt(item.file_name) ?? item.source_name;
   $: scorePct = Math.round((item.normalized_score ?? 0) * 100);
@@ -31,6 +34,12 @@
   // marked.parse is sanitized globally (the +layout.svelte marked.use hook wires
   // DOMPurify), so {@html} here is safe.
   $: isMarkdown = isMarkdownChunk(item);
+
+  // B3: split the plain-text snippet into {text, highlight} segments so the
+  // template can wrap matched terms in <mark> without any raw-HTML injection.
+  // Markdown snippets go through `marked` and keep their own emphasis; we leave
+  // them unmarked (injecting <mark> mid-parse would corrupt the AST).
+  $: snippetSegments = isMarkdown ? null : highlightTerms(item.text, query);
 </script>
 
 <li class="result surface surface--interactive">
@@ -75,7 +84,11 @@
   {#if isMarkdown}
     <div class="snippet markdown-body markdown-body--compact">{@html marked.parse(item.text)}</div>
   {:else}
-    <p class="snippet">{item.text}</p>
+    <p class="snippet">
+      {#each snippetSegments as seg}
+        {#if seg.highlight}<mark>{seg.text}</mark>{:else}{seg.text}{/if}
+      {/each}
+    </p>
   {/if}
 </li>
 

--- a/bartleby/web/src/lib/format.js
+++ b/bartleby/web/src/lib/format.js
@@ -46,6 +46,46 @@ export function pluralize(count, singular, plural = `${singular}s`) {
   return `${shown} ${count === 1 ? singular : plural}`;
 }
 
+// Split a plain-text snippet into segments for client-side term highlighting.
+// Returns an array of {text: string, highlight: boolean} objects whose `text`
+// values, concatenated, equal the original snippet. Matched spans are flagged
+// so the caller can wrap them in <mark> without any raw-HTML injection.
+//
+// Matching is case-insensitive; each whitespace-separated token in `query` is
+// treated as an independent term (same tokenisation as the FTS search leg).
+// Only used on PLAIN-TEXT snippets — markdown snippets go through `marked` and
+// keep their own emphasis, so we leave them unmarked rather than injecting
+// <mark> mid-parse.
+//
+// Returns [{text, highlight: false}] when query is absent/empty so callers
+// can always iterate the return value without a guard.
+export function highlightTerms(text, query) {
+  if (!text) return [];
+  if (!query || !query.trim()) return [{ text, highlight: false }];
+
+  // Build one regex that matches any token in the query (word-boundary anchored,
+  // case-insensitive). Escape special regex chars in each token so a query like
+  // "C++ pointer" doesn't blow up.
+  const tokens = query.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [{ text, highlight: false }];
+  const escaped = tokens.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const re = new RegExp(`(${escaped.join('|')})`, 'gi');
+
+  const segments = [];
+  let last = 0;
+  for (const match of text.matchAll(re)) {
+    if (match.index > last) {
+      segments.push({ text: text.slice(last, match.index), highlight: false });
+    }
+    segments.push({ text: match[0], highlight: true });
+    last = match.index + match[0].length;
+  }
+  if (last < text.length) {
+    segments.push({ text: text.slice(last), highlight: false });
+  }
+  return segments.length > 0 ? segments : [{ text, highlight: false }];
+}
+
 // Whether a chunk's text is reliably markdown-authored — so it should render
 // through `marked` — versus extracted/plain text that must stay literal (running
 // it through marked would mangle stray *, _, # chars). Agent/model output

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -58,7 +58,7 @@
       />
       <ul class="list">
         {#each result.matches as m (m.chunk_id)}
-          <ResultCard item={m} variant="scan" />
+          <ResultCard item={m} variant="scan" query={result.query} />
         {/each}
       </ul>
       <Pagination
@@ -79,7 +79,7 @@
       </p>
       <ul class="list">
         {#each result.results as h (h.chunk_id)}
-          <ResultCard item={h} variant="search" />
+          <ResultCard item={h} variant="search" query={result.query} />
         {/each}
       </ul>
     {/if}


### PR DESCRIPTION
Part of #589.

## What

Wraps matched query terms in `<mark>` inside result-card snippets so the
user sees immediately WHY a result matched.

## How

**Client-side, no XSS surface.** A new `highlightTerms(text, query)`
helper in `bartleby/web/src/lib/format.js` splits the clean plain-text
snippet (already clamped by B4's `clampSnippet`) into
`{text, highlight}` segments using one case-insensitive regex over the
query's whitespace-delimited tokens. `ResultCard.svelte` renders the
segments with a Svelte `{#each}` — matched spans become `<mark>` DOM
elements, unmatched text stays as text nodes. No `{@html}` of user input,
no concatenated HTML strings.

Markdown snippets (`isMarkdownChunk`) are left untouched and continue
through `marked` — injecting `<mark>` mid-parse would corrupt the AST.

The query string (`result.query`) is passed from `+page.svelte` to
`ResultCard` as a new `query=""` prop for both scan and search variants.

**CSS (B3 section, end of `app.css`).** `.snippet mark` resets the
browser's default yellow and applies:
- Background: `--color-token` (pale amber wash, readable on paper cards)
- Color: inherit (keeps the Source Serif prose color)
- Underline: `--color-token-dark` 1px (second visual anchor, survives
  print / high-contrast)
- Radius: 0 (square corners, per the R1 radius-reset convention)

## Verification

Playwright against the demo sandbox on port 5191. Searched `particulate`
(scan) and `particulate matter` (search/FTS); the accessibility snapshot
confirms `mark` elements wrapping each matched token in every result card.
Screenshot saved as `scan-highlight-after.png` and `search-highlight-after.png`.

Tests: skipped (web-only ship, no Python tests touched).