### PR TITLE
feat(web): center main content column app-wide

### DIFF
--- a/bartleby/web/src/routes/+page.svelte
+++ b/bartleby/web/src/routes/+page.svelte
@@ -179,6 +179,7 @@
      (--width-content); it's a grid of panels, not a reading column. */
   .home {
     max-width: 52rem;
+    margin-inline: auto;
   }
   h1.display {
     font-family: var(--font-display);

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -21,6 +21,7 @@
   }
 </script>
 
+<div class="search">
 <h1>Search</h1>
 
 <SearchForm {params} availableTags={available.tags} />
@@ -85,10 +86,14 @@
     {/if}
   {/if}
 </div>
+</div>
 
 <style>
-  .results {
+  .search {
     max-width: var(--width-content);
+    margin-inline: auto;
+  }
+  .results {
     transition: opacity 0.15s;
   }
   .results.dim {


### PR DESCRIPTION
## Summary

- Added `margin-inline: auto` to `.home` in `+page.svelte` (52rem cap) so the home dashboard centers at wide viewports
- Wrapped all search page content in a `.search` container with `max-width: var(--width-content)` + `margin-inline: auto`, moving the cap from `.results` up to the wrapper so the `h1`, `SearchForm`, and result list all center together

## Approach

Centering is applied per-page at the containers that already carry a `max-width` cap. This is intentionally NOT done at the `main`/layout level because:
- Findings (`/findings`) intentionally has no max-width — it uses a full-viewport hero grid + index table
- Documents (`/documents`) and Tags (`/tags`) use `.card-grid` which is designed to fill available width (B2 decision)

So only the two pages with explicit column caps needed the change.

## Verified in browser

Ran `vite dev` at 1600px viewport and took screenshots of all four main pages:
- **Home** (`/`): content column (52rem) sits centered with dark shell on both sides ✓
- **Search** (`/search`): "Search" h1, SearchForm, filters, and results all center together at 48rem ✓
- **Findings** (`/findings`): intentionally full-width — hero grid + index table expand to viewport, unchanged ✓
- **Documents** (`/documents`): intentionally full-width card grid, unchanged ✓

Screenshots saved under `.playwright-mcp/` in the main repo.

Part of #622