### PR TITLE
feat(web): replace searching blink with ouroboros waiting indicator

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -847,48 +847,19 @@ input[type="number"] {
 }
 
 /* =========================================================================
-   R5 · Boot/loading flourish (#594) — dot-matrix cursor + terminal empties.
+   R5 · Boot/loading flourish (#594, ouroboros updated #620) — terminal empties.
 
-   A restrained retro affordance for the search route. Two pieces, both loose
-   on the dark shell:
-     - `.cursor`  a blinking Doto block, shown while a search/scan is in flight
-                  (a console "working…" tick). Honours the display floor.
+   A restrained retro affordance for the search route. The blinking `.cursor`
+   from #594 was replaced in #620 by the WaitingIndicator component (a 4-cell
+   Doto ouroboros chase). Only the terminal-empty state class remains here.
      - `.empty--terminal`  a console-prompt empty state ("> no results …").
                   A modifier on the shared `.empty`; the base `.empty` (used by
                   documents/findings/tags/source-viewer) is left untouched so
                   this stays scoped to search and clear of B5 (#599).
    ========================================================================= */
 
-/* The block tick. Doto, so it reads as one lit dot-matrix cell; held at the
-   display floor so the dots never turn to mud. Sits inline at the end of the
-   line it follows (busy banner copy, terminal-empty prompt). */
-@keyframes r5-blink {
-  0%,
-  49% {
-    opacity: 1;
-  }
-  50%,
-  100% {
-    opacity: 0;
-  }
-}
-.cursor {
-  font-family: var(--font-display);
-  font-size: max(var(--text-display-floor), 1em);
-  /* The lit cell. A filled block glyph reads as a terminal cursor at any size. */
-  line-height: 0;
-  /* No layout shift: the cell reserves its width and only its opacity animates. */
-  animation: r5-blink 1.06s steps(1, end) infinite;
-}
-/* Respect reduced-motion: hold the cursor lit rather than blinking it. */
-@media (prefers-reduced-motion: reduce) {
-  .cursor {
-    animation: none;
-  }
-}
-
 /* Terminal-prompt empty state. Iosevka (UI chrome, not prose), a lit amber
-   prompt mark, and a trailing blinking cursor — a console waiting for input
+   prompt mark, and a trailing WaitingIndicator — a console waiting for input
    with nothing to show. Overrides the base `.empty` (inherited serif + its
    italic); equal specificity, wins on declaration order (defined after it). */
 .empty--terminal {

--- a/bartleby/web/src/lib/components/WaitingIndicator.svelte
+++ b/bartleby/web/src/lib/components/WaitingIndicator.svelte
@@ -1,0 +1,120 @@
+<script>
+  // WaitingIndicator — a shared ouroboros chase for any waiting / loading state.
+  //
+  // Props:
+  //   label   string   Text shown beside the indicator. E.g. "Searching…",
+  //                    "Loading…", "awaiting query". Caller owns the copy.
+  //   active  boolean  true  → ouroboros animates (system is busy).
+  //                    false → static dim frame (idle / waiting for user input).
+  //
+  // Usage:
+  //   <WaitingIndicator label="Searching…" active={true}  />   ← active search
+  //   <WaitingIndicator label="awaiting query" active={false} /> ← idle empty state
+  //   <WaitingIndicator label="Loading…" active={true}  />   ← #621 navigation
+  //
+  // The 4 Doto block cells are arranged in a clockwise square track:
+  //   [0] top-left  [1] top-right
+  //   [3] bot-left  [2] bot-right
+  // When active, a "lit" highlight sweeps clockwise (0→1→2→3→0…) using
+  // animation-delay offsets. When idle the track dims to shell-text-soft; no
+  // motion. prefers-reduced-motion: holds a static frame regardless of active.
+
+  export let label = "awaiting query";
+  export let active = false;
+</script>
+
+<span
+  class="waiting-indicator"
+  class:active
+  aria-label={label}
+  aria-live={active ? "polite" : undefined}
+  aria-busy={active}
+  role="status"
+>
+  <!--
+    4-cell ouroboros track. Order matches clockwise sweep:
+      cell-0 (top-left) → cell-1 (top-right) → cell-2 (bot-right) → cell-3 (bot-left)
+    CSS animation-delay staggers each cell's brightness peak by one quarter cycle.
+  -->
+  <span class="track" aria-hidden="true">
+    <span class="cell cell-0">█</span><span class="cell cell-1">█</span><!--
+    --><span class="cell cell-3">█</span><span class="cell cell-2">█</span>
+  </span>
+  <span class="label">{label}</span>
+</span>
+
+<style>
+  /* Container: inline-flex so it fits inside StatusBanner copy or a <p>. */
+  .waiting-indicator {
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-sm);
+    /* Anchor font-family and size so the Doto cells share metrics with the label. */
+  }
+
+  /* The 2×2 block track, rendered in Doto dot-matrix. Laid out as a 2-column
+     inline-grid so the four cells form a square regardless of font metrics.
+     Fixed dimensions prevent layout jitter — width is exactly 2 Doto "cells". */
+  .track {
+    font-family: var(--font-display);
+    font-size: max(var(--text-display-floor), 0.9em);
+    line-height: 0.9;
+    display: inline-grid;
+    grid-template-columns: repeat(2, 1ch);
+    grid-template-rows: repeat(2, 0.9em);
+    /* Align baseline of the bottom row with the label baseline. */
+    align-self: baseline;
+  }
+
+  .cell {
+    display: block;
+    /* Idle: dim cells (system is not busy). */
+    opacity: 0.18;
+    transition: opacity 0.1s;
+  }
+
+  /* ── Active / chase animation ──────────────────────────────────────────────
+     Clockwise sweep: cell-0 → cell-1 → cell-2 → cell-3 → repeat.
+     Each cell peaks at opacity 1, decays to ~0.12, over a shared 1.6 s cycle.
+     Stagger = cycle / 4 = 0.4 s per step. No steps(); easing is ease-in-out
+     so the peak is soft — no hard on/off, no strobe.
+  */
+  @keyframes ouroboros-pulse {
+    0%   { opacity: 1;    }
+    20%  { opacity: 0.12; }
+    75%  { opacity: 0.12; }
+    100% { opacity: 1;    }
+  }
+
+  .active .cell {
+    animation: ouroboros-pulse 1.6s ease-in-out infinite;
+  }
+
+  /* Clockwise stagger: cell-0 leads, each subsequent cell is +0.4 s behind. */
+  .active .cell-0 { animation-delay: 0s; }
+  .active .cell-1 { animation-delay: -1.2s; } /* 0.4 s into cycle */
+  .active .cell-2 { animation-delay: -0.8s; } /* 0.8 s into cycle */
+  .active .cell-3 { animation-delay: -0.4s; } /* 1.2 s into cycle */
+
+  /* Label: Iosevka (UI chrome). Inherits parent color (shell-text or banner). */
+  .label {
+    font-family: var(--font-sans);
+    font-size: inherit;
+  }
+
+  /* Reduced-motion: hold a static frame — one cell lit, no animation. */
+  @media (prefers-reduced-motion: reduce) {
+    .active .cell {
+      animation: none;
+    }
+    /* Keep cell-0 lit as the static "active" indicator. */
+    .active .cell-0 {
+      opacity: 1;
+    }
+    .active .cell-1,
+    .active .cell-2,
+    .active .cell-3 {
+      opacity: 0.18;
+    }
+  }
+</style>

