### PR TITLE
feat(scan): add regex filter mode to select chunks by body match (#653)

### DIFF
--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -815,6 +815,39 @@ class CaptureSpec:
         }
 
 
+def _compile_slash_regex(value: str, *, flag: str, error_code: str) -> re.Pattern:
+    """Shared prologue: validate ``/regex/`` delimiters and compile.
+
+    Raises ``SkillError(error_code, ...)`` for a missing slash-delimiter or a
+    pattern that doesn't compile.  Both :func:`parse_filter_regex` and
+    :func:`parse_capture_regex` differ only in what they do *after* this step.
+    """
+    if not (len(value) >= 2 and value.startswith("/") and value.endswith("/")):
+        raise SkillError(
+            error_code,
+            f"{flag} must be a /regex/ delimited by slashes; got {value!r}.",
+        )
+    try:
+        return re.compile(value[1:-1])
+    except re.error as exc:
+        raise SkillError(
+            error_code,
+            f"{flag} regex {value!r} does not compile: {exc}.",
+        )
+
+
+def parse_filter_regex(value: str, *, flag: str) -> re.Pattern:
+    """Parse a ``/regex/`` filter pattern into a compiled :class:`re.Pattern`.
+
+    The selector sibling of :func:`parse_capture_regex`: a ``/.../``-delimited
+    pattern with no capture-group requirement.  Used by ``scan --body-matches``
+    to post-filter FTS5 chunks by body text.  Raises (as the JSON error envelope):
+
+    - ``INVALID_FILTER_REGEX`` — not ``/.../``-delimited, or doesn't compile.
+    """
+    return _compile_slash_regex(value, flag=flag, error_code="INVALID_FILTER_REGEX")
+
+
 def parse_capture_regex(value: str, *, flag: str) -> CaptureSpec:
     """Parse a ``/regex/`` capture pattern into a :class:`CaptureSpec`.
 
@@ -827,19 +860,7 @@ def parse_capture_regex(value: str, *, flag: str) -> CaptureSpec:
     - ``CAPTURE_NO_GROUP`` — compiles but carries no capture group (nothing to
       project into a column).
     """
-    if not (len(value) >= 2 and value.startswith("/") and value.endswith("/")):
-        raise SkillError(
-            "INVALID_CAPTURE_REGEX",
-            f"{flag} must be a /regex/ delimited by slashes; got {value!r}.",
-        )
-    pattern_src = value[1:-1]
-    try:
-        compiled = re.compile(pattern_src)
-    except re.error as exc:
-        raise SkillError(
-            "INVALID_CAPTURE_REGEX",
-            f"{flag} regex {value!r} does not compile: {exc}.",
-        )
+    compiled = _compile_slash_regex(value, flag=flag, error_code="INVALID_CAPTURE_REGEX")
     if compiled.groups < 1:
         raise SkillError(
             "CAPTURE_NO_GROUP",

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -218,6 +218,30 @@ Zero-result diagnosis:
     real matches — where ``total`` is still > 0 — carries no diagnosis: there
     are matches, just not on this page.
 
+``--body-matches '/regex/'`` adds a **regex filter** that selects only chunks
+whose body text matches the given ``/pattern/`` (Python ``re.search``). It
+acts as the locator: the FTS query narrows to the token-matching chunks, then
+``--body-matches`` post-filters to those where the regex holds. Use it when
+the target is literal punctuation (``5376``, ``$``, ``H.R. 815``) that FTS5's
+tokenizer treats as a boundary and cannot phrase-match. Pairs naturally with
+``--extract`` — filter to locate, extract to project. The regex must be
+``/.../'``-delimited but carries **no capture group** (it is a selector, not a
+projector — use ``--extract`` for captures). Composes with all scope flags.
+Performance: O(n) over FTS5 matches (not all chunks); acceptable for a filter
+primitive, but avoid very broad regexes on very large match sets.
+
+Output shape with ``--body-matches``:
+
+    {
+      "query": str,
+      "match_mode": "phrase" | "terms",
+      "body_matches": "/regex/",    # the pattern as passed
+      "offset": int, "limit": int, "total": int,
+      "preview": int,
+      "filters": {...},             # same as without; body_matches echoed above
+      ...
+    }
+
 Scope (both modes): ``--in-documents`` and ``--tag`` (repeatable, OR
 semantics) scope the match the same way they do in ``search``; combined they
 intersect. ``--file-like <pattern>`` (SQL ``LIKE``, repeatable for OR) keeps
