### PR TITLE
Part of #635: fix --file-like high-cardinality crash via temp-table join (#632)

### DIFF
--- a/bartleby/skill_scripts/_tags.py
+++ b/bartleby/skill_scripts/_tags.py
@@ -168,24 +168,6 @@ def documents_with_any_tag(conn, tag_ids: list[int]) -> list[int]:
     ]
 
 
-def documents_matching_file_like(conn, patterns: list[str]) -> list[int]:
-    """Distinct document_ids whose ``file_name`` matches any of ``patterns``.
-
-    SQL ``LIKE`` semantics, OR across patterns, pushed down to SQLite as a
-    parameterized predicate (the user's pattern never reaches the SQL text).
-    Returns ``[]`` for an empty pattern list.
-    """
-    if not patterns:
-        return []
-    clause = " OR ".join("file_name LIKE ?" for _ in patterns)
-    return [
-        row[0] for row in conn.cursor().execute(
-            f"SELECT document_id FROM documents WHERE {clause}",
-            patterns,
-        )
-    ]
-
-
 # ---------- scope resolution (tags + in_documents + date bounds) ----------
 
 
@@ -219,6 +201,12 @@ class Scope:
     matched nothing" (short-circuit to zero results). The remaining fields echo
     the *requested* filter so a response can be self-describing via
     ``echo_into``.
+
+    ``temp_table`` is set when ``--file-like`` produced a scope that was
+    materialized into a SQLite temp table instead of a Python list (to avoid
+    binding >32 k variables). When set, ``document_ids`` is ``None`` (the
+    Python list is not populated) and callers must use ``restrict_in`` rather
+    than reading ``document_ids`` directly for SQL predicate building.
     """
 
     document_ids: list[int] | None
@@ -229,6 +217,7 @@ class Scope:
     authored_before: str | None
     include_nulls: bool
     excluded_null_dated: int
+    temp_table: str | None = None       # set when file-like scope lives in a temp table
 
     @property
     def date_active(self) -> bool:
@@ -267,14 +256,16 @@ class Scope:
     def restrict_in(self, col: str) -> tuple[str, list]:
         """A bare ``document_ids`` predicate for ``col`` plus its params.
 
-        Returns one of three forms, *without* a leading ``WHERE``/``AND`` so the
+        Returns one of four forms, *without* a leading ``WHERE``/``AND`` so the
         caller composes it freely:
           - ``("", [])`` — whole corpus, no restriction.
           - ``("0", [])`` — a filter matched nothing; matches no rows.
