### PR TITLE
fix(deps): bump sqlite-vec floor to >=0.1.9 for correct aarch64 wheel (#652)

### DIFF
--- a/docs/decisions/GH-0652-sqlite-vec-aarch64-floor-0001.md
+++ b/docs/decisions/GH-0652-sqlite-vec-aarch64-floor-0001.md
@@ -1,0 +1,5 @@
+# sqlite-vec floor bumped to >=0.1.9 for correct aarch64 wheel (issue #652)
+
+> Source: [#652](https://github.com/jswest/bartleby/issues/652)
+
+On aarch64, the `sqlite-vec==0.1.6` wheel on PyPI installs a 32-bit (`ELFCLASS32`) `vec0.so` shared library. When `apsw` tries to load it as a SQLite extension it refuses with `apsw.ExtensionLoadingError: … wrong ELF class: ELFCLASS32`, which errors every test that opens a corpus DB. This is a packaging defect in the 0.1.6 aarch64 wheel — the upstream project shipped a 32-bit artifact for a 64-bit platform target. `sqlite-vec==0.1.9` corrects this: its aarch64 wheel contains a properly built 64-bit `vec0.so` that `apsw` loads without error. The fix is a one-line floor bump in `pyproject.toml` (`sqlite-vec>=0.1.6` → `>=0.1.9`) plus a minimal `uv lock --upgrade-package sqlite-vec` relock. No query logic, schema, runtime behavior, or API surface changed; the only effect is that `uv sync` now resolves to a wheel whose extension binary matches the host architecture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "rich>=14.2.0",
     "sentence-transformers>=5.1.2",
-    "sqlite-vec>=0.1.6",
+    "sqlite-vec>=0.1.9",
     "tiktoken>=0.12.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "sec2md", marker = "extra == 'sec2md'", specifier = "==0.1.22" },
     { name = "sentence-transformers", specifier = ">=5.1.2" },
-    { name = "sqlite-vec", specifier = ">=0.1.6" },
+    { name = "sqlite-vec", specifier = ">=0.1.9" },
     { name = "tiktoken", specifier = ">=0.12.0" },
 ]
 provides-extras = ["docling", "sec2md"]
@@ -2930,14 +2930,14 @@ wheels = [
 
 [[package]]
 name = "sqlite-vec"
-version = "0.1.6"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ed/aabc328f29ee6814033d008ec43e44f2c595447d9cccd5f2aabe60df2933/sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3", size = 164075, upload-time = "2024-11-20T16:40:29.847Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/57/05604e509a129b22e303758bfa062c19afb020557d5e19b008c64016704e/sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361", size = 165242, upload-time = "2024-11-20T16:40:31.206Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/48/dbb2cc4e5bad88c89c7bb296e2d0a8df58aab9edc75853728c361eefc24f/sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3", size = 103704, upload-time = "2024-11-20T16:40:33.729Z" },
-    { url = "https://files.pythonhosted.org/packages/80/76/97f33b1a2446f6ae55e59b33869bed4eafaf59b7f4c662c8d9491b6a714a/sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24", size = 151556, upload-time = "2024-11-20T16:40:35.387Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/98/e8bc58b178266eae2fcf4c9c7a8303a8d41164d781b32d71097924a6bebe/sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c", size = 281540, upload-time = "2024-11-20T16:40:37.296Z" },
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `sqlite-vec==0.1.6` ships a 32-bit (`ELFCLASS32`) `vec0.so` for the aarch64 platform; `apsw` refuses to load it with `ExtensionLoadingError: wrong ELF class: ELFCLASS32`, breaking every test that opens a corpus DB.
- Bumps the dependency floor in `pyproject.toml` from `>=0.1.6` to `>=0.1.9`, which ships a correct 64-bit aarch64 wheel.
- Relocked with `uv lock --upgrade-package sqlite-vec` (minimal diff — only sqlite-vec line changed).
- Test result: **1221 passed, 5 skipped** — no `ExtensionLoadingError` errors.

Part of #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)