### PR TITLE
feat(web): global loading indicator for slow navigation (#621)

### DIFF
--- a/bartleby/web/src/routes/+layout.svelte
+++ b/bartleby/web/src/routes/+layout.svelte
@@ -26,13 +26,15 @@
 
 <script>
   import "../app.css";
-  import { page } from "$app/stores";
+  import { navigating, page } from "$app/stores";
   import {
     SEARCH_ICON,
     FINDINGS_ICON,
     DOCUMENTS_ICON,
     TAGS_ICON,
   } from "$lib/icons.js";
+  import StatusBanner from "$lib/components/StatusBanner.svelte";
+  import WaitingIndicator from "$lib/components/WaitingIndicator.svelte";
   export let data;
 
   // A nav link is "active" if the current path matches exactly OR is a child
@@ -47,6 +49,20 @@
   $: path = $page.url.pathname;
   $: isActive = (href) =>
     href === "/" ? path === "/" : path === href || path.startsWith(href + "/");
+
+  // Show a global "Loading…" indicator for any navigation that is NOT a search
+  // submission. A search submission navigates TO /search with a non-empty ?q=
+  // param — the search page's own "Searching…" banner covers that case with a
+  // richer embedding-model hint. Every other in-flight navigation (clicking a
+  // result, pressing Back, moving to /findings, etc.) gets the global banner.
+  //
+  // We check $navigating.to so the layout never shows "Loading…" during a
+  // search — preventing two simultaneous indicators and wrong copy.
+  $: isSearchNavigation =
+    !!$navigating &&
+    $navigating.to?.url?.pathname?.startsWith("/search") &&
+    !!$navigating.to?.url?.searchParams?.get("q");
+  $: loading = !!$navigating && !isSearchNavigation;
 </script>
 
 <header>
@@ -61,6 +77,14 @@
     <span class="project display">{data.project}</span>
   </nav>
 </header>
+
+{#if loading}
+  <div class="global-loading">
+    <StatusBanner variant="busy">
+      <WaitingIndicator label="Loading…" active={true} />
+    </StatusBanner>
+  </div>
+{/if}
 
 <main>
   <slot />
@@ -140,6 +164,24 @@
     margin-left: auto;
     color: var(--color-shell-text-soft);
     font-size: var(--text-base);
+  }
+  /* Global navigation loading banner: fixed just below the header so it's
+     always visible regardless of scroll position. Dismissed the instant
+     $navigating clears. The banner's own margin-bottom is ignored here since
+     it's taken out of flow; we use padding-top inside .banner instead. */
+  .global-loading {
+    position: fixed;
+    top: 3rem; /* sits just below the fixed header bar */
+    left: 0;
+    right: 0;
+    z-index: 9;
+    padding: var(--space-sm) var(--space-lg) 0;
+  }
+  /* Remove the bottom margin that StatusBanner adds (it's irrelevant when
+     the banner is fixed-positioned above the content). */
+  .global-loading :global(.banner) {
+    margin-bottom: 0;
+    max-width: none;
   }
   main {
     /* Offset the fixed header (a fixed structural height) so content doesn't

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -10,9 +10,16 @@
   export let data;
 
   $: ({ params, available, result, error } = data);
-  // Any in-flight navigation here is a search/scan submit — show progress
-  // while the subprocess (and, for semantic search, the BGE model) runs.
-  $: busy = !!$navigating;
+  // Show "Searching…" only when navigating TO /search with a real query —
+  // i.e. a genuine search/scan submission. Clicking a result or pressing Back
+  // also triggers $navigating while on this page, but those go elsewhere
+  // (chunks, documents, …) and are handled by the global layout indicator.
+  // Narrowing here prevents "Searching…" appearing for non-search navigations
+  // and avoids two simultaneous indicators.
+  $: busy =
+    !!$navigating &&
+    $navigating.to?.url?.pathname?.startsWith("/search") &&
+    !!$navigating.to?.url?.searchParams?.get("q");
 
   // Preserve the current query while only moving the scan offset.
   function scanHref(offset) {


### PR DESCRIPTION
## Summary

- Adds a layout-level "Loading…" indicator (in `+layout.svelte`) that fires for **any navigation that is not a genuine search submission** — covering back/forward button, clicking into a chunk or document, and all other page transitions.
- Narrows the search page's existing "Searching…" banner so it only fires when `$navigating.to` is `/search` with a non-empty `?q=` param (an actual search submission, not a result click or Back press).
- The two conditions are mutually exclusive by construction — **only one indicator can ever be visible at a time**, and the label always reflects the actual state.

## Design decision

The `$navigating.to.url` approach is the cleanest split: `pathname.startsWith('/search') && searchParams.get('q')` is truthy only for a search submission. Everything else — Back, result clicks, nav bar links — has a different destination and gets the layout-level "Loading…". No shared flag, no event bus, no additional state.

The global banner is `position: fixed` just below the fixed header (`top: 3rem; z-index: 9`), spans the full viewport width (overrides StatusBanner's `max-width` and `margin-bottom` via `:global(.banner)`), and disappears the instant `$navigating` clears.

## Test plan

- [ ] `/search` idle: no indicator visible
- [ ] Submit a search query → "Searching…" appears (search page banner), no "Loading…"
- [ ] Click a result (chunk/document link) → "Loading…" appears (layout banner), no "Searching…"
- [ ] Press browser Back from chunk/document → "Loading…" appears, no "Searching…"
- [ ] No two indicators simultaneously in any scenario

Tests skipped (frontend-only, `--skip-tests`).

Part of #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)