-          - ``("<col> IN (?,?)", [ids...])`` — restrict to the resolved slice.
-        This is the single source for the None/empty/list branch all three
-        scripts otherwise hand-roll.
+          - ``("<col> IN (?,?)", [ids...])`` — restrict to a small resolved slice.
+          - ``("<col> IN (SELECT document_id FROM <temp>)", [])`` — restrict via
+            temp-table join when ``--file-like`` produced a large match set.
         """
+        if self.temp_table is not None:
+            return f"{col} IN (SELECT document_id FROM {self.temp_table})", []
         if self.document_ids is None:
             return "", []
         if not self.document_ids:
@@ -337,6 +328,58 @@ def _apply_date_bound(
     return document_ids, excluded
 
 
+def _apply_date_bound_to_temp(
+    conn, temp_table: str, *,
+    after: str | None, before: str | None, include_nulls: bool,
+) -> int:
+    """Apply a date bound by deleting non-qualifying rows from ``temp_table`` in place.
+
+    Used when the scope was materialized into a temp table (the file-like path).
+    Removes rows that don't satisfy the date bound, returning ``excluded_null_dated``.
+    The temp table is modified in place so callers retain the same table name.
+    """
+    bounds, bound_params = [], []
+    if after is not None:
+        bounds.append("s.authored_date >= ?")
+        bound_params.append(after)
+    if before is not None:
+        bounds.append("s.authored_date <= ?")
+        bound_params.append(before)
+    bounds_sql = " AND ".join(bounds)
+
+    cur = conn.cursor()
+    excluded = 0
+
+    if include_nulls:
+        # Keep rows where date is NULL OR satisfies the bound; drop the rest.
+        cur.execute(
+            f"DELETE FROM {temp_table} WHERE document_id NOT IN ("
+            f"  SELECT t.document_id FROM {temp_table} t "
+            f"  LEFT JOIN summaries s USING (document_id) "
+            f"  WHERE s.authored_date IS NULL OR ({bounds_sql})"
+            f")",
+            bound_params,
+        )
+    else:
+        # Count undated rows (excluded from any date-bound result), then remove
+        # all rows that don't satisfy the bound. The INNER JOIN naturally drops
+        # undated rows (no summaries row → no join hit), so no separate null pass.
+        excluded = cur.execute(
+            f"SELECT COUNT(*) FROM {temp_table} t "
+            f"LEFT JOIN summaries s USING (document_id) "
+            f"WHERE s.authored_date IS NULL",
+        ).fetchone()[0]
+        cur.execute(
+            f"DELETE FROM {temp_table} WHERE document_id NOT IN ("
+            f"  SELECT t.document_id FROM {temp_table} t "
+            f"  JOIN summaries s USING (document_id) "
+            f"  WHERE {bounds_sql}"
+            f")",
+            bound_params,
+        )
+    return excluded
+
+
 def resolve_scope(
     conn, *,
     in_documents: list[int] | None = None,
@@ -355,24 +398,128 @@ def resolve_scope(
     Each intersection yields ``[]`` (short-circuit to zero hits) when empty, or
     passes the prior scope through unchanged when its filter is absent.
     Unknown tags raise ``TAG_NOT_FOUND`` and malformed bounds raise ``INVALID_DATE``.
+
+    When ``--file-like`` is present the matched ids are materialized into a
+    SQLite temp table (``_scope_file_like``) instead of a Python list, so a
+    broad glob that matches hundreds of thousands of documents never triggers
+    SQLite's ``SQLITE_MAX_VARIABLE_NUMBER`` limit. The returned ``Scope`` carries
+    ``temp_table`` set to the table name; ``restrict_in`` returns a subquery
+    predicate against it rather than an ``IN (?, ?, …)`` list.
     """
     after = validate_date_bound("--authored-after", authored_after)
     before = validate_date_bound("--authored-before", authored_before)
 
+    date_active = after is not None or before is not None
+
+    if file_like:
+        # Build the temp table: start with all file-like matches, then intersect
+        # with tags and in_documents inside SQLite (never in Python) to avoid
+        # a high-cardinality bind list at every consumer.
+        tag_ids: list[int] = []
+        if tags:
+            tag_ids = resolve_tag_names(conn, tags)
+
+        like_clause = " OR ".join("d.file_name LIKE ?" for _ in file_like)
+        conditions: list[str] = [f"({like_clause})"]
+        params: list = list(file_like)
+
+        if in_documents is not None:
+            if not in_documents:
+                # Explicit empty in_documents → nothing matches.
+                return Scope(
+                    document_ids=[],
+                    in_documents=in_documents,
+                    tags=tags or None,
+                    file_like=file_like,
+                    authored_after=after,
+                    authored_before=before,
+                    include_nulls=include_nulls,
+                    excluded_null_dated=0,
+                )
+            id_ph = ",".join("?" * len(in_documents))
+            conditions.append(f"d.document_id IN ({id_ph})")
+            params.extend(in_documents)
+
+        if tag_ids:
+            tid_ph = ",".join("?" * len(tag_ids))
+            conditions.append(
+                f"EXISTS (SELECT 1 FROM document_tags dt "
+                f"WHERE dt.document_id = d.document_id AND dt.tag_id IN ({tid_ph}))"
+            )
+            params.extend(tag_ids)
+
+        where_sql = " AND ".join(conditions)
+        cur = conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS temp._scope_file_like")
+        cur.execute(
+            "CREATE TEMP TABLE _scope_file_like (document_id INTEGER PRIMARY KEY)"
+        )
+        cur.execute(
+            f"INSERT INTO _scope_file_like "
+            f"SELECT DISTINCT d.document_id FROM documents d WHERE {where_sql}",
+            params,
+        )
+
+        # Check whether the temp table is empty (whole filter matched nothing).
+        count = cur.execute(
+            "SELECT COUNT(*) FROM _scope_file_like"
+        ).fetchone()[0]
+        if count == 0:
+            return Scope(
+                document_ids=[],
+                in_documents=in_documents,
+                tags=tags or None,
+                file_like=file_like,
+                authored_after=after,
+                authored_before=before,
+                include_nulls=include_nulls,
+                excluded_null_dated=0,
+            )
+
+        excluded = 0
+        if date_active:
+            excluded = _apply_date_bound_to_temp(
+                conn, "_scope_file_like",
+                after=after, before=before, include_nulls=include_nulls,
+            )
+            # After date filtering, check again for empty.
+            count = cur.execute(
+                "SELECT COUNT(*) FROM _scope_file_like"
+            ).fetchone()[0]
+            if count == 0:
+                return Scope(
+                    document_ids=[],
+                    in_documents=in_documents,
+                    tags=tags or None,
+                    file_like=file_like,
+                    authored_after=after,
+                    authored_before=before,
+                    include_nulls=include_nulls,
+                    excluded_null_dated=excluded,
+                )
+
+        return Scope(
+            document_ids=None,
+            in_documents=in_documents,
+            tags=tags or None,
+            file_like=file_like,
+            authored_after=after,
+            authored_before=before,
+            include_nulls=include_nulls,
+            excluded_null_dated=excluded,
+            temp_table="_scope_file_like",
+        )
+
+    # No file-like: use the original Python-list path.
     scoped_docs = in_documents
     if tags:
         tagged = documents_with_any_tag(conn, resolve_tag_names(conn, tags))
         scoped_docs = tagged if scoped_docs is None else sorted(set(scoped_docs) & set(tagged))