--- a/bartleby/web/src/lib/components/WaitingIndicator.svelte
+++ b/bartleby/web/src/lib/components/WaitingIndicator.svelte
@@ -28,7 +28,7 @@
   class:active
   aria-label={label}
   aria-live={active ? "polite" : undefined}
-  aria-busy={active}
+  aria-busy={active || undefined}
   role="status"
 >
   <!--
@@ -40,16 +40,18 @@
     <span class="cell cell-0">█</span><span class="cell cell-1">█</span><!--
     --><span class="cell cell-3">█</span><span class="cell cell-2">█</span>
   </span>
-  <span class="label">{label}</span>
+  {label}
 </span>
 
 <style>
-  /* Container: inline-flex so it fits inside StatusBanner copy or a <p>. */
+  /* Container: inline-flex so it fits inside StatusBanner copy or a <p>.
+     Sets font-sans for the label text node; .track overrides to Doto for the
+     dot-matrix cells. */
   .waiting-indicator {
     display: inline-flex;
     align-items: baseline;
     gap: var(--space-sm);
-    /* Anchor font-family and size so the Doto cells share metrics with the label. */
+    font-family: var(--font-sans);
   }
 
   /* The 2×2 block track, rendered in Doto dot-matrix. Laid out as a 2-column
@@ -95,12 +97,6 @@
   .active .cell-1 { animation-delay: -1.2s; } /* 0.4 s into cycle */
   .active .cell-2 { animation-delay: -0.8s; } /* 0.8 s into cycle */
   .active .cell-3 { animation-delay: -0.4s; } /* 1.2 s into cycle */
