### PR TITLE
docs(skills): note that --no-memory hides same-session saved findings (#655)

### DIFF
--- a/bartleby/skill_scripts/session.py
+++ b/bartleby/skill_scripts/session.py
@@ -60,7 +60,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     new.add_argument(
         "--no-memory", action="store_true", dest="no_memory",
-        help="Start the run with memory off (blind eval isolation).",
+        help=(
+            "Start the run with memory off (blind eval isolation). "
+            "Note: this also hides findings saved earlier in THIS session — "
+            "a just-saved finding will not appear in search until memory is enabled."
+        ),
     )
     return p.parse_args(argv)
 


### PR DESCRIPTION
Adds a one-line note to the `--no-memory` flag's `--help` text in `session.py` so users know that findings saved in the current session also won't appear in `search` (not just prior-session findings).

No behavior change — help text only.

Part of #656

## Test plan
- [ ] `uv run pytest -q` — 1245 passed, 5 skipped