-    if file_like:
-        matched = documents_matching_file_like(conn, file_like)
-        scoped_docs = matched if scoped_docs is None else sorted(set(scoped_docs) & set(matched))
-    date_active = after is not None or before is not None
 
     if not date_active:
         document_ids, excluded = scoped_docs, 0
     elif scoped_docs is not None and not scoped_docs:
-        # The tag/in-documents/file-like scope is already empty — the bound
-        # can't add anything.
+        # The tag/in-documents scope is already empty — the bound can't add anything.
         document_ids, excluded = [], 0
     else:
         document_ids, excluded = _apply_date_bound(

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -544,22 +544,26 @@ def _heading_qualified_fts(fts_expr: str) -> str:
     return f"{{section_heading}} : ({fts_expr})"
 
 
-def _count_match(cur, column_fts: str, restrict: list | None) -> int:
+def _count_match(
+    cur, column_fts: str,
+    restrict_sql: str, restrict_params: list,
+) -> int:
     """COUNT document chunks whose ``column_fts`` MATCH holds, optionally scoped.
 
     A single cheap COUNT over ``chunks_fts`` joined to ``chunks`` — the diagnosis
-    primitive. ``restrict`` is the scope's resolved document-id set (``None`` =
-    whole corpus); ``column_fts`` is an already-column-qualified FTS expression
-    (body via :func:`text_qualified_fts`, heading via :func:`_heading_qualified_fts`).
+    primitive. ``restrict_sql`` / ``restrict_params`` are the SQL fragment and bind
+    values from ``Scope.restrict_in("c.source_id")``: empty string for whole corpus,
+    ``"0"`` for an empty scope, or a subquery/IN predicate for a restricted scope.
+    ``column_fts`` is an already-column-qualified FTS expression (body via
+    :func:`text_qualified_fts`, heading via :func:`_heading_qualified_fts`).
     Heading-like / pagination never reach here — the diagnosis answers "where does
     the signal live", not "what did this exact filtered scan return".
     """
     where = "chunks_fts MATCH ? AND c.source_kind = 'document'"
     params: list = [column_fts]
-    if restrict is not None:
-        placeholders = ",".join("?" * len(restrict))
-        where += f" AND c.source_id IN ({placeholders})"
-        params.extend(restrict)
+    if restrict_sql:
+        where += f" AND {restrict_sql}"
+        params.extend(restrict_params)
     return cur.execute(
         f"SELECT COUNT(*) FROM chunks_fts "
         f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
@@ -568,7 +572,10 @@ def _count_match(cur, column_fts: str, restrict: list | None) -> int:
     ).fetchone()[0]
 
 
-def _build_diagnosis(cur, fts_query: str, restrict: list | None) -> dict:
+def _build_diagnosis(
+    cur, fts_query: str,
+    restrict_sql: str, restrict_params: list,
+) -> dict:
     """Coverage-aware diagnosis for a zero-result scan (fired only on that path).
 
     scan matches body ``text`` only, column-qualified — so a ``0`` can mean
@@ -597,20 +604,20 @@ def _build_diagnosis(cur, fts_query: str, restrict: list | None) -> dict:
     body_fts = text_qualified_fts(fts_query)
     heading_fts = _heading_qualified_fts(fts_query)
 
-    body_corpus_wide = _count_match(cur, body_fts, None)
-    heading_corpus_wide = _count_match(cur, heading_fts, None)
+    body_corpus_wide = _count_match(cur, body_fts, "", [])
+    heading_corpus_wide = _count_match(cur, heading_fts, "", [])
     # "in scope" follows the *document-level* restrict only; --heading-like is a
     # chunk-level filter and is deliberately stripped here, so body_in_scope > 0
     # on a zero scan means that filter (not absence) dropped the body hits.
-    if restrict is None:
+    if not restrict_sql:
         # No document-level scope: in-scope equals corpus-wide, no extra COUNTs.
         body_in_scope, heading_in_scope = body_corpus_wide, heading_corpus_wide
-    elif restrict:
-        body_in_scope = _count_match(cur, body_fts, restrict)
-        heading_in_scope = _count_match(cur, heading_fts, restrict)
-    else:
+    elif restrict_sql == "0":
         # Scope resolved to no documents — nothing in scope can match.
         body_in_scope = heading_in_scope = 0
+    else:
+        body_in_scope = _count_match(cur, body_fts, restrict_sql, restrict_params)
+        heading_in_scope = _count_match(cur, heading_fts, restrict_sql, restrict_params)
 
     if body_in_scope:
         verdict = "filtered_out"  # body hits in scope, dropped by a chunk filter
@@ -675,7 +682,12 @@ def work(*, conn, args, session_id) -> dict:
         authored_before=args.authored_before,
         include_nulls=args.include_nulls,
     )
-    restrict = scope.document_ids  # None = whole corpus, [] = empty, else a set
+    # Build the scope predicate once; all three query sites (main scan, _count_match
+    # diagnosis, _count_total) consume the same (restrict_sql, restrict_params) pair.
+    # scope.restrict_in returns ("", []) for whole corpus, ("0", []) for empty scope,
+    # or a subquery/IN predicate — which may join a temp table for high-cardinality
+    # file-like scopes, avoiding the SQLITE_MAX_VARIABLE_NUMBER limit (#632).
+    restrict_sql, restrict_params = scope.restrict_in("c.source_id")
 
     def _envelope(extra: dict) -> dict:
         env = scope.echo_into({"query": args.query, "match_mode": match_mode, **extra})
@@ -692,17 +704,16 @@ def work(*, conn, args, session_id) -> dict:
     fts_query = _build_fts_query(args.query, match_mode)
     # Nothing can match: an empty token set, or a scope that resolved to no
     # documents (an empty tag / in-documents / date slice).
-    no_match = not fts_query or (restrict is not None and not restrict)
+    no_match = not fts_query or restrict_sql == "0"
 
     # Confine MATCH to the body text (``{text} : (...)``) so a heading-only term
     # never inflates grep-totals with a snippet that doesn't contain it.
     # Deliberate heading recall stays available via --heading-like.
     where = "chunks_fts MATCH ? AND c.source_kind = 'document'"
     params: list = [text_qualified_fts(fts_query)]
-    if restrict is not None:
-        placeholders = ",".join("?" * len(restrict))
-        where += f" AND c.source_id IN ({placeholders})"
-        params.extend(restrict)
+    if restrict_sql:
+        where += f" AND {restrict_sql}"
+        params.extend(restrict_params)
     if args.heading_like:
         # OR the patterns within the group; the group ANDs with the rest. Pushed
         # down parameterized — the agent's pattern never reaches the SQL text.
@@ -717,7 +728,9 @@ def work(*, conn, args, session_id) -> dict:
         confirmed zero result, so the extra COUNTs stay off the hot path. An empty
         token set carries no FTS expression to COUNT, so it gets no diagnosis."""
         if fts_query:
-            env["diagnosis"] = _build_diagnosis(cur, fts_query, restrict)
+            env["diagnosis"] = _build_diagnosis(
+                cur, fts_query, restrict_sql, restrict_params,
+            )
         return env
 
     if extract_specs is not None:

--- a/bartleby/skill_scripts/search.py
+++ b/bartleby/skill_scripts/search.py
@@ -226,19 +226,30 @@ def _fts_query(query: str) -> str:
 
 
 def _scope_clause(
-    scope: dict[str, list[int] | None],
+    scope: dict[str, list[int] | str | None],
 ) -> tuple[str, list]:
     """Build a SQL predicate over ``chunks`` that matches any allowed
     (source_kind, source_id) combination.
 
-    ``scope`` maps source_kind → either a list of allowed source_ids
-    (filtered scope) or ``None`` (unrestricted — match all of that kind).
+    ``scope`` maps source_kind → one of:
+      - ``None`` — unrestricted (match all of that kind)
+      - ``[]`` — empty list (matches nothing for this kind)
+      - ``[int, ...]`` — restrict to these source_ids
+      - ``str`` — a subquery string like ``"SELECT … FROM …"`` used as
+        ``source_id IN (<subquery>)`` to avoid large bind-parameter lists
+        (the file-like high-cardinality path, #632)
     """
     parts: list[str] = []
     params: list = []
     for kind, ids in scope.items():
         if ids is None:
             parts.append("chunks.source_kind = ?")
+            params.append(kind)
+        elif isinstance(ids, str):
+            # Subquery form: ids is a SELECT statement, no bind params needed.
+            parts.append(
+                f"(chunks.source_kind = ? AND chunks.source_id IN ({ids}))"
+            )
             params.append(kind)
         else:
             if not ids:
@@ -257,22 +268,48 @@ def _scope_clause(
 def _build_scope(
     conn,
     source_kinds: list[str],
-    in_documents: list[int] | None,
-) -> dict[str, list[int] | None]:
+    scope_obj,
+) -> dict[str, list[int] | str | None]:
     """Resolve the scope dict consumed by ``_scope_clause``.
 
-    Without ``in_documents``, every requested kind is unrestricted.
-    With ``in_documents``: 'document' is restricted to those ids; 'summary'
+    Without any document restriction, every requested kind is unrestricted.
+    With a restriction: 'document' is restricted to the matching ids; 'summary'
     is restricted to summaries whose document_id is in those ids; 'image' is
     restricted to images linked to those documents via ``document_images``;
     'finding' is excluded entirely (findings aren't tied to documents).
+
+    When ``scope_obj.temp_table`` is set (file-like high-cardinality path),
+    dict values are SQL subquery strings rather than Python lists, so no
+    large IN-parameter list is ever built.
     """
+    from bartleby.skill_scripts._tags import Scope
+
+    if scope_obj.temp_table is not None:
+        # High-cardinality file-like path: use subqueries against the temp table
+        # so no Python list is materialized.
+        temp = scope_obj.temp_table
+        scope: dict[str, list[int] | str | None] = {}
+        if "document" in source_kinds:
+            scope["document"] = f"SELECT document_id FROM {temp}"
+        if "summary" in source_kinds:
+            scope["summary"] = (
+                f"SELECT summary_id FROM summaries "
+                f"WHERE document_id IN (SELECT document_id FROM {temp})"
+            )
+        if "image" in source_kinds:
+            scope["image"] = (
+                f"SELECT DISTINCT image_id FROM document_images "
+                f"WHERE document_id IN (SELECT document_id FROM {temp})"
+            )
+        return scope
+
+    in_documents = scope_obj.document_ids
     if in_documents is None:
         return {kind: None for kind in source_kinds}
 
     placeholders = ",".join("?" * len(in_documents))
     cur = conn.cursor()
-    scope: dict[str, list[int] | None] = {}
+    scope = {}
     if "document" in source_kinds:
         scope["document"] = list(in_documents)
     if "summary" in source_kinds:
@@ -427,16 +464,12 @@ def work(*, conn, args, session_id) -> dict:
         authored_before=args.authored_before,
         include_nulls=args.include_nulls,
     )
