### PR TITLE
Front-end polish: centering, grouped findings default, ouroboros loading indicators (#622)

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -262,8 +262,8 @@ proceed.
 6. **Docs sweep** (§Docs sweep) on the omnibus branch.
 7. **Promote:** reconcile the native sub-issue links against the final landed set
    (add any tracked-but-unlinked, remove a stale link), then open the **omnibus →
-   `base_branch`** PR enumerating `Closes #<N>` for the bundle, with a risk-ranked
-   report (§Report). **Stop.** A human merges — that one merge auto-closes every
+   `base_branch`** PR enumerating `Closes #<N>` for the bundle, with an at-a-glance
+   triage report (§Report). **Stop.** A human merges — that one merge auto-closes every
    sub-issue and the omnibus.
 
 ### Live progress
@@ -404,10 +404,27 @@ Sweep edits that stay within the documentation set keep the diff docs-only, so t
 test gate auto-skips (`auto_skip_globs`); a sweep that touches source re-runs it.
 
 ## Report (promotion PR body)
-Risk-ranked and plain-language, for a human skimming at a glance: what landed,
-what **parked** (with the written questions), the critics' surviving findings,
-and **which tier ran** (cheap players, `--strong`, or `--thrifty`) — a reviewer
-should weigh a cheap-tier diff a touch more skeptically.
+The omnibus→`base_branch` PR body opens with an **at-a-glance triage** — a
+red/yellow/green reading that answers a reviewer's only first question, *where do
+my eyes need to go?*, before they read a word. (Leaf issue→target PRs don't get
+this; it's a promotion-only summary over the whole bundle.)
+
+- **🔴 CHECK** — a human should look before merging: parked items (§Triage) with
+  their written questions, critic findings that survived the cap unresolved, any
+  judgment call the director made that warrants a second set of eyes. Keep red
+  rare and meaningful — its value is that it's short.
+- **🟡 FYI** — worth knowing, no action needed: decisions/tradeoffs taken, a
+  manual conflict park later resolved, and **which tier ran** (cheap players,
+  `--strong`, `--thrifty`) — a reviewer weighs a cheap-tier diff a touch more
+  skeptically. Not a dumping ground; if it won't inform a merge call, cut it.
+- **🟢 OK** — one line, not a list: what was verified and held (e.g. `tests green
+  · both critics clean · 4/4 sub-PRs landed clean`). Break out an individual green
+  item only when it's something that plausibly could have failed and didn't (a
+  risky integration seam that held).
+
+Below the triage, the plain-language detail: the `Closes #<N>` bundle that landed
+and the full text of any parked questions. Always pair the light with its word
+(🔴 CHECK / 🟡 FYI / 🟢 OK) so it survives where color alone doesn't.
 
 ## Cleanup
 After the user confirms the merge, remove the worktree(s) you created and

--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -847,48 +847,19 @@ input[type="number"] {
 }
 
 /* =========================================================================
-   R5 · Boot/loading flourish (#594) — dot-matrix cursor + terminal empties.
+   R5 · Boot/loading flourish (#594, ouroboros updated #620) — terminal empties.
 
-   A restrained retro affordance for the search route. Two pieces, both loose
-   on the dark shell:
-     - `.cursor`  a blinking Doto block, shown while a search/scan is in flight
-                  (a console "working…" tick). Honours the display floor.
+   A restrained retro affordance for the search route. The blinking `.cursor`
+   from #594 was replaced in #620 by the WaitingIndicator component (a 4-cell
+   Doto ouroboros chase). Only the terminal-empty state class remains here.
      - `.empty--terminal`  a console-prompt empty state ("> no results …").
                   A modifier on the shared `.empty`; the base `.empty` (used by
                   documents/findings/tags/source-viewer) is left untouched so
                   this stays scoped to search and clear of B5 (#599).
    ========================================================================= */
 
-/* The block tick. Doto, so it reads as one lit dot-matrix cell; held at the
-   display floor so the dots never turn to mud. Sits inline at the end of the
-   line it follows (busy banner copy, terminal-empty prompt). */
-@keyframes r5-blink {
-  0%,
-  49% {
-    opacity: 1;
-  }
-  50%,
-  100% {
-    opacity: 0;
-  }
-}
-.cursor {
-  font-family: var(--font-display);
-  font-size: max(var(--text-display-floor), 1em);
-  /* The lit cell. A filled block glyph reads as a terminal cursor at any size. */
-  line-height: 0;
-  /* No layout shift: the cell reserves its width and only its opacity animates. */
-  animation: r5-blink 1.06s steps(1, end) infinite;
-}
-/* Respect reduced-motion: hold the cursor lit rather than blinking it. */
-@media (prefers-reduced-motion: reduce) {
-  .cursor {
-    animation: none;
-  }
-}
-
 /* Terminal-prompt empty state. Iosevka (UI chrome, not prose), a lit amber
-   prompt mark, and a trailing blinking cursor — a console waiting for input
+   prompt mark, and a trailing WaitingIndicator — a console waiting for input
    with nothing to show. Overrides the base `.empty` (inherited serif + its
    italic); equal specificity, wins on declaration order (defined after it). */
 .empty--terminal {

--- a/bartleby/web/src/lib/components/WaitingIndicator.svelte
+++ b/bartleby/web/src/lib/components/WaitingIndicator.svelte
@@ -1,0 +1,120 @@
+<script>
+  // WaitingIndicator — a shared ouroboros chase for any waiting / loading state.
+  //
+  // Props:
+  //   label   string   Text shown beside the indicator. E.g. "Searching…",
+  //                    "Loading…", "awaiting query". Caller owns the copy.
+  //   active  boolean  true  → ouroboros animates (system is busy).
+  //                    false → static dim frame (idle / waiting for user input).
+  //
+  // Usage:
+  //   <WaitingIndicator label="Searching…" active={true}  />   ← active search
+  //   <WaitingIndicator label="awaiting query" active={false} /> ← idle empty state
+  //   <WaitingIndicator label="Loading…" active={true}  />   ← #621 navigation
+  //
+  // The 4 Doto block cells are arranged in a clockwise square track:
+  //   [0] top-left  [1] top-right
+  //   [3] bot-left  [2] bot-right
+  // When active, a "lit" highlight sweeps clockwise (0→1→2→3→0…) using
+  // animation-delay offsets. When idle the track dims to shell-text-soft; no
+  // motion. prefers-reduced-motion: holds a static frame regardless of active.
+
+  export let label = "awaiting query";
+  export let active = false;
+</script>
+
+<span
+  class="waiting-indicator"
+  class:active
+  aria-label={label}
+  aria-live={active ? "polite" : undefined}
+  aria-busy={active}
+  role="status"
+>
+  <!--
+    4-cell ouroboros track. Order matches clockwise sweep:
+      cell-0 (top-left) → cell-1 (top-right) → cell-2 (bot-right) → cell-3 (bot-left)
+    CSS animation-delay staggers each cell's brightness peak by one quarter cycle.
+  -->
+  <span class="track" aria-hidden="true">
+    <span class="cell cell-0">█</span><span class="cell cell-1">█</span><!--
+    --><span class="cell cell-3">█</span><span class="cell cell-2">█</span>
+  </span>
+  <span class="label">{label}</span>
+</span>
+
+<style>
+  /* Container: inline-flex so it fits inside StatusBanner copy or a <p>. */
+  .waiting-indicator {
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-sm);
+    /* Anchor font-family and size so the Doto cells share metrics with the label. */
+  }
+
+  /* The 2×2 block track, rendered in Doto dot-matrix. Laid out as a 2-column
+     inline-grid so the four cells form a square regardless of font metrics.
+     Fixed dimensions prevent layout jitter — width is exactly 2 Doto "cells". */
+  .track {
+    font-family: var(--font-display);
+    font-size: max(var(--text-display-floor), 0.9em);
+    line-height: 0.9;
+    display: inline-grid;
+    grid-template-columns: repeat(2, 1ch);
+    grid-template-rows: repeat(2, 0.9em);
+    /* Align baseline of the bottom row with the label baseline. */
+    align-self: baseline;
+  }
+
+  .cell {
+    display: block;
+    /* Idle: dim cells (system is not busy). */
+    opacity: 0.18;
+    transition: opacity 0.1s;
+  }
+
+  /* ── Active / chase animation ──────────────────────────────────────────────
+     Clockwise sweep: cell-0 → cell-1 → cell-2 → cell-3 → repeat.
+     Each cell peaks at opacity 1, decays to ~0.12, over a shared 1.6 s cycle.
+     Stagger = cycle / 4 = 0.4 s per step. No steps(); easing is ease-in-out
+     so the peak is soft — no hard on/off, no strobe.
+  */
+  @keyframes ouroboros-pulse {
+    0%   { opacity: 1;    }
+    20%  { opacity: 0.12; }
+    75%  { opacity: 0.12; }
+    100% { opacity: 1;    }
+  }
+
+  .active .cell {
+    animation: ouroboros-pulse 1.6s ease-in-out infinite;
+  }
+
+  /* Clockwise stagger: cell-0 leads, each subsequent cell is +0.4 s behind. */
+  .active .cell-0 { animation-delay: 0s; }
+  .active .cell-1 { animation-delay: -1.2s; } /* 0.4 s into cycle */
+  .active .cell-2 { animation-delay: -0.8s; } /* 0.8 s into cycle */
+  .active .cell-3 { animation-delay: -0.4s; } /* 1.2 s into cycle */
+
+  /* Label: Iosevka (UI chrome). Inherits parent color (shell-text or banner). */
+  .label {
+    font-family: var(--font-sans);
+    font-size: inherit;
+  }
+
+  /* Reduced-motion: hold a static frame — one cell lit, no animation. */
+  @media (prefers-reduced-motion: reduce) {
+    .active .cell {
+      animation: none;
+    }
+    /* Keep cell-0 lit as the static "active" indicator. */
+    .active .cell-0 {
+      opacity: 1;
+    }
+    .active .cell-1,
+    .active .cell-2,
+    .active .cell-3 {
+      opacity: 0.18;
+    }
+  }
+</style>

--- a/bartleby/web/src/lib/components/WaitingIndicator.svelte
+++ b/bartleby/web/src/lib/components/WaitingIndicator.svelte
@@ -28,7 +28,7 @@
   class:active
   aria-label={label}
   aria-live={active ? "polite" : undefined}
-  aria-busy={active}
+  aria-busy={active || undefined}
   role="status"
 >
   <!--
@@ -40,16 +40,18 @@
     <span class="cell cell-0">█</span><span class="cell cell-1">█</span><!--
     --><span class="cell cell-3">█</span><span class="cell cell-2">█</span>
   </span>
-  <span class="label">{label}</span>
+  {label}
 </span>
 
 <style>
-  /* Container: inline-flex so it fits inside StatusBanner copy or a <p>. */
+  /* Container: inline-flex so it fits inside StatusBanner copy or a <p>.
+     Sets font-sans for the label text node; .track overrides to Doto for the
+     dot-matrix cells. */
   .waiting-indicator {
     display: inline-flex;
     align-items: baseline;
     gap: var(--space-sm);
-    /* Anchor font-family and size so the Doto cells share metrics with the label. */
+    font-family: var(--font-sans);
   }
 
   /* The 2×2 block track, rendered in Doto dot-matrix. Laid out as a 2-column
@@ -95,12 +97,6 @@
   .active .cell-1 { animation-delay: -1.2s; } /* 0.4 s into cycle */
   .active .cell-2 { animation-delay: -0.8s; } /* 0.8 s into cycle */
   .active .cell-3 { animation-delay: -0.4s; } /* 1.2 s into cycle */
-
-  /* Label: Iosevka (UI chrome). Inherits parent color (shell-text or banner). */
-  .label {
-    font-family: var(--font-sans);
-    font-size: inherit;
-  }
 
   /* Reduced-motion: hold a static frame — one cell lit, no animation. */
   @media (prefers-reduced-motion: reduce) {

--- a/bartleby/web/src/lib/navigation.js
+++ b/bartleby/web/src/lib/navigation.js
@@ -1,0 +1,13 @@
+// True when an in-flight navigation is a real search submission — going TO
+// /search with a non-empty ?q= (a query submit, a scan step, or pagination,
+// all of which carry q). The search page shows "Searching…" when this is true;
+// the global layout indicator shows "Loading…" when it is false. They are
+// complements, so the rule lives in one place: a one-sided edit would otherwise
+// produce a double indicator or a silent gap.
+export function isSearchNavigation(navigating) {
+  return (
+    !!navigating &&
+    navigating.to?.url?.pathname?.startsWith("/search") &&
+    !!navigating.to?.url?.searchParams?.get("q")
+  );
+}

--- a/bartleby/web/src/routes/+layout.svelte
+++ b/bartleby/web/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
   } from "$lib/icons.js";
   import StatusBanner from "$lib/components/StatusBanner.svelte";
   import WaitingIndicator from "$lib/components/WaitingIndicator.svelte";
+  import { isSearchNavigation } from "$lib/navigation.js";
   export let data;
 
   // A nav link is "active" if the current path matches exactly OR is a child
@@ -50,19 +51,12 @@
   $: isActive = (href) =>
     href === "/" ? path === "/" : path === href || path.startsWith(href + "/");
 
-  // Show a global "Loading…" indicator for any navigation that is NOT a search
-  // submission. A search submission navigates TO /search with a non-empty ?q=
-  // param — the search page's own "Searching…" banner covers that case with a
-  // richer embedding-model hint. Every other in-flight navigation (clicking a
-  // result, pressing Back, moving to /findings, etc.) gets the global banner.
-  //
-  // We check $navigating.to so the layout never shows "Loading…" during a
-  // search — preventing two simultaneous indicators and wrong copy.
-  $: isSearchNavigation =
-    !!$navigating &&
-    $navigating.to?.url?.pathname?.startsWith("/search") &&
-    !!$navigating.to?.url?.searchParams?.get("q");
-  $: loading = !!$navigating && !isSearchNavigation;
+  // Show a global "Loading…" indicator for any in-flight navigation that is NOT
+  // a search submission — clicking a result, pressing Back, moving to /findings,
+  // etc. A real search is owned by the search page's richer "Searching…" banner;
+  // isSearchNavigation (shared with that page) is the single source of truth for
+  // the distinction, so the two indicators never both fire or show wrong copy.
+  $: loading = !!$navigating && !isSearchNavigation($navigating);
 </script>
 
 <header>
@@ -233,6 +227,11 @@
     main {
       /* Taller offset: two-line header is ~3rem taller at mobile. */
       padding-top: 6.5rem;
+    }
+    .global-loading {
+      /* Clear the taller two-line mobile header (matches main's offset above);
+         otherwise the fixed banner overlaps the header on phones. */
+      top: 6rem;
     }
   }
 </style>

--- a/bartleby/web/src/routes/+layout.svelte
+++ b/bartleby/web/src/routes/+layout.svelte
@@ -26,13 +26,15 @@
 
 <script>
   import "../app.css";
-  import { page } from "$app/stores";
+  import { navigating, page } from "$app/stores";
   import {
     SEARCH_ICON,
     FINDINGS_ICON,
     DOCUMENTS_ICON,
     TAGS_ICON,
   } from "$lib/icons.js";
+  import StatusBanner from "$lib/components/StatusBanner.svelte";
+  import WaitingIndicator from "$lib/components/WaitingIndicator.svelte";
   export let data;
 
   // A nav link is "active" if the current path matches exactly OR is a child
@@ -47,6 +49,20 @@
   $: path = $page.url.pathname;
   $: isActive = (href) =>
     href === "/" ? path === "/" : path === href || path.startsWith(href + "/");
+
+  // Show a global "Loading…" indicator for any navigation that is NOT a search
+  // submission. A search submission navigates TO /search with a non-empty ?q=
+  // param — the search page's own "Searching…" banner covers that case with a
+  // richer embedding-model hint. Every other in-flight navigation (clicking a
+  // result, pressing Back, moving to /findings, etc.) gets the global banner.
+  //
+  // We check $navigating.to so the layout never shows "Loading…" during a
+  // search — preventing two simultaneous indicators and wrong copy.
+  $: isSearchNavigation =
+    !!$navigating &&
+    $navigating.to?.url?.pathname?.startsWith("/search") &&
+    !!$navigating.to?.url?.searchParams?.get("q");
+  $: loading = !!$navigating && !isSearchNavigation;
 </script>
 
 <header>
@@ -61,6 +77,14 @@
     <span class="project display">{data.project}</span>
   </nav>
 </header>
+
+{#if loading}
+  <div class="global-loading">
+    <StatusBanner variant="busy">
+      <WaitingIndicator label="Loading…" active={true} />
+    </StatusBanner>
+  </div>
+{/if}
 
 <main>
   <slot />
@@ -140,6 +164,24 @@
     margin-left: auto;
     color: var(--color-shell-text-soft);
     font-size: var(--text-base);
+  }
+  /* Global navigation loading banner: fixed just below the header so it's
+     always visible regardless of scroll position. Dismissed the instant
+     $navigating clears. The banner's own margin-bottom is ignored here since
+     it's taken out of flow; we use padding-top inside .banner instead. */
+  .global-loading {
+    position: fixed;
+    top: 3rem; /* sits just below the fixed header bar */
+    left: 0;
+    right: 0;
+    z-index: 9;
+    padding: var(--space-sm) var(--space-lg) 0;
+  }
+  /* Remove the bottom margin that StatusBanner adds (it's irrelevant when
+     the banner is fixed-positioned above the content). */
+  .global-loading :global(.banner) {
+    margin-bottom: 0;
+    max-width: none;
   }
   main {
     /* Offset the fixed header (a fixed structural height) so content doesn't

--- a/bartleby/web/src/routes/+page.svelte
+++ b/bartleby/web/src/routes/+page.svelte
@@ -179,6 +179,7 @@
      (--width-content); it's a grid of panels, not a reading column. */
   .home {
     max-width: 52rem;
+    margin-inline: auto;
   }
   h1.display {
     font-family: var(--font-display);

--- a/bartleby/web/src/routes/findings/+page.svelte
+++ b/bartleby/web/src/routes/findings/+page.svelte
@@ -14,7 +14,7 @@
 
   // Index view: a scannable table by default, or the same findings grouped by
   // the research session that produced them. Client-side only.
-  let mode = "table";
+  let mode = "grouped";
 
   // Group findings by session, preserving first-appearance order. Because
   // `findings` is newest-first, sessions sort newest-first too, and each

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -4,6 +4,7 @@
   import ResultCard from "$lib/components/ResultCard.svelte";
   import StatusBanner from "$lib/components/StatusBanner.svelte";
   import Pagination from "$lib/components/Pagination.svelte";
+  import WaitingIndicator from "$lib/components/WaitingIndicator.svelte";
   import { pluralize } from "$lib/format.js";
 
   export let data;
@@ -28,7 +29,7 @@
 
 {#if busy}
   <StatusBanner variant="busy">
-    Searching<span class="cursor" aria-hidden="true">█</span>
+    <WaitingIndicator label="Searching…" active={true} />
     <span class="hint">semantic queries load the embedding model and can take a few seconds.</span>
   </StatusBanner>
 {/if}
@@ -41,7 +42,7 @@
     </StatusBanner>
   {:else if !params.q}
     <p class="empty empty--terminal">
-      awaiting query<span class="cursor" aria-hidden="true">█</span>
+      <WaitingIndicator label="awaiting query" active={false} />
     </p>
   {:else if params.mode === "scan"}
     {#if result.matches.length === 0}

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -6,20 +6,16 @@
   import Pagination from "$lib/components/Pagination.svelte";
   import WaitingIndicator from "$lib/components/WaitingIndicator.svelte";
   import { pluralize } from "$lib/format.js";
+  import { isSearchNavigation } from "$lib/navigation.js";
 
   export let data;
 
   $: ({ params, available, result, error } = data);
-  // Show "Searching…" only when navigating TO /search with a real query —
-  // i.e. a genuine search/scan submission. Clicking a result or pressing Back
-  // also triggers $navigating while on this page, but those go elsewhere
-  // (chunks, documents, …) and are handled by the global layout indicator.
-  // Narrowing here prevents "Searching…" appearing for non-search navigations
-  // and avoids two simultaneous indicators.
-  $: busy =
-    !!$navigating &&
-    $navigating.to?.url?.pathname?.startsWith("/search") &&
-    !!$navigating.to?.url?.searchParams?.get("q");
+  // Show "Searching…" only for a genuine search/scan submission. Clicking a
+  // result or pressing Back also triggers $navigating while on this page, but
+  // those go elsewhere and are owned by the global layout "Loading…" indicator.
+  // The shared isSearchNavigation predicate keeps the two in lockstep.
+  $: busy = isSearchNavigation($navigating);
 
   // Preserve the current query while only moving the scan offset.
   function scanHref(offset) {

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -21,6 +21,7 @@
   }
 </script>
 
+<div class="search">
 <h1>Search</h1>
 
 <SearchForm {params} availableTags={available.tags} />
@@ -85,10 +86,14 @@
     {/if}
   {/if}
 </div>
+</div>
 
 <style>
-  .results {
+  .search {
     max-width: var(--width-content);
+    margin-inline: auto;
+  }
+  .results {
     transition: opacity 0.15s;
   }
   .results.dim {

--- a/bartleby/web/src/routes/search/+page.svelte
+++ b/bartleby/web/src/routes/search/+page.svelte
@@ -10,9 +10,16 @@
   export let data;
 
   $: ({ params, available, result, error } = data);
-  // Any in-flight navigation here is a search/scan submit — show progress
-  // while the subprocess (and, for semantic search, the BGE model) runs.
-  $: busy = !!$navigating;
+  // Show "Searching…" only when navigating TO /search with a real query —
+  // i.e. a genuine search/scan submission. Clicking a result or pressing Back
+  // also triggers $navigating while on this page, but those go elsewhere
+  // (chunks, documents, …) and are handled by the global layout indicator.
+  // Narrowing here prevents "Searching…" appearing for non-search navigations
+  // and avoids two simultaneous indicators.
+  $: busy =
+    !!$navigating &&
+    $navigating.to?.url?.pathname?.startsWith("/search") &&
+    !!$navigating.to?.url?.searchParams?.get("q");
 
   // Preserve the current query while only moving the scan offset.
   function scanHref(offset) {


### PR DESCRIPTION
Polish follow-ups to the retro redesign (#589). Four small web-UI sub-issues plus a `/ship` re-press. Players ran on the cheap tier (Sonnet); director + critics on Opus.

## At-a-glance triage

**🔴 CHECK — look before merging**
- **Centering scope.** #618 centered the **home** and **search** columns only; **findings / documents / tags** were deliberately left full-width (they're card/hero grids, not reading columns). This is narrower than this omnibus's issue body (which also named findings/documents) but matches the original ask (you only asked about home + search). Confirm you're happy leaving the wide pages uncentered.
- **Back-button loading not eyeballed.** The dev DB returns too fast to hold the mid-navigation "Loading…" state for a screenshot. #621's routing logic was verified in-browser (every destination URL classifies correctly: search→"Searching…", chunk/doc/back→"Loading…", never both), but the actual *slow back-button* experience depends on production DB latency to be visible and wasn't reproduced live.

**🟡 FYI — no action needed**
- **Model tier:** players were cheap-tier (Sonnet) — weigh those diffs a touch more skeptically. Director + both critics were Opus.
- **Two LOW critic findings left by design:** (1) submitting an *empty* query briefly flashes "Loading…" before the "awaiting query" empty state — the alternative copy is equally wrong, so left as-is; (2) when active, `WaitingIndicator`'s `role="status"`/`aria-live` nests inside `StatusBanner`'s live region — mild double-announce; fixing it would couple the component's a11y to its container.
- **Integration mechanism:** sub-PRs were integrated onto the omnibus branch via local `git merge` + push (you authorized this) after the auto-mode classifier blocked `gh pr merge`. `main` was never touched — this promotion PR is the only path to `main`, and it's yours to merge.
- **Tooling rider:** a re-press of the `/ship` skill (`SKILL.md` → at-a-glance triage Report) landed on this branch as the first commit.

**🟢 OK — verified and held**
`vite build` passes clean · correctness critic: no high-risk findings (the medium — mobile loading-banner overlapping the two-line header — is fixed) · cross-cutting simplicity: the duplicated search-nav predicate was extracted to `$lib/navigation.js` (single source of truth) · 4/4 sub-PRs landed · old `.cursor`/`r5-blink` fully removed · pytest skipped (frontend-only, `--skip-tests`).

## What landed
- **#618** — centered the home + search content columns (`margin-inline: auto`).
- **#619** — findings index now defaults to **Grouped by session** (toggle still flips to Table).
- **#620** — replaced the hard "Searching" block-blink with a shared **ouroboros** `WaitingIndicator` component (smooth chase, fixed footprint, reduced-motion fallback); honest idle vs active states.
- **#621** — global **"Loading…"** indicator in the layout keyed on `$navigating`, covering the slow back button and all navigations; "Searching…" narrowed to genuine search submissions so the two never conflict.
- **post-assembly (director):** extracted `isSearchNavigation` to `$lib/navigation.js`; fixed the mobile loading-banner overlap; re-pressed `/ship`.

**Parked:** none.

Closes #618
Closes #619
Closes #620
Closes #621
Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)