@@ -245,7 +269,7 @@ from collections import Counter
 from bartleby.skill_runner import SkillError, build_arg_parser, run
 from bartleby.skill_scripts._common import (
     CaptureSpec, add_date_filter_args, add_file_like_arg, add_returning_arg,
-    apply_preview, nonneg_int, parse_capture_regex,
+    apply_preview, nonneg_int, parse_capture_regex, parse_filter_regex,
     positive_int, project_row, text_qualified_fts, validate_returning,
 )
 from bartleby.skill_scripts._ids import format_output_ids, prefixed_int_list
@@ -309,6 +333,21 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
             "pattern (%% = any run, _ = one char), e.g. '2023 Q%%'. Repeat for "
             "OR; the group ANDs with --tag / --in-documents / --file-like / "
             "date bounds. Chunks with no heading never match."
+        ),
+    )
+    p.add_argument(
+        "--body-matches",
+        default=None,
+        dest="body_matches",
+        metavar="/regex/",
+        help=(
+            "Post-filter: keep only chunks whose body text matches this regex "
+            "(/pattern/ delimited by slashes, Python re.search). Acts as the "
+            "locator when FTS phrase-matching is blocked by punctuation — e.g. "
+            "'--body-matches /5376/' or '--body-matches /H\\.R\\.\\s*815/'. "
+            "No capture group required (use --extract for captures). Composes "
+            "with all scope flags. Performance: O(n) over FTS5 matches, not all "
+            "chunks; acceptable for a filter primitive."
         ),
     )
     p.add_argument(
@@ -664,6 +703,9 @@ def work(*, conn, args, session_id) -> dict:
         raise SkillError("EMPTY_QUERY", "Query must be non-empty.")
 
     match_mode = "terms" if args.match_terms else "phrase"
+    body_filter = None
+    if args.body_matches is not None:
+        body_filter = parse_filter_regex(args.body_matches, flag="--body-matches")
     count_mode, count_regex = (None, None)
     if args.count_by is not None:
         count_mode, count_regex = _parse_count_by(args.count_by)
@@ -690,7 +732,10 @@ def work(*, conn, args, session_id) -> dict:
     restrict_sql, restrict_params = scope.restrict_in("c.source_id")
 
     def _envelope(extra: dict) -> dict:
-        env = scope.echo_into({"query": args.query, "match_mode": match_mode, **extra})
+        base = {"query": args.query, "match_mode": match_mode}
+        if body_filter is not None:
+            base["body_matches"] = args.body_matches
+        env = scope.echo_into({**base, **extra})
         if args.heading_like:
             # --heading-like is a chunk-level filter, so it lives outside Scope's
             # document-level echo; fold it into the same filters object (creating
@@ -743,23 +788,20 @@ def work(*, conn, args, session_id) -> dict:
                 "offset": args.offset, "limit": args.limit, "total": 0,
                 "columns": extract_columns, "rows": [],
             }))
-        total = _count_total(cur, where, params)
+        # Walk all FTS5 matches in memory (needed for the deadline guard anyway)
+        # and filter by body_filter when active; the list gives an honest total.
+        all_extract_rows = [
+            (chunk_id, source_id, file_name, text)
+            for chunk_id, source_id, file_name, text in _scan_chunk_texts(
+                cur, where, params, "--extract regex"
+            )
+            if body_filter is None or body_filter.search(text)
+        ]
+        total = len(all_extract_rows)
+        page = all_extract_rows[args.offset : args.offset + args.limit]
         rows_out = []