-    # None = whole corpus, [] = a filter matched nothing, else the resolved slice.
-    restrict = scope.document_ids
-
-    # Findings drop out when memory is off OR when --in-documents/--tag is set
-    # (findings have no document anchor). memory_excluded reports only the
-    # memory case — that's the signal documented in SKILL.md.
+    # Findings drop out when memory is off OR when any document-level scope is active
+    # (findings have no document anchor). memory_excluded reports only the memory case.
     memory_excluded = (
         "finding" in source_kinds and not memory_enabled(conn, session_id)
     )
-    drop_findings = memory_excluded or restrict is not None
+    drop_findings = memory_excluded or scope.active
     if drop_findings:
         source_kinds = [k for k in source_kinds if k != "finding"]
 
@@ -453,11 +486,14 @@ def work(*, conn, args, session_id) -> dict:
             "results": results,
         }))
 
-    # No source kinds left, or a scope filter that matched nothing: zero hits.
-    if not source_kinds or (restrict is not None and not restrict):
+    # No source kinds left, or a scope filter that resolved to nothing: zero hits.
+    # When scope.temp_table is set, document_ids is None (handled by _build_scope);
+    # the only "nothing matched" signal on that path is document_ids == [] (resolved
+    # by resolve_scope before setting temp_table).
+    if not source_kinds or scope.document_ids == []:
         return _response([])
 
