### PR TITLE
feat(web): default findings view to grouped-by-session

### DIFF
--- a/bartleby/web/src/routes/findings/+page.svelte
+++ b/bartleby/web/src/routes/findings/+page.svelte
@@ -14,7 +14,7 @@
 
   // Index view: a scannable table by default, or the same findings grouped by
   // the research session that produced them. Client-side only.
-  let mode = "table";
+  let mode = "grouped";
 
   // Group findings by session, preserving first-appearance order. Because
   // `findings` is newest-first, sessions sort newest-first too, and each


### PR DESCRIPTION
## Summary

- Changes the findings index default mode from `"table"` to `"grouped"` so the Grouped by Session view is shown on first load.
- The Table/Grouped toggle continues to work — users can still switch to Table view.
- One-line change in `bartleby/web/src/routes/findings/+page.svelte`.

Part of #622

## Verification

Code inspection only — this is a one-liner with no risk of regression. Browser verification skipped as not warranted for a string literal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)