### PR TITLE
fix(web): constrain report title/meta/dek width to align with margin-note gutter

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -684,12 +684,16 @@ input[type="number"] {
   grid-template-columns: minmax(0, 54rem) minmax(0, 1fr);
 }
 
-/* Shared cap: the title, meta line, and dek should not bleed past the right
-   edge of the .ledger-column block (prose 36rem + gap 1.5rem + notes 14rem).
-   Defined once here; the three header selectors below all reference it so the
-   three values and .ledger-column's grid can't drift apart. */
+/* The ledger column's track widths, defined once. .ledger-column's grid and the
+   header cap below both reference these, so the two can't drift apart. The cap
+   keeps the title, meta line, and dek from bleeding past the right edge of the
+   prose + gap + note-gutter block. */
 .ledger {
-  --ledger-content-width: calc(36rem + var(--space-xl) + 14rem);
+  --ledger-prose-width: 36rem;
+  --ledger-notes-width: 14rem;
+  --ledger-content-width: calc(
+    var(--ledger-prose-width) + var(--space-xl) + var(--ledger-notes-width)
+  );
 }
 
 /* --- Hed + dek: Iosevka chrome, not serif --- */
@@ -723,7 +727,7 @@ input[type="number"] {
 .ledger-column {
   display: grid;
   /* ~62–66 characters at the body serif size, then the margin-note gutter. */
-  grid-template-columns: minmax(0, 36rem) minmax(0, 14rem);
+  grid-template-columns: minmax(0, var(--ledger-prose-width)) minmax(0, var(--ledger-notes-width));
   gap: var(--space-xl);
   align-items: start;
   margin: var(--space-xl) 0;

--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -684,11 +684,24 @@ input[type="number"] {
   grid-template-columns: minmax(0, 54rem) minmax(0, 1fr);
 }
 
+/* Shared cap: the title, meta line, and dek should not bleed past the right
+   edge of the .ledger-column block (prose 36rem + gap 1.5rem + notes 14rem).
+   Defined once here; the three header selectors below all reference it so the
+   three values and .ledger-column's grid can't drift apart. */
+.ledger {
+  --ledger-content-width: calc(36rem + var(--space-xl) + 14rem);
+}
+
 /* --- Hed + dek: Iosevka chrome, not serif --- */
 .ledger-hed {
   font-family: var(--font-sans);
   font-weight: 700;
   letter-spacing: -0.01em;
+  max-width: var(--ledger-content-width);
+}
+/* Meta line: same right-edge cap as the hed and dek. */
+.ledger .meta {
+  max-width: var(--ledger-content-width);
 }
 .ledger-dek {
   font-family: var(--font-sans);
@@ -698,6 +711,7 @@ input[type="number"] {
   font-feature-settings: "lnum" 1;
   color: var(--color-text-soft);
   margin-bottom: var(--space-lg);
+  max-width: var(--ledger-content-width);
 }
 /* The shared `.split .desc` rule italicises + serif-spaces the dek; the ledger
    overrides that to plain Iosevka. (Equal-ish specificity — pin it here.) */


### PR DESCRIPTION
## Summary

- Before: `.ledger-hed`, `.meta`, and `.ledger-dek` on the finding/report page filled the full 54rem report column, so the title's right edge bled 2.5rem past the right edge of the prose+notes block.
- After: all three elements share a `--ledger-content-width` custom property (`calc(36rem + var(--space-xl) + 14rem)` = 51.5rem), applied as `max-width`. The title, meta line, and dek now share one consistent right boundary with the margin-note gutter.

**Right-edge arithmetic:**
- `.ledger-column` grid: 36rem prose + 1.5rem (`--space-xl`) gap + 14rem notes = **51.5rem**
- `.ledger-hed` (before): max 54rem — overshot by 2.5rem
- `.ledger-hed` (after): max 51.5rem via `--ledger-content-width` — aligned

**Narrow breakpoint (`max-width: 56rem`):** No regression. At that breakpoint `.ledger-column` collapses to `minmax(0, 1fr)`, so the viewport is ≤56rem. The `max-width: 51.5rem` cap is an upper bound — it won't be hit on a screen narrower than it, and it doesn't fight the single-column reflow.

## Test plan

- [x] `uv run pytest` — 1202 passed, 2 skipped, 0 failures
- [ ] Visual check: on wide viewport, title/meta/dek right edge aligns with the right edge of the margin-note gutter column
- [ ] Visual check: on narrow viewport (≤56rem), layout still stacks cleanly

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)