-    scope_dict = _build_scope(conn, source_kinds, restrict)
+    scope_dict = _build_scope(conn, source_kinds, scope)
     overfetch = max(args.limit * OVERFETCH_MULTIPLIER, OVERFETCH_FLOOR)
 
     rankings: list[list[int]] = []

--- a/docs/decisions/GH-0632-file-like-temp-table-0001.md
+++ b/docs/decisions/GH-0632-file-like-temp-table-0001.md
@@ -1,0 +1,42 @@
+# GH-0632 — file-like high-cardinality scope via temp table
+
+**Context.** A broad `--file-like` glob (e.g. `%__202%`) matching ~141k documents
+crashed `search`, `scan`, and `list_documents` with `too many SQL variables`. The
+previous implementation in `resolve_scope` called `documents_matching_file_like()`,
+which materialised all matched document_ids as a Python `list[int]`.  That list then
+appeared as `IN (?, ?, …)` bind-parameter lists at three call sites — one in
+`Scope.restrict_in` (used by `list_documents`), one in `scan.work`, and one in
+`search._build_scope` — each of which hit SQLite's `SQLITE_MAX_VARIABLE_NUMBER`
+limit (32,766 on this build) and raised an error.
+
+**Decision.** When `--file-like` is present, `resolve_scope` now materialises the
+matched document_ids — intersected with `--in-documents`, `--tag`, and `--authored-*`
+date bounds entirely inside SQLite — into a connection-scoped temp table
+(`_scope_file_like`) instead of a Python list.  The `Scope` dataclass gains a
+`temp_table: str | None` field; when set, `restrict_in()` emits a subquery
+(`col IN (SELECT document_id FROM _scope_file_like)`) with no bind parameters.
+
+Three consumer sites were updated:
+- `list_documents.py` — already delegated to `Scope.restrict_in`; picks up the fix
+  automatically.
+- `scan.py` — `_count_match` and `_build_diagnosis` now accept `(restrict_sql,
+  restrict_params)` instead of a `restrict: list | None`; the main query in `work()`
+  calls `scope.restrict_in("c.source_id")` directly.
+- `search.py` — `_build_scope` now accepts the full `Scope` object; when
+  `temp_table` is set it returns subquery strings (not Python lists) for each source
+  kind.  `_scope_clause` was extended to accept string values (treated as subquery
+  SQL) alongside the existing `list[int] | None` values.
+
+**Why.** The fix keeps the match set inside SQLite across the entire request
+lifecycle.  No large Python list is ever built; no large bind-parameter list is ever
+sent to the engine.  The temp table is `PRIMARY KEY`-indexed so joining against it is
+O(log n) per chunk row.  The connection lifetime is the natural cleanup boundary —
+the table is dropped implicitly when the connection closes (one per skill invocation).
+
+**Why not a threshold / lazy approach.** A threshold (switch to temp table only above
+N ids) would leave the edge case untested on small corpora and require maintaining two
+code paths.  Always using the temp table for any `--file-like` invocation is simpler
+and consistent.
+
+**Touched files.** `bartleby/skill_scripts/_tags.py`, `scan.py`, `search.py`;
+`tests/test_skill_file_like_highcard.py` (new, 33k-document regression fixture).

--- a/tests/test_skill_file_like_highcard.py
+++ b/tests/test_skill_file_like_highcard.py
@@ -1,0 +1,143 @@
+"""High-cardinality --file-like regression test for issue #632.
+
+Before the fix, a broad --file-like glob that matched >32,766 documents
+crashed search, scan, AND list_documents with "too many SQL variables" because
+the matched ids were materialized as an IN (?, ?, ...) bind list that exceeded
+SQLite's SQLITE_MAX_VARIABLE_NUMBER limit (32,766 on this build).
+
+The fix materializes the match set into a temp table (_scope_file_like) inside
+SQLite and has all three consumers join against it instead.
+
+This test creates 33,000 documents so the file-like match set exceeds the cap,
+then asserts that all three commands return (not crash) the correct results.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import bartleby.project
+from bartleby.db.chunks import ChunkInput, insert_document_chunks
+from bartleby.db.connection import open_db
+from bartleby.skill_scripts import list_documents, scan, search
+from tests._skill_fixtures import _emb, mock_embed, project_env  # noqa: F401
+
+
+# One more than SQLITE_MAX_VARIABLE_NUMBER (32,766) so a naive IN-list would crash.
+_HIGHCARD_COUNT = 33_000
+_PATTERN = "hc_doc_%"
+_MARKER = "highcard unique marker phrase"
+
+
+@pytest.fixture
+def highcard_project(project_env):  # noqa: F811
+    """A project with 33,000 matching documents and 1 non-matching document.
+
+    All 33k documents share a filename prefix ``hc_doc_`` and contain a unique
+    marker phrase. One extra document (``other_doc.txt``) does NOT match the
+    pattern, to verify the scope excludes it.
+    """
+    conn = open_db(project_env)
+    try:
+        cur = conn.cursor()
+
+        # Bulk-insert 33k documents without chunks — we only need them for the
+        # scope/filter path, not for FTS matches. One chunk per doc keeps the
+        # test honest for scan (FTS must find something) without being slow.
+        rows = [
+            (f"h{i:07d}", f"hc_doc_{i:07d}.txt", f"/tmp/hc_doc_{i:07d}.txt", 1, 50)
+            for i in range(_HIGHCARD_COUNT)
+        ]
+        cur.executemany(
+            "INSERT INTO documents (file_hash, file_name, file_path, page_count, token_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows,
+        )
+        # Fetch the first inserted id to compute the range.
+        first_id = conn.last_insert_rowid() - _HIGHCARD_COUNT + 1
+        doc_ids = list(range(first_id, first_id + _HIGHCARD_COUNT))
+
+        # One chunk per doc — content contains the marker so scan can find it.
+        insert_document_chunks(conn, doc_ids[0], [
+            ChunkInput(
+                text=_MARKER,
+                embedding=_emb(0.0),
+                chunk_index=0,
+            ),
+        ])
+
+        # One document that does NOT match the pattern — control for exclusion.
+        cur.execute(
+            "INSERT INTO documents (file_hash, file_name, file_path, page_count, token_count) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("other_hash", "other_doc.txt", "/tmp/other_doc.txt", 1, 20),
+        )
+        other_id = conn.last_insert_rowid()
+    finally:
+        conn.close()
+
+    return {
+        "project": project_env,
+        "doc_ids": doc_ids,
+        "other_id": other_id,
+    }
+
+
+def _run_list(project, extra_args):
+    list_documents.main(["--project", project, *extra_args])
+
+
+def _run_scan(project, extra_args):
+    scan.main(["--project", project, *extra_args])
+
+
+def _run_search(project, extra_args):
+    search.main(["--project", project, *extra_args])
+
+
+def test_file_like_highcard_list_documents(highcard_project, capsys):
+    """list_documents --file-like with >32,766 matches must not crash."""
+    _run_list(highcard_project["project"], ["--file-like", _PATTERN, "--limit", "10"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == _HIGHCARD_COUNT
+    assert len(out["documents"]) == 10
+    assert out["filters"]["file_like"] == [_PATTERN]
+
+
+def test_file_like_highcard_scan(highcard_project, capsys):
+    """scan --file-like with >32,766 matches must not crash."""
+    _run_scan(
+        highcard_project["project"],
+        [_MARKER, "--file-like", _PATTERN, "--limit", "5"],
+    )
+    out = json.loads(capsys.readouterr().out)
+    # Exactly one doc has the marker chunk — the scope must not widen.
+    assert out["total"] == 1
+    assert out["filters"]["file_like"] == [_PATTERN]
+
+
+def test_file_like_highcard_search(highcard_project, capsys):
+    """search --file-like with >32,766 matches must not crash."""
+    _run_search(
+        highcard_project["project"],
+        [_MARKER, "--file-like", _PATTERN, "--limit", "5", "--full-text"],
+    )
+    out = json.loads(capsys.readouterr().out)
+    assert out["filters"]["file_like"] == [_PATTERN]
+    # Exactly one doc has the marker chunk; the non-matching doc must be absent.
+    assert len(out["results"]) >= 1
+    result_source_ids = [r["source_id"] for r in out["results"]]
+    assert f"document:{highcard_project['other_id']}" not in result_source_ids
+
+
+def test_file_like_highcard_excludes_nonmatching(highcard_project, capsys):
+    """The non-matching document must not appear when --file-like is active."""
+    _run_list(
+        highcard_project["project"],
+        ["--file-like", _PATTERN, "--limit", str(_HIGHCARD_COUNT + 1)],
+    )
+    out = json.loads(capsys.readouterr().out)
+    returned_ids = [int(d["id"].split(":")[1]) for d in out["documents"]]
+    assert highcard_project["other_id"] not in returned_ids


### PR DESCRIPTION
## Summary

- **Bug fixed:** `search`, `scan`, and `list_documents` crashed with `too many SQL variables` when `--file-like` matched more than 32,766 documents (SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit).
- **Fix:** `resolve_scope` now materialises the file-like match set — intersected with `--in-documents`, `--tag`, and date bounds — into a SQLite temp table (`_scope_file_like`) instead of a Python list. All three consumers receive a subquery predicate against the temp table rather than a bind-parameter `IN (?, ?, …)` list of arbitrary length.
- **Scope of change:** The fix is in `resolve_scope` / `Scope` (`_tags.py`), with three consumer-side updates: `list_documents` picks it up automatically via `Scope.restrict_in`; `scan._count_match` and `scan._build_diagnosis` were refactored to accept `(restrict_sql, restrict_params)` instead of a raw list; `search._build_scope` and `_scope_clause` were updated to accept and emit subquery strings when `temp_table` is set.
- **Decision file:** `docs/decisions/GH-0632-file-like-temp-table-0001.md`

## Test

`tests/test_skill_file_like_highcard.py` — new fixture with **33,000 documents** (one more than `SQLITE_MAX_VARIABLE_NUMBER = 32,766`). Four tests exercise the three commands and verify: (1) `list_documents` returns the correct total and subset; (2) `scan` finds the one document with the marker chunk; (3) `search` returns results without the non-matching document; (4) the non-matching document is absent from `list_documents` results.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)