-
-  /* Label: Iosevka (UI chrome). Inherits parent color (shell-text or banner). */
-  .label {
-    font-family: var(--font-sans);
-    font-size: inherit;
-  }
 
   /* Reduced-motion: hold a static frame — one cell lit, no animation. */
   @media (prefers-reduced-motion: reduce) {

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -4,6 +4,7 @@
   import ResultCard from "$lib/components/ResultCard.svelte";
   import StatusBanner from "$lib/components/StatusBanner.svelte";
   import Pagination from "$lib/components/Pagination.svelte";
+  import WaitingIndicator from "$lib/components/WaitingIndicator.svelte";
   import { pluralize } from "$lib/format.js";
 
   export let data;
@@ -28,7 +29,7 @@
 
 {#if busy}
   <StatusBanner variant="busy">
-    Searching<span class="cursor" aria-hidden="true">█</span>
+    <WaitingIndicator label="Searching…" active={true} />
     <span class="hint">semantic queries load the embedding model and can take a few seconds.</span>
   </StatusBanner>
 {/if}
@@ -41,7 +42,7 @@
     </StatusBanner>
   {:else if !params.q}
     <p class="empty empty--terminal">
-      awaiting query<span class="cursor" aria-hidden="true">█</span>
+      <WaitingIndicator label="awaiting query" active={false} />
     </p>
   {:else if params.mode === "scan"}
     {#if result.matches.length === 0}


### PR DESCRIPTION
## Summary

- Replaces the hard-strobing `.cursor` / `@keyframes r5-blink` from #594 with a new reusable `WaitingIndicator.svelte` component
- The indicator uses a 4-cell Doto block track (2×2 square) with clockwise-staggered CSS `animation-delay` for a smooth snake-chase effect — no `steps()`, no hard on/off, no strobe, no layout jitter
- Honest state: `active={true}` animates (used in "Searching…" banner); `active={false}` is dim and static (used in "awaiting query" idle state — correctly signals the system is not busy)
- Dead code removed: `@keyframes r5-blink` and `.cursor` class deleted from `app.css`
- `prefers-reduced-motion: reduce` respected — animation suppressed, one cell held lit

## Reuse by #621

`WaitingIndicator` accepts two props:
- `label` (string) — any copy, e.g. `"Loading…"`
- `active` (boolean) — controls animation on/off

#621 can drop in `<WaitingIndicator label="Loading…" active={true} />` with no changes to this component.

## Test plan

- [x] Idle state verified in browser: dim 2×2 block track + "awaiting query", amber `>` prompt, no motion
- [x] Active state verified by DOM injection in browser: animated track in amber StatusBanner with "Searching…" label
- [x] `prefers-reduced-motion` covered by CSS media query in component
- [x] No remaining `.cursor` class or `r5-blink` references in web src
- [ ] pytest skipped (frontend-only, `--skip-tests`)

Part of #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)