### PR TITLE
R3 · Pixelarticons 1-bit icon set

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -951,3 +951,52 @@ input[type="number"] {
 .card-grid .desc {
   margin: var(--space-2xs) 0 0;
 }
+
+/* =========================================================================
+   R3 · Pixelarticons 1-bit icon set (#592)
+   Adopts Pixelarticons (https://pixelarticons.com, MIT) — 1-bit pixel-art
+   glyphs — for nav links, card eyebrows, the chunk "open in context" link, and
+   the citation daggers. Glyphs are inline <svg> strings in lib/icons.js
+   (tree-shaken; no runtime icon dependency), emitted via {@html} so they pick
+   up `currentColor` at each site — nav shell-text, card ink, citation amber.
+
+   This block owns ONLY icon presentation (sizing + the pixelated render hint
+   + the citation-dagger glyph). It adds nothing to :root and touches none of
+   R1's tokens or the two-grounds rules.
+   ========================================================================= */
+
+/* Shared glyph rule. Every Pixelarticon carries `.pixel`; the inline width/
+   height set its box, but when a glyph is scaled up `image-rendering: pixelated`
+   keeps the 1-bit squares crisp instead of blurring them. `fill: currentColor`
+   is also on the element, so the glyph inherits its site's text color. */
+.pixel {
+  display: inline-block;
+  image-rendering: pixelated;
+  /* Don't let the glyph stretch the line-box it rides in. */
+  vertical-align: middle;
+  flex: none;
+}
+
+/* --- Citation daggers (R4 #593) get a Pixelarticons bookmark mark ---
+   R4's render emits `<sup class="cite-ref …">†N</sup>` inline and a
+   `.margin-note__dagger` in the gutter, with the †/ordinal as the tie-back. We
+   DON'T touch that markup: a ::before pseudo on the gutter dagger paints a small
+   pixel bookmark via CSS mask, so it inherits the head color (amber for source,
+   danger for gone) and the †N tie-back text stays exactly as R4 wrote it. */
+.margin-note__dagger::before {
+  content: "";
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  margin-right: 0.25em;
+  vertical-align: -1px;
+  background-color: currentColor;
+  image-rendering: pixelated;
+  -webkit-mask: var(--pixel-bookmark) center / contain no-repeat;
+  mask: var(--pixel-bookmark) center / contain no-repeat;
+}
+:root {
+  /* Pixelarticons "bookmark" (MIT), inlined as a mask data-URI. Mask uses alpha
+     only, so the fill is irrelevant — the dagger's currentColor shows through. */
+  --pixel-bookmark: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M6%202h12v2H6zM4%204h2v18H4zm14%200h2v18h-2zm-2%2016h2v2h-2zm-2-2h2v2h-2zm-8%202h2v2H6zm2-2h2v2H8zm2-2h4v2h-4z%22%2F%3E%3C%2Fsvg%3E");
+}

--- a/bartleby/web/src/lib/components/ResultCard.svelte
+++ b/bartleby/web/src/lib/components/ResultCard.svelte
@@ -1,7 +1,11 @@
 <script>
   import { marked } from "marked";
   import { pluralize, stripExt, isMarkdownChunk, highlightTerms } from "$lib/format.js";
-  import { CHUNK_ICON as chunkIcon } from "$lib/icons.js";
+  import {
+    CHUNK_ICON as chunkIcon,
+    FINDINGS_ICON,
+    DOCUMENTS_ICON,
+  } from "$lib/icons.js";
 
   // One card for both search hits and scan matches — they share ~90% of their
   // shape. `variant` picks the two differences: a search hit shows a normalized
@@ -40,6 +44,11 @@
   // Markdown snippets go through `marked` and keep their own emphasis; we leave
   // them unmarked (injecting <mark> mid-parse would corrupt the AST).
   $: snippetSegments = isMarkdown ? null : highlightTerms(item.text, query);
+
+  // Source-kind eyebrow glyph (search variant): a sparkle for agent findings,
+  // a file-text for everything document-derived — the same mint/paper signal the
+  // home cards teach.
+  $: kindIcon = item.source_kind === "finding" ? FINDINGS_ICON : DOCUMENTS_ICON;
 </script>
 
 <li class="result surface surface--interactive">
@@ -66,7 +75,7 @@
 
   <p class="meta">
     {#if variant === "search"}
-      <span class="kind">{item.source_kind}</span>
+      <span class="kind"><span class="kind-icon">{@html kindIcon}</span>{item.source_kind}</span>
       {#if item.section_heading} · {item.section_heading}{/if}
       {#if item.content_type} · {item.content_type}{/if}
       · chunk {item.chunk_id}{@html chunkLink}
@@ -145,6 +154,17 @@
     letter-spacing: 0.04em;
     font-weight: 600;
   }
+  /* R3 (#592): a Pixelarticon eyebrow before the source-kind label, inheriting
+     the meta-line ink. Small inline glyph riding the baseline. */
+  .kind-icon {
+    display: inline-flex;
+    vertical-align: -2px;
+    margin-right: var(--space-3xs);
+  }
+  .kind-icon :global(.pixel) {
+    width: 12px;
+    height: 12px;
+  }
   /* Tiny "open chunk" affordance riding the meta line, right after the chunk id.
      Sits on the baseline of the surrounding text; brightens to the link color on
      hover so it's discoverable without shouting. */
@@ -159,7 +179,7 @@
   }
   /* The glyph is injected via {@html}, so it sits outside Svelte's scoping —
      reach it with :global (the .chunk-link ancestor is still scoped). */
-  .chunk-link :global(.icon) {
+  .chunk-link :global(.pixel) {
     position: relative;
     top: 1px;
   }

--- a/bartleby/web/src/lib/icons.js
+++ b/bartleby/web/src/lib/icons.js
@@ -1,12 +1,47 @@
-// Inline SVG markup, shared so the same glyph reads identically wherever a chunk
-// is linked. Emitted as a raw string: ResultCard drops it via {@html}, and the
-// finding viewer splices it into the citation-chip HTML it builds by hand. Uses
-// currentColor so it inherits the link/text color at each site.
+// Pixelarticons (https://pixelarticons.com, MIT) — a 1-bit pixel-art glyph set.
+// We DON'T pull in the npm package or an icon framework: each glyph here is the
+// raw <svg> copied verbatim from the Pixelarticons source and inlined as a
+// string, so the bundle carries only the handful of icons we actually use (no
+// runtime icon dependency). This matches the existing pattern: ResultCard drops
+// the markup via {@html}, and the finding viewer splices it into citation HTML
+// it builds by hand.
+//
+// Every glyph is a 24×24, fill="currentColor" path, so it inherits the
+// link/text color at each site (nav shell-text, citation amber, card ink). The
+// shared `pixel` class carries the sizing + `image-rendering: pixelated` (so
+// scaled glyphs stay crisp 1-bit squares) — see the R3 block in app.css.
+//
+// Helper: stamp the shared class + a11y attrs onto a raw Pixelarticons body so
+// every export reads identically.
+const icon = (paths, { size = 16 } = {}) =>
+  `<svg class="pixel" viewBox="0 0 24 24" width="${size}" height="${size}"` +
+  ` fill="currentColor" aria-hidden="true" focusable="false">${paths}</svg>`;
 
-// "Open in context" — a small arrow leaving a box. Next to every chunk
-// reference (search/scan cards, finding citation chips) it links to /chunks/<id>.
-export const CHUNK_ICON =
-  '<svg class="icon" viewBox="0 0 16 16" width="11" height="11" aria-hidden="true" focusable="false">' +
-  '<path d="M9 3h4v4M13 3 8 8M11 9.5V12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h2.5" ' +
-  'fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>' +
-  '</svg>';
+// Nav: Search (magnifying glass).
+export const SEARCH_ICON = icon(
+  '<path d="M22 22h-2v-2h2v2Zm-2-2h-2v-2h2v2Zm-6-2H6v-2h8v2Zm4 0h-2v-2h2v2ZM6 16H4v-2h2v2Zm10 0h-2v-2h2v2ZM4 14H2V6h2v8Zm14 0h-2V6h2v8ZM6 6H4V4h2v2Zm10 0h-2V4h2v2Zm-2-2H6V2h8v2Z"/>',
+);
+
+// Findings (sparkle) — agent output, the same signal the mint cards carry.
+export const FINDINGS_ICON = icon(
+  '<path d="M11 1h2v4h-2zm0 22h2v-4h-2zM9 5h2v4H9zm0 14h2v-4H9zm4-14h2v4h-2zm0 14h2v-4h-2zM5 9h4v2H5zm14 0h-4v2h4zM1 11h4v2H1zm22 0h-4v2h4zM5 13h4v2H5zm14 0h-4v2h4z"/>',
+);
+
+// Documents (file with text lines) — source material with summaries.
+export const DOCUMENTS_ICON = icon(
+  '<path d="M6 4H4v16h2zm10-2H6v2h10zm4 4h-2v14h2zm-2 14H6v2h12zM16 4h2v2h-2zm-4 0h2v6h-2z"/><path d="M12 8h6v2h-6zm-4 8h8v2H8zm0-4h8v2H8zm0-4h2v2H8z"/>',
+);
+
+// Tags (hash) — Pixelarticons has no tag glyph; tags read as #docket / #filer,
+// so the hash is the right semantic stand-in.
+export const TAGS_ICON = icon(
+  '<path d="M9 3h2v5H9zm6 0h2v5h-2zm-7 7h2v4H8zm6 0h2v4h-2zm-7 6h2v5H7zm6 0h2v5h-2zM3 8h18v2H3zm0 6h18v2H3z"/>',
+);
+
+// "Open in context" — an arrow leaving a box. Next to every chunk reference
+// (search/scan cards, finding citation chips) it links to /chunks/<id>.
+// Replaces the lone hand-rolled ↗ glyph; the link still opens in a new tab.
+export const CHUNK_ICON = icon(
+  '<path d="M11 5H5v2h6V5ZM5 7H3v12h2V7Zm12 12H5v2h12v-2Zm2-6h-2v6h2v-6Zm-8 0H9v2h2v-2Zm2-2h-2v2h2v-2Zm2-2h-2v2h2V9Zm2-2h-2v2h2V7Zm2-2h-2v2h2V5Zm2-2h-2v8h2V3Z"/><path d="M21 3h-8v2h8V3Z"/>',
+  { size: 11 },
+);

--- a/bartleby/web/src/routes/+layout.svelte
+++ b/bartleby/web/src/routes/+layout.svelte
@@ -27,6 +27,12 @@
 <script>
   import "../app.css";
   import { page } from "$app/stores";
+  import {
+    SEARCH_ICON,
+    FINDINGS_ICON,
+    DOCUMENTS_ICON,
+    TAGS_ICON,
+  } from "$lib/icons.js";
   export let data;
 
   // A nav link is "active" if the current path matches exactly OR is a child
@@ -47,10 +53,10 @@
   <nav class="bar">
     <a class="brand display" href="/" class:active={isActive("/")}>Bartleby</a>
     <div class="links">
-      <a href="/search" class:active={isActive("/search")}>Search</a>
-      <a href="/findings" class:active={isActive("/findings")}>Findings</a>
-      <a href="/documents" class:active={isActive("/documents")}>Documents</a>
-      <a href="/tags" class:active={isActive("/tags")}>Tags</a>
+      <a href="/search" class:active={isActive("/search")}><span class="nav-icon">{@html SEARCH_ICON}</span>Search</a>
+      <a href="/findings" class:active={isActive("/findings")}><span class="nav-icon">{@html FINDINGS_ICON}</span>Findings</a>
+      <a href="/documents" class:active={isActive("/documents")}><span class="nav-icon">{@html DOCUMENTS_ICON}</span>Documents</a>
+      <a href="/tags" class:active={isActive("/tags")}><span class="nav-icon">{@html TAGS_ICON}</span>Tags</a>
     </div>
     <span class="project display">{data.project}</span>
   </nav>
@@ -106,6 +112,22 @@
     font-size: var(--text-base);
     padding-bottom: 2px;
     border-bottom: 2px solid transparent;
+    /* Icon + label ride together on the chrome line. The link's own baseline
+       still aligns with the wordmark/project (.bar is baseline-aligned). */
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2xs);
+  }
+  /* R3 (#592): the Pixelarticon sits just before each nav label, inheriting the
+     shell-text color (it goes mint on hover/active with the label). The icon is
+     a fixed square so it never reflows the wrap math B1 (#595) depends on. */
+  .nav-icon {
+    display: inline-flex;
+    color: var(--color-shell-text-soft);
+  }
+  .links a:hover .nav-icon,
+  .links a.active .nav-icon {
+    color: var(--color-token-dark);
   }
   .links a:hover {
     color: var(--color-off-light);
@@ -157,6 +179,14 @@
     }
     .links a {
       font-size: var(--text-sm);
+      /* Tighter icon↔label gap so four icon+label pairs still fit the 375px
+         row without forcing a third line (B1 #595 wrap math). */
+      gap: var(--space-3xs);
+    }
+    /* Shrink the glyph a hair on the narrow row to keep the links compact. */
+    .nav-icon :global(.pixel) {
+      width: 13px;
+      height: 13px;
     }
     main {
       /* Taller offset: two-line header is ~3rem taller at mobile. */

--- a/bartleby/web/src/routes/+page.svelte
+++ b/bartleby/web/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { formatDateRange, pluralize, stripExt } from "$lib/format.js";
   import StatusBanner from "$lib/components/StatusBanner.svelte";
+  import { FINDINGS_ICON, DOCUMENTS_ICON } from "$lib/icons.js";
   export let data;
 
   $: ({ project, counts, corpus, error } = data);
@@ -52,14 +53,14 @@
   <ul class="cards">
     <li>
       <a class="surface surface--finding surface--interactive" href="/findings">
-        <h2>Findings</h2>
+        <h2><span class="card-eyebrow-icon">{@html FINDINGS_ICON}</span>Findings</h2>
         <p class="count">{fmt(counts.findings)}</p>
         <p class="hint">Saved research notes with inline citations.</p>
       </a>
     </li>
     <li>
       <a class="surface surface--interactive" href="/documents">
-        <h2>Documents</h2>
+        <h2><span class="card-eyebrow-icon">{@html DOCUMENTS_ICON}</span>Documents</h2>
         <p class="count">{fmt(counts.documents)}</p>
         <p class="hint">Ingested source material with summaries.</p>
       </a>
@@ -211,6 +212,14 @@
     text-transform: uppercase;
     letter-spacing: var(--tracking-wide);
     margin-bottom: var(--space-sm);
+    /* R3 (#592): a Pixelarticon eyebrow rides before the card label, inheriting
+       the sage --color-off the heading already carries. */
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+  }
+  .card-eyebrow-icon {
+    display: inline-flex;
   }
   .count {
     font-family: var(--font-display);

--- a/docs/decisions/GH-0592-r3-pixelarticons-0001.md
+++ b/docs/decisions/GH-0592-r3-pixelarticons-0001.md
@@ -1,0 +1,50 @@
+# Pixelarticons via inlined SVG strings, not a runtime icon framework (issue #592)
+
+> Source: [#592](https://github.com/jswest/bartleby/issues/592)
+
+R3 adopts **[Pixelarticons](https://pixelarticons.com)** — a 1-bit pixel-art
+glyph set, **MIT-licensed** — as the redesign's icon vocabulary, replacing the
+lone hand-rolled chunk-↗ SVG and adding consistent glyphs to nav links, card
+eyebrows, and the finding-detail citation daggers. The hand-rolled pixels read
+as "adorable but a little messy"; an extant set that plays nice with the
+Iosevka/Doto chrome was wanted, and Pixelarticons' square 1-bit glyphs are that.
+
+**The set is inlined as raw `<svg>` strings in `lib/icons.js`, NOT pulled in as
+an npm package or icon framework.** Neither `pixelarticons` nor
+`@iconify-json/pixelarticons` is a dependency. We copy the handful of glyphs we
+actually use (`search`, `sparkle`, `file-text`, `hash`, `external-link`,
+`bookmark`) verbatim from the Pixelarticons source and stamp them with a shared
+`icon()` helper. Rationale: this extends the pattern that already existed
+(`CHUNK_ICON` was a `{@html}`'d SVG string), keeps the bundle to only the icons
+in use with zero tree-shaking ceremony and no runtime icon component, and avoids
+an Iconify build-plugin or a `<Icon>` component for what is six static glyphs.
+Each glyph is `fill="currentColor"` so it inherits its site's text color — nav
+shell-text, card ink, citation amber — exactly like the prior pattern. The
+shared `.pixel` class (in the new `R3` block at the end of `app.css`) carries
+`image-rendering: pixelated` so any scaled glyph stays crisp 1-bit squares.
+
+**Glyph mapping.** Nav: `search` → Search, `sparkle` → Findings (the agent-output
+signal the mint cards carry), `file-text` → Documents (source-with-summaries),
+`hash` → Tags (Pixelarticons ships no tag glyph; tags read as `#docket`/`#filer`,
+so the hash is the right semantic stand-in). Card eyebrows reuse
+`sparkle`/`file-text` for the home Findings/Documents tiles and the
+`ResultCard` source-kind eyebrow (finding → sparkle, else file-text).
+`external-link` replaces the hand-rolled chunk-↗; the chunk link's
+href/title/aria/same-tab behavior is untouched (R4's markdown citation path,
+which opens in a new tab via the `marked` hook, no longer splices `CHUNK_ICON`).
+
+**Citations: a CSS mask, no R4 render change.** R4 (#593) left
+`margin-note__dagger` and `cite-ref` as a stable contract. Rather than edit
+R4's render logic (which would risk the †/ordinal tie-back), the dagger gets a
+small Pixelarticons `bookmark` painted by a `::before` pseudo via CSS `mask`
+(the glyph is a `--pixel-bookmark` data-URI; mask uses alpha, so the dagger's
+`currentColor` — amber for source, danger for gone — shows through). The `†N`/
+`‡N` text the tie-back depends on is unchanged.
+
+**Scope discipline.** All icon CSS lives in a self-contained
+`R3 · Pixelarticons 1-bit icon set` block at the end of `app.css`; it adds
+nothing to R1's `:root` tokens (only a `--pixel-bookmark` mask URL) and touches
+none of the two-grounds rules. The nav-icon sizing respects B1's (#595) wrap
+math — glyphs are fixed squares and shrink to 13px on the ≤480px row, so all
+four icon+label links still fit 375px with no horizontal scroll. No schema
+change; web-only.


### PR DESCRIPTION
Part of #589.

Adopts **Pixelarticons** (MIT, 1-bit pixel-art glyphs) as the redesign's icon vocabulary and wires icons into the nav, cards, and finding-detail citations.

## Approach: inline SVG strings, no dependency
Glyphs are copied verbatim from the Pixelarticons source and inlined as `{@html}`'d `<svg>` strings in `lib/icons.js` (a shared `icon()` helper stamps the `.pixel` class + a11y attrs). **No `pixelarticons` / `@iconify-json` dependency, no icon component** — this extends the pre-existing pattern (`CHUNK_ICON` was already a `{@html}`'d SVG string), keeps the bundle to only the six glyphs used, and needs no Iconify build plugin. Each glyph is `fill="currentColor"` so it inherits its site's color; `.pixel` carries `image-rendering: pixelated` so scaled glyphs stay crisp.

## Where the icons went
- **Nav** (`+layout.svelte`): `search` / `sparkle` / `file-text` / `hash`. Pixelarticons ships no tag glyph; tags read as `#docket`/`#filer`, so `hash` is the semantic stand-in. Icons shrink to 13px on the ≤480px row so **B1's (#595) wrap math is preserved** — all four icon+label links still fit 375px with no horizontal scroll.
- **Card eyebrows**: home Findings/Documents tiles (`+page.svelte`) + the `ResultCard` source-kind eyebrow (finding → sparkle, else file-text). B3 `<mark>` highlights and B4 clamped snippets untouched.
- **Chunk "open in context"**: `external-link` replaces the hand-rolled ↗ glyph. The link's href/title/aria and **same-tab behavior are unchanged** (the original ResultCard chunk-link had no `target="_blank"`; that's preserved verbatim).
- **Citation daggers** (R4 #593): a `::before` CSS mask paints a pixel `bookmark` on `.margin-note__dagger`, inheriting source-amber / gone-danger. **R4's render logic and the †N/‡N tie-back text are untouched** — the icon is pure CSS over the stable markup contract R4 left.

## Scope discipline
All icon CSS lives in a new self-contained `R3 · Pixelarticons` block at the end of `app.css`; nothing added to R1's `:root` tokens (only a `--pixel-bookmark` mask URL), two-grounds rules untouched.

## Verification (Playwright, throwaway sandbox)
Drove the dev server against the `issue-589-sandbox` demo corpus on a distinct port (5193) — never a live corpus / Ollama.
- **Desktop 1280**: nav icons crisp & sage; active link icon goes amber; card eyebrows render; finding ledger daggers show the pixel bookmark in amber (source) / red (gone) with †1/‡2 intact.
- **Search `/search`**: source-kind eyebrow + chunk-link arrow render; B3/B4 intact.
- **Mobile 375**: nav wraps cleanly to two lines, all four links on one row, rightmost edge 302px < 375px, **no horizontal overflow**.

## Notes
- Tests skipped this ship (`--skip-tests`; web-only — no Python touched).
- Decision file: `docs/decisions/GH-0592-r3-pixelarticons-0001.md` (icon-set choice, MIT license, inline-vs-dependency rationale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)