-        page_end = args.offset + args.limit
-        for i, (chunk_id, source_id, file_name, text) in enumerate(
-            _scan_chunk_texts(cur, where, params, "--extract regex")
-        ):
-            # Page in Python over the deterministic scan order — the spec walk is
-            # already a full read for the deadline; slicing here keeps one path.
-            if i < args.offset:
-                continue
-            if i >= page_end:
-                break
-            row = {
-                "chunk_id": chunk_id,
-                "document_id": source_id,
-                "file_name": file_name,
-            }
+        for chunk_id, source_id, file_name, text in page:
+            row = {"chunk_id": chunk_id, "document_id": source_id, "file_name": file_name}
             for spec in extract_specs:
                 row.update(spec.extract_first(text))
             rows_out.append(row)
@@ -843,34 +885,61 @@ def work(*, conn, args, session_id) -> dict:
     # Default mode: paginated per-chunk matches.
     validate_returning(args.returning, MATCH_FIELDS)
     preview = args.preview if args.preview is not None else DEFAULT_PREVIEW
-    total = 0 if no_match else _count_total(cur, where, params)
+
+    if body_filter is not None and not no_match:
+        # --body-matches is a Python post-filter over FTS5 matches: we walk all
+        # FTS5-matching chunks in sort order, filter by regex, and page manually.
+        # This gives an honest total (the pre-pagination count of regex-matching
+        # chunks) without a second SQL pass. O(n) over FTS5 matches, not all
+        # chunks — FTS5 pre-narrows the set before the regex fires.
+        all_rows = list(cur.execute(
+            f"SELECT c.chunk_id, c.source_id, c.chunk_index, c.section_heading, "
+            f"       c.page_number, c.content_type, c.text, d.file_name, "
+            f"       s.authored_date "
+            f"FROM chunks_fts "
+            f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
+            f"JOIN documents d ON d.document_id = c.source_id "
+            f"LEFT JOIN summaries s ON s.document_id = c.source_id "
+            f"WHERE {where} "
+            f"ORDER BY {_CHUNK_ORDER_BY[args.sort]}",
+            params,
+        ))
+        filtered = [row for row in all_rows if body_filter.search(row[6])]
+        total = len(filtered)
+        page_rows = filtered[args.offset : args.offset + args.limit]
+    else:
+        total = 0 if no_match else _count_total(cur, where, params)
+        page_rows = None  # signal to use SQL-paginated fetch below
+
     if total == 0:
         return _with_diagnosis(_envelope({
             "offset": args.offset, "limit": args.limit, "total": 0,
             "preview": preview, "matches": [],
         }))
 
-    # authored_date rides the summaries LEFT JOIN that --sort date already needs —
-    # the canonical summarizer-inferred date that list_documents and the date
-    # filters use — so it costs no extra query and is NULL for undated docs (no
-    # summary, or a summary with no inferred date).
-    rows = cur.execute(
-        f"SELECT c.chunk_id, c.source_id, c.chunk_index, c.section_heading, "
-        f"       c.page_number, c.content_type, c.text, d.file_name, "
-        f"       s.authored_date "
-        f"FROM chunks_fts "
-        f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
-        f"JOIN documents d ON d.document_id = c.source_id "
-        f"LEFT JOIN summaries s ON s.document_id = c.source_id "
-        f"WHERE {where} "
-        f"ORDER BY {_CHUNK_ORDER_BY[args.sort]} "
-        f"LIMIT ? OFFSET ?",
-        [*params, args.limit, args.offset],
-    )
+    if page_rows is None:
+        # Standard SQL-paginated fetch (no --body-matches active).
+        # authored_date rides the summaries LEFT JOIN that --sort date already needs —
+        # the canonical summarizer-inferred date that list_documents and the date
+        # filters use — so it costs no extra query and is NULL for undated docs (no
+        # summary, or a summary with no inferred date).
+        page_rows = list(cur.execute(
+            f"SELECT c.chunk_id, c.source_id, c.chunk_index, c.section_heading, "
+            f"       c.page_number, c.content_type, c.text, d.file_name, "
+            f"       s.authored_date "
+            f"FROM chunks_fts "
+            f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
+            f"JOIN documents d ON d.document_id = c.source_id "
+            f"LEFT JOIN summaries s ON s.document_id = c.source_id "
+            f"WHERE {where} "
+            f"ORDER BY {_CHUNK_ORDER_BY[args.sort]} "
+            f"LIMIT ? OFFSET ?",
+            [*params, args.limit, args.offset],
+        ))
 
     matches = []
     for (chunk_id, source_id, chunk_index, section_heading,
-         page_number, content_type, text, file_name, authored_date) in rows:
+         page_number, content_type, text, file_name, authored_date) in page_rows:
         # The full whitelisted row, built once. --returning projects from it;
         # otherwise --brief / default shape it (and only then is text truncated).
         full = {

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -238,7 +238,7 @@ Output shape with ``--body-matches``:
       "body_matches": "/regex/",    # the pattern as passed
       "offset": int, "limit": int, "total": int,
       "preview": int,
-      "filters": {...},             # same as without; body_matches echoed above
+      "filters": {...},             # scope filters only; body_matches is top-level
       ...
     }
 
@@ -341,13 +341,11 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         dest="body_matches",
         metavar="/regex/",
         help=(
-            "Post-filter: keep only chunks whose body text matches this regex "
-            "(/pattern/ delimited by slashes, Python re.search). Acts as the "
-            "locator when FTS phrase-matching is blocked by punctuation — e.g. "
-            "'--body-matches /5376/' or '--body-matches /H\\.R\\.\\s*815/'. "
-            "No capture group required (use --extract for captures). Composes "
-            "with all scope flags. Performance: O(n) over FTS5 matches, not all "
-            "chunks; acceptable for a filter primitive."
+            "Post-filter: keep only chunks whose body text matches this /regex/ "
+            "(slash-delimited, Python re.search). Acts as the locator when FTS "
+            "phrase-matching is blocked by punctuation — e.g. '--body-matches "
+            "/5376/' or '--body-matches /H\\.R\\.\\s*815/'. No capture group "
+            "required (use --extract for captures). Composes with all scope flags."
         ),
     )
     p.add_argument(
@@ -886,56 +884,41 @@ def work(*, conn, args, session_id) -> dict:
     validate_returning(args.returning, MATCH_FIELDS)
     preview = args.preview if args.preview is not None else DEFAULT_PREVIEW
 
+    # The page query is shared; --body-matches only changes how we paginate it.
+    # authored_date rides the summaries LEFT JOIN that --sort date already needs —
+    # the canonical summarizer-inferred date that list_documents and the date
+    # filters use — so it costs no extra query and is NULL for undated docs.
+    base_sql = (
+        f"SELECT c.chunk_id, c.source_id, c.chunk_index, c.section_heading, "
+        f"       c.page_number, c.content_type, c.text, d.file_name, "
+        f"       s.authored_date "
+        f"FROM chunks_fts "
+        f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
+        f"JOIN documents d ON d.document_id = c.source_id "
+        f"LEFT JOIN summaries s ON s.document_id = c.source_id "
+        f"WHERE {where} "
+        f"ORDER BY {_CHUNK_ORDER_BY[args.sort]}"
+    )
+
     if body_filter is not None and not no_match:
-        # --body-matches is a Python post-filter over FTS5 matches: we walk all
-        # FTS5-matching chunks in sort order, filter by regex, and page manually.
-        # This gives an honest total (the pre-pagination count of regex-matching
-        # chunks) without a second SQL pass. O(n) over FTS5 matches, not all
-        # chunks — FTS5 pre-narrows the set before the regex fires.
-        all_rows = list(cur.execute(
-            f"SELECT c.chunk_id, c.source_id, c.chunk_index, c.section_heading, "
-            f"       c.page_number, c.content_type, c.text, d.file_name, "
-            f"       s.authored_date "
-            f"FROM chunks_fts "
-            f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
-            f"JOIN documents d ON d.document_id = c.source_id "
-            f"LEFT JOIN summaries s ON s.document_id = c.source_id "
-            f"WHERE {where} "
-            f"ORDER BY {_CHUNK_ORDER_BY[args.sort]}",
-            params,
-        ))
-        filtered = [row for row in all_rows if body_filter.search(row[6])]
+        # --body-matches is a Python post-filter over FTS5 matches: walk every
+        # FTS5-matching chunk in sort order, filter by regex, page manually. This
+        # gives an honest total (the pre-pagination count of regex-matching chunks)
+        # with no second SQL pass. O(n) over FTS5 matches — FTS5 narrows first.
+        filtered = [r for r in cur.execute(base_sql, params) if body_filter.search(r[6])]
         total = len(filtered)
         page_rows = filtered[args.offset : args.offset + args.limit]
     else:
         total = 0 if no_match else _count_total(cur, where, params)
-        page_rows = None  # signal to use SQL-paginated fetch below
+        page_rows = [] if total == 0 else list(cur.execute(
+            base_sql + " LIMIT ? OFFSET ?", [*params, args.limit, args.offset]
+        ))
 
     if total == 0:
         return _with_diagnosis(_envelope({
             "offset": args.offset, "limit": args.limit, "total": 0,
             "preview": preview, "matches": [],
         }))
-
-    if page_rows is None:
-        # Standard SQL-paginated fetch (no --body-matches active).
-        # authored_date rides the summaries LEFT JOIN that --sort date already needs —
-        # the canonical summarizer-inferred date that list_documents and the date
-        # filters use — so it costs no extra query and is NULL for undated docs (no
-        # summary, or a summary with no inferred date).
-        page_rows = list(cur.execute(
-            f"SELECT c.chunk_id, c.source_id, c.chunk_index, c.section_heading, "
-            f"       c.page_number, c.content_type, c.text, d.file_name, "
-            f"       s.authored_date "
-            f"FROM chunks_fts "
-            f"JOIN chunks c ON c.chunk_id = chunks_fts.rowid "
-            f"JOIN documents d ON d.document_id = c.source_id "
-            f"LEFT JOIN summaries s ON s.document_id = c.source_id "
-            f"WHERE {where} "
-            f"ORDER BY {_CHUNK_ORDER_BY[args.sort]} "
-            f"LIMIT ? OFFSET ?",
-            [*params, args.limit, args.offset],
-        ))
 
     matches = []
     for (chunk_id, source_id, chunk_index, section_heading,

--- a/docs/decisions/GH-0653-scan-regex-filter-0001.md
+++ b/docs/decisions/GH-0653-scan-regex-filter-0001.md
@@ -1,0 +1,40 @@
+# `scan --body-matches` — first-class regex filter mode (issue #653)
+
+> Source: [#653](https://github.com/jswest/bartleby/issues/653)
+
+## Problem
+
+FTS5 phrase queries treat punctuation as a token boundary, so bare tokens like `5376`, `$120,000`, or `H.R. 815` match nothing via `scan "H.R. 815"`. The existing `--extract '/regex/'` can project captures from chunks already located by an FTS query, but it cannot *locate* chunks — it's a projector, not a selector.
+
+## Flag
+
+`--body-matches '/regex/'` — a `/pattern/`-delimited Python `re.search` filter that selects only chunks whose body text matches. No capture group required (it's a selector, not a projector; use `--extract` for captures). Example:
+
+```
+scan "Income" --body-matches '/\$[\d,]+/' --extract '/\$([\d,]+)/'
+```
+
+## Design choice: Python post-filter, not registered SQL `regexp` function
+
+Two options were considered:
+
+1. **Register a scalar `regexp(pattern, text)` function on the apsw connection** (in `_attach` in `connection.py`) and push the filter into the SQL `WHERE` clause.
+2. **Python post-filter** over the FTS5 result set.
+
+Chose **Python post-filter** for these reasons:
+
+- **No connection.py change.** Adding a scalar to `_attach` would run for every connection open (read paths, ingest, the web UI), not just `scan`. The filter is an agent-supplied pattern that only `scan` needs; coupling it to the connection setup leaks scope.
+- **Simpler total accounting.** An honest `total` (pre-pagination count of regex-matching chunks) requires counting the filtered set. With a SQL `regexp` in `WHERE`, a second `SELECT COUNT(*)` would be needed. With the Python walk, the list comprehension materializes the full filtered result set once, `len()` gives the total, and a slice gives the page — one pass, no extra query.
+- **FTS5 pre-filters first.** The regex fires on FTS5-matched chunks only, not all chunks, so the O(n) cost is proportional to the FTS match set size — the same size that `--count-by '/regex/'` and `--extract` already walk.
+
+## Performance trade-off
+
+O(n) over the FTS5 match set (not the whole corpus). For a broad FTS query on a large corpus this materializes all matching chunk texts in memory before slicing the page. Acceptable for a filter primitive (the issue explicitly notes this); the existing `--extract` and `--count-by '/regex/'` modes have the same profile. The `--body-matches` path does **not** apply the `CAPTURE_DEADLINE_SECONDS` / `CAPTURE_MAX_MATCHES` guards (those guard the regex-*capture* modes against runaway patterns; a `re.search` selector is cheaper — one boolean per chunk, no iteration inside the match). Very broad patterns on very large match sets are the user's footgun to manage.
+
+## Composition
+
+Composes with all scope flags (`--in-documents`, `--tag`, `--file-like`, `--heading-like`, `--authored-after/before`) and with `--extract` (filter to locate, extract to project). The `--extract` path was updated to apply `body_filter` inline in the list comprehension that already materializes all rows, keeping one walk with both the deadline guard and the regex check.
+
+## Output shape
+
+`body_matches` is echoed at envelope top-level (alongside `query` / `match_mode`), not inside the `filters` object — it is a matching mode, not a scope filter. `filters` is only present when a scope filter is also active.

--- a/tests/test_skill_scan.py
+++ b/tests/test_skill_scan.py
@@ -1252,3 +1252,129 @@ def test_scan_zero_heading_only_diagnosis(project_env, capsys):  # noqa: F811
     assert diag["verdict"] == "heading_only"
     assert diag["body_corpus_wide"] == 0
     assert diag["heading_corpus_wide"] == 1
+
+
+# --- --body-matches '/regex/' (regex filter mode, issue #653) ----------------
+
+
+def test_scan_body_matches_filters_to_regex_hits(scan_corpus, capsys):
+    """--body-matches keeps only chunks whose body text matches the regex.
+    The FTS query locates marker chunks; the regex sub-selects those containing
+    a specific company name that FTS can't phrase-match (punctuation etc.)."""
+    # MARKER matches chunks in d1 (ACME/BETA) and d2 (GAMMA). The regex
+    # selects only those containing "BETA" or "GAMMA" — not "ACME".
+    _run(scan_corpus, [MARKER, "--body-matches", "/(BETA|GAMMA)/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["body_matches"] == "/(BETA|GAMMA)/"
+    assert out["total"] == 2
+    texts = [m["text"] for m in out["matches"]]
+    assert any("BETA" in t for t in texts)
+    assert any("GAMMA" in t for t in texts)
+    assert not any("ACME CORP" in t for t in texts)
+
+
+def test_scan_body_matches_total_is_honest(scan_corpus, capsys):
+    """--body-matches total reflects post-filter count, not FTS count."""
+    # Without --body-matches: total=3 (three MARKER chunks).
+    _run(scan_corpus, [MARKER])
+    assert json.loads(capsys.readouterr().out)["total"] == 3
+
+    # With --body-matches limiting to one company: total=1.
+    _run(scan_corpus, [MARKER, "--body-matches", "/GAMMA/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 1
+    assert len(out["matches"]) == 1
+
+
+def test_scan_body_matches_pagination_stable(scan_corpus, capsys):
+    """Pagination over --body-matches uses the filtered total as the base."""
+    # MARKER + body_matches "/(BETA|GAMMA)/" → 2 matching chunks.
+    _run(scan_corpus, [MARKER, "--body-matches", "/(BETA|GAMMA)/",
+                       "--limit", "1", "--offset", "0"])
+    p1 = json.loads(capsys.readouterr().out)
+    assert p1["total"] == 2
+    assert len(p1["matches"]) == 1
+
+    _run(scan_corpus, [MARKER, "--body-matches", "/(BETA|GAMMA)/",
+                       "--limit", "1", "--offset", "1"])
+    p2 = json.loads(capsys.readouterr().out)
+    assert p2["total"] == 2
+    assert len(p2["matches"]) == 1
+    # The two pages cover different chunks.
+    assert p1["matches"][0]["chunk_id"] != p2["matches"][0]["chunk_id"]
+
+
+def test_scan_body_matches_no_regex_match_is_zero(scan_corpus, capsys):
+    """A regex that matches no chunk body → total=0, diagnosis attached."""
+    _run(scan_corpus, [MARKER, "--body-matches", "/XYZZY_IMPOSSIBLE/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 0
+    assert out["matches"] == []
+    # Diagnosis fires on the zero path.
+    assert "diagnosis" in out
+
+
+def test_scan_body_matches_composes_with_scope(scan_corpus, capsys):
+    """--body-matches ANDs with --tag scope: scope first, then regex."""
+    # Only d2 carries the 'senate' tag, and its chunk contains GAMMA.
+    _run(scan_corpus, [MARKER, "--tag", "senate", "--body-matches", "/GAMMA/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 1
+    assert all(m["document_id"] == f"document:{scan_corpus['d2']}" for m in out["matches"])
+    assert out["filters"]["tags"] == ["senate"]
+    assert out["body_matches"] == "/GAMMA/"
+
+
+def test_scan_body_matches_composes_with_file_like(scan_corpus, capsys):
+    """--body-matches composes with --file-like."""
+    _run(scan_corpus, [MARKER, "--file-like", "filing_b%", "--body-matches", "/GAMMA/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 1
+    assert out["matches"][0]["file_name"] == "filing_b.txt"
+
+
+def test_scan_body_matches_composes_with_extract(scan_corpus, capsys):
+    """--body-matches as the locator, --extract as the projector."""
+    # Use body_matches to locate BETA/GAMMA chunks, extract the company name.
+    _run(scan_corpus, [MARKER, "--body-matches", "/(BETA|GAMMA)/",
+                       "--extract", r"/I will divest my interests in (?P<company>\S+)/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 2
+    companies = {r["company"] for r in out["rows"]}
+    assert "BETA" in companies
+    assert "GAMMA" in companies
+
+
+def test_scan_body_matches_invalid_regex_errors(scan_corpus, capsys):
+    """An invalid regex errors cleanly."""
+    with pytest.raises(SystemExit) as exc:
+        _run(scan_corpus, [MARKER, "--body-matches", "/(/"])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "INVALID_FILTER_REGEX"
+
+
+def test_scan_body_matches_not_slash_delimited_errors(scan_corpus, capsys):
+    """A non-slash-delimited --body-matches value errors cleanly."""
+    with pytest.raises(SystemExit) as exc:
+        _run(scan_corpus, [MARKER, "--body-matches", "GAMMA"])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "INVALID_FILTER_REGEX"
+
+
+def test_scan_body_matches_echoed_in_envelope(scan_corpus, capsys):
+    """body_matches is echoed at envelope top-level, not inside filters."""
+    _run(scan_corpus, [MARKER, "--body-matches", "/GAMMA/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["body_matches"] == "/GAMMA/"
+    # filters is absent when no scope filter is active (only body_matches set).
+    assert "filters" not in out
+
+
+def test_scan_body_matches_no_fts_match_is_zero(scan_corpus, capsys):
+    """When FTS itself finds nothing, body_matches has nothing to filter — zero."""
+    _run(scan_corpus, ["phrase that appears nowhere", "--body-matches", "/GAMMA/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["total"] == 0
+    assert out["matches"] == []


### PR DESCRIPTION
## Summary

- Adds `--body-matches '/regex/'` to `scan`: a Python `re.search` post-filter that selects only chunks whose body text matches the regex, acting as the locator when FTS5 phrase-matching is blocked by punctuation (e.g. `$`, `H.R. 815`, bare integers like `5376`).
- Adds `parse_filter_regex()` to `_common.py` (no capture group required, shares the `/.../'`-delimiter + compile prologue with `parse_capture_regex` via the new `_compile_slash_regex` helper).
- Composes with all existing scope flags and with `--extract` (filter to locate, extract to project).
- `body_matches` is echoed at envelope top-level. `total` is the honest post-filter count.
- 11 new tests in `tests/test_skill_scan.py`; all 1232 tests pass.
- Decision file: `docs/decisions/GH-0653-scan-regex-filter-0001.md`.

Part of #656

## Test plan

- [ ] `uv run pytest tests/test_skill_scan.py -q` — 100 passed
- [ ] `uv run pytest -q` — 1232 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)