### PR TITLE
feat(scan): --count-by over document fields (file_name histogram) (#641)

### DIFF
--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -924,6 +924,52 @@ def parse_capture_regex(value: str, *, flag: str) -> CaptureSpec:
     return CaptureSpec(compiled, value)
 
 
+# The only document field supported by ``--count-by field_name:/regex/``.
+# Defined here so the parser and error messages stay in sync.
+_COUNT_BY_FIELD_NAMES = ("file_name",)
+
+
+def parse_field_capture(value: str, *, flag: str) -> "tuple[str, CaptureSpec] | None":
+    """Parse a ``field_name:/regex/`` count-by value into ``(field_name, spec)``.
+
+    Returns ``None`` when ``value`` doesn't match the ``<word>:/regex/`` form (so
+    the caller can try the existing ``/regex/`` body-text path). Raises
+    ``SkillError`` when the prefix is present but the field name is not in the
+    supported set (``file_name`` only), the ``/regex/`` is missing delimiters,
+    doesn't compile, or carries no capture group.
+
+    Supported fields: ``file_name`` (the document's filename column in the
+    ``documents`` table). The field name must be an exact word match before the
+    first ``:``.
+    """
+    colon = value.find(":")
+    if colon < 1:
+        return None
+    prefix = value[:colon]
+    # Must look like a bare word (no slashes, no spaces) — otherwise this is
+    # not a field-prefix form at all (e.g. a plain ``/regex/`` starts with ``/``
+    # not a word).
+    if not prefix.isidentifier():
+        return None
+    rest = value[colon + 1:]
+    # The remainder must look like a /regex/ — if not, this isn't the
+    # field-prefix form; fall back to the existing parser.
+    if not rest.startswith("/"):
+        return None
+    # At this point we're committed: we have ``<word>:/...`` — validate the
+    # field name and parse the regex, raising on error.
+    if prefix not in _COUNT_BY_FIELD_NAMES:
+        raise SkillError(
+            "INVALID_COUNT_BY_FIELD",
+            f"{flag} field {prefix!r} is not supported. "
+            f"Supported fields: {', '.join(_COUNT_BY_FIELD_NAMES)}. "
+            f"Use '{_COUNT_BY_FIELD_NAMES[0]}:/regex/' to histogram by filename.",
+            supported_fields=list(_COUNT_BY_FIELD_NAMES),
+        )
+    spec = parse_capture_regex(rest, flag=flag)
+    return prefix, spec
+
+
 def comma_int_list(label: str) -> Callable[[str], list[int]]:
     """argparse ``type=`` factory for a comma-separated list of ints.
 

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -645,7 +645,6 @@ def _count_by_field(cur, spec: CaptureSpec) -> tuple[Counter, bool]:
     return counter, False
 
 
-
 def _heading_qualified_fts(fts_expr: str) -> str:
     """Column-qualify an FTS5 MATCH expression to the ``section_heading`` column.
 
@@ -894,6 +893,9 @@ def work(*, conn, args, session_id) -> dict:
                 "--returning has no effect on --count-by 'field_name:/regex/' "
                 "output: filename buckets carry no citable id to project.",
             )
+        # Deliberately corpus-wide: the field histogram answers "what's in the
+        # corpus", so it does NOT take the FTS `where`/`params` the other count
+        # modes do — scoping it would silently produce a partial histogram.
         counter, truncated = _count_by_field(cur, count_regex)
         ordered = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
         page = ordered[args.offset : args.offset + args.limit]

--- a/bartleby/skill_scripts/scan.py
+++ b/bartleby/skill_scripts/scan.py
@@ -148,6 +148,38 @@ Count-by capture (``--count-by '/regex/'``):
       ]
     }
 
+Count-by field (``--count-by 'file_name:/regex/'``):
+    Histogram the corpus by a document-level field instead of chunk body text.
+    Pass ``file_name:/regex/`` to apply the capture regex to every document's
+    ``file_name`` column — useful on corpora with structured filenames
+    (member prefixes, date stamps, doc-type codes) where a "docs per prefix"
+    tally is the answer:
+
+        scan "bill" --count-by 'file_name:/^([A-Za-z]+)_/'
+        → buckets: [{"value": "smith", "count": 14}, ...]
+
+    Counting is **per document** (first capture only) — a filename that matches
+    the regex twice still counts once. Buckets sort by count desc then value asc,
+    paginated by ``--limit``/``--offset``; ``--sort`` has no effect. Cannot
+    combine with ``--preview``/``--brief``. Only ``file_name`` is supported as
+    a field name; other fields raise ``INVALID_COUNT_BY_FIELD``.
+
+    Output differs from the body-text bucket envelope to avoid ambiguity:
+
+    {
+      "query": str, "match_mode": "phrase" | "terms",
+      "count_by_field": "file_name",    # the field name
+      "count_by_regex": "/regex/",      # the capture pattern
+      "offset": int, "limit": int,
+      "distinct_value_count": int,
+      "total_match_count": int,
+      "truncated": bool,
+      "buckets": [
+        {"value": str, "count": int}, ...
+      ]
+    }
+
+
 Extract capture table (``--extract '/regex/'``, repeatable):
     The tidy-table sibling of ``--count-by '/regex/'``: instead of folding
     captures into a histogram, return **one row per matching chunk** carrying
@@ -269,7 +301,7 @@ from collections import Counter
 from bartleby.skill_runner import SkillError, build_arg_parser, run
 from bartleby.skill_scripts._common import (
     CaptureSpec, add_date_filter_args, add_file_like_arg, add_returning_arg,
-    apply_preview, nonneg_int, parse_capture_regex, parse_filter_regex,
+    apply_preview, nonneg_int, parse_capture_regex, parse_field_capture, parse_filter_regex,
     positive_int, project_row, text_qualified_fts, validate_returning,
 )
 from bartleby.skill_scripts._ids import format_output_ids, prefixed_int_list
@@ -352,12 +384,14 @@ def parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--count-by",
         default=None,
         dest="count_by",
-        metavar="document|/regex/",
+        metavar="document|/regex/|field_name:/regex/",
         help="Aggregate mode. 'document' returns a per-document hit histogram "
              "(distinct_document_count + total_chunk_count). A /regex/ with a "
              "capture group instead buckets matches by the captured substring "
-             "(distinct_value_count + total_match_count). Cannot be combined "
-             "with --preview/--brief.",
+             "(distinct_value_count + total_match_count). 'file_name:/regex/' "
+             "applies the capture regex to the document's file_name column "
+             "(per-document: first capture per doc, no double-counting). "
+             "Cannot be combined with --preview/--brief.",
     )
     p.add_argument(
         "--extract",
@@ -453,24 +487,35 @@ def _build_fts_query(query: str, match_mode: str) -> str:
     return " ".join(pieces)
 
 
-def _parse_count_by(value: str) -> tuple[str, CaptureSpec | None]:
+def _parse_count_by(
+    value: str,
+) -> tuple[str, CaptureSpec | None, str | None]:
     """Classify a --count-by value.
 
-    Returns ('document', None) for the literal keyword, or ('regex', spec) for a
-    /pattern/ that carries at least one capture group — parsed through the shared
-    capture machinery (:func:`parse_capture_regex`), so --count-by '/regex/' is
-    extract-then-group-and-count over the *same* primitive --extract uses. A
-    capture spec may carry several groups; --count-by buckets on the first one.
-    Raises SkillError on a malformed value, an uncompilable pattern, or a
+    Returns a ``(mode, spec, field)`` triple:
+
+    - ``('document', None, None)`` for the literal keyword.
+    - ``('regex', spec, None)`` for a ``/pattern/`` — extract-then-group-and-count
+      over chunk body text; same primitive ``--extract`` uses.
+    - ``('field', spec, 'file_name')`` for a ``file_name:/pattern/`` — apply the
+      capture regex to the document's ``file_name`` column (per-document, first
+      capture only, no double-counting).
+
+    Raises ``SkillError`` on a malformed value, an uncompilable pattern, or a
     capture-less regex.
     """
     if value == "document":
-        return "document", None
+        return "document", None, None
+    field_result = parse_field_capture(value, flag="--count-by")
+    if field_result is not None:
+        field_name, spec = field_result
+        return "field", spec, field_name
     if value.startswith("/"):
-        return "regex", parse_capture_regex(value, flag="--count-by")
+        return "regex", parse_capture_regex(value, flag="--count-by"), None
     raise SkillError(
         "INVALID_COUNT_BY",
-        f"--count-by must be 'document' or a /regex/ with a capture group; "
+        f"--count-by must be 'document', a /regex/ with a capture group, or "
+        f"'file_name:/regex/' to histogram by document field; "
         f"got {value!r}.",
     )
 
@@ -566,6 +611,39 @@ def _count_by_regex(cur, where: str, params: list, spec: CaptureSpec) -> tuple[C
             if total >= CAPTURE_MAX_MATCHES:
                 return counter, True  # match cap hit → partial counts
     return counter, False
+
+
+def _count_by_field(cur, spec: CaptureSpec) -> tuple[Counter, bool]:
+    """Tally spec's first capture group across all documents' file_name values.
+
+    Per-document counting: take only the FIRST match per document to avoid
+    double-counting when a filename matches the regex more than once. Returns the
+    histogram and whether the match cap truncated it.
+
+    Each project is its own SQLite DB, so querying all documents gives the full
+    project corpus — no project_id needed. The FTS scope filters (in_documents /
+    tag / file_like / date bounds) are intentionally **not** applied here — this
+    mode histograms the filename space of the whole project, not chunk hits.
+    The FTS query is required by ``scan``'s interface but the filename histogram
+    is query-independent.
+    """
+    counter: Counter = Counter()
+    total = 0
+    for (file_name,) in cur.execute("SELECT file_name FROM documents"):
+        if file_name is None:
+            continue
+        match = spec.pattern.search(file_name)
+        if match is None:
+            continue
+        value = match.group(1)
+        if value is None:
+            continue
+        counter[value] += 1
+        total += 1
+        if total >= CAPTURE_MAX_MATCHES:
+            return counter, True
+    return counter, False
+
 
 
 def _heading_qualified_fts(fts_expr: str) -> str:
@@ -704,9 +782,9 @@ def work(*, conn, args, session_id) -> dict:
     body_filter = None
     if args.body_matches is not None:
         body_filter = parse_filter_regex(args.body_matches, flag="--body-matches")
-    count_mode, count_regex = (None, None)
+    count_mode, count_regex, count_field = (None, None, None)
     if args.count_by is not None:
-        count_mode, count_regex = _parse_count_by(args.count_by)
+        count_mode, count_regex, count_field = _parse_count_by(args.count_by)
     extract_specs = None
     if args.extract is not None:
         extract_specs = [
@@ -808,6 +886,28 @@ def work(*, conn, args, session_id) -> dict:
             "columns": extract_columns, "rows": rows_out,
         })
         return _with_diagnosis(env) if total == 0 else env
+
+    if count_mode == "field":
+        if args.returning is not None:
+            raise SkillError(
+                "RETURNING_NOT_APPLICABLE",
+                "--returning has no effect on --count-by 'field_name:/regex/' "
+                "output: filename buckets carry no citable id to project.",
+            )
+        counter, truncated = _count_by_field(cur, count_regex)
+        ordered = sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))
+        page = ordered[args.offset : args.offset + args.limit]
+        env = _envelope({
+            "count_by_field": count_field,
+            "count_by_regex": count_regex.raw,
+            "offset": args.offset,
+            "limit": args.limit,
+            "distinct_value_count": len(counter),
+            "total_match_count": sum(counter.values()),
+            "truncated": truncated,
+            "buckets": [{"value": value, "count": count} for value, count in page],
+        })
+        return env
 
     if count_mode == "regex":
         if args.returning is not None:

--- a/docs/decisions/GH-0641-scan-count-by-fields-0001.md
+++ b/docs/decisions/GH-0641-scan-count-by-fields-0001.md
@@ -1,0 +1,72 @@
+# `scan --count-by 'file_name:/regex/'` — per-document field histogram
+
+Issue #641 (part of omnibus #656).
+
+## Problem
+
+Corpora with structured filenames (member prefixes, date stamps, doc-type codes)
+are common in EDGAR/OGE/PACER-style datasets. Getting a "documents per
+filename-prefix" histogram previously meant reaching for `list_documents
+--returning file_name` piped into a shell `grep | sort | uniq -c` loop — a
+pattern brittle enough (whitespace, encoding, OS portability) to justify a
+primitive.
+
+## Decision
+
+Extend `--count-by` to accept a `field_name:/regex/` form — a colon-separated
+prefix that tells scan to apply the capture regex to a **document column** rather
+than chunk body text. Initial support covers `file_name` only; no generic column
+engine is built speculatively.
+
+### Syntax choice
+
+`--count-by 'file_name:/^([A-Za-z]+)_/'` (field-prefixed) was chosen over a
+separate `--count-over <field>` selector. All histogram modes stay in one flag;
+the field prefix is unambiguous and self-documenting; and the existing `document`
+keyword is untouched.
+
+### Per-document, not per-match
+
+The body-text `--count-by '/regex/'` mode counts **per match** (a chunk with two
+matches contributes two) — an honest frequency for the "how often does this term
+appear" question. For a filename histogram the question is "how many documents
+match each prefix" — so the field mode counts **per document**: one capture per
+document, ignoring multiple regex matches within the same filename. Double-counting
+would give misleading totals with no way to opt out.
+
+### FTS scope intentionally not applied
+
+The field histogram runs against `SELECT file_name FROM documents` (all documents
+in the project DB), not against the FTS5 match set. The FTS query is required by
+`scan`'s interface but the filename histogram is query-independent — the user is
+asking "what's in my corpus" not "which FTS-matching documents have this prefix."
+Applying the FTS scope would silently restrict the histogram to documents that
+happen to contain the FTS query term, producing a subtly confusing partial
+histogram. This is the deliberate semantics.
+
+### Output envelope
+
+A distinct output envelope (`count_by_field` / `count_by_regex` / `buckets`)
+rather than reusing the body-text envelope (`count_by` / `groups`) avoids
+ambiguity: a caller can always tell which mode produced the response. The bucket
+shape (`{value, count}`) and rollup fields (`distinct_value_count`,
+`total_match_count`, `truncated`, paginated by `--limit`/`--offset`) mirror the
+body-text mode for consistency.
+
+## Implementation
+
+- `_common.py`: `parse_field_capture(value, *, flag)` — parses
+  `<word>:/regex/` form, returns `(field_name, CaptureSpec)` or `None` if not
+  field-prefixed. Validates the field name against `_COUNT_BY_FIELD_NAMES`
+  (currently `("file_name",)`) before parsing the regex.
+- `scan.py`: `_count_by_field(cur, spec)` — walks `documents`, applies
+  `spec.pattern.search(file_name)`, takes the first capture group, accumulates a
+  `Counter`. Honors the existing `CAPTURE_MAX_MATCHES` cap and returns
+  `(counter, truncated)` matching `_count_by_regex`'s signature.
+- `_parse_count_by` extended to a 3-tuple `(mode, spec, field)` — `field` is
+  `None` for the `document` and `regex` modes.
+
+## Scope
+
+Non-schema, additive. Touches `bartleby/skill_scripts/_common.py`,
+`bartleby/skill_scripts/scan.py`, and `tests/test_skill_scan.py`.

--- a/tests/test_skill_scan.py
+++ b/tests/test_skill_scan.py
@@ -1378,3 +1378,163 @@ def test_scan_body_matches_no_fts_match_is_zero(scan_corpus, capsys):
     out = json.loads(capsys.readouterr().out)
     assert out["total"] == 0
     assert out["matches"] == []
+
+
+# --- --count-by 'file_name:/regex/' (field histogram, issue #641) ------------
+
+
+@pytest.fixture
+def filename_corpus(project_env):  # noqa: F811
+    """Documents with structured filenames (member_prefix_date.txt), multiple
+    chunks per document, to prove per-document de-dup in the histogram."""
+    conn = open_db(project_env)
+    try:
+        cur = conn.cursor()
+
+        def _doc(file_hash, file_name, n_chunks=2):
+            cur.execute(
+                "INSERT INTO documents (file_hash, file_name, file_path, page_count, token_count) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (file_hash, file_name, f"/tmp/{file_name}", 1, 50),
+            )
+            doc_id = conn.last_insert_rowid()
+            insert_document_chunks(conn, doc_id, [
+                ChunkInput(text=f"Content chunk {i} of {file_name}",
+                           embedding=_emb(float(doc_id * 10 + i)),
+                           chunk_index=i, page_number=1)
+                for i in range(n_chunks)
+            ])
+            return doc_id
+
+        # Three documents from member "smith" (two chunks each) — should count 3.
+        d1 = _doc("fa", "smith_001_2024.txt")
+        d2 = _doc("fb", "smith_002_2024.txt")
+        d3 = _doc("fc", "smith_003_2024.txt")
+        # Two documents from member "jones".
+        d4 = _doc("fd", "jones_001_2024.txt")
+        d5 = _doc("fe", "jones_002_2024.txt")
+        # One document with no matching prefix structure.
+        d6 = _doc("ff", "readme.txt")
+    finally:
+        conn.close()
+    return {
+        "project": project_env,
+        "d1": d1, "d2": d2, "d3": d3, "d4": d4, "d5": d5, "d6": d6,
+    }
+
+
+def test_count_by_field_basic_histogram(filename_corpus, capsys):
+    """file_name:/^([a-zA-Z]+)_/ produces a correct histogram over all documents."""
+    _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^([a-zA-Z]+)_/"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["count_by_field"] == "file_name"
+    assert out["count_by_regex"] == "/^([a-zA-Z]+)_/"
+    assert out["distinct_value_count"] == 2    # smith, jones
+    assert out["total_match_count"] == 5       # 3 smiths + 2 jones
+    assert out["truncated"] is False
+    # Sorted count-desc then value-asc
+    assert out["buckets"] == [
+        {"value": "smith", "count": 3},
+        {"value": "jones", "count": 2},
+    ]
+    # Per-chunk envelope keys are absent.
+    for absent in ("matches", "documents", "total", "preview"):
+        assert absent not in out
+
+
+def test_count_by_field_per_document_dedup(filename_corpus, capsys):
+    """Each document counts once: two chunks per doc does not inflate counts."""
+    # If per-chunk (wrong), smith would be 6, jones 4.  Per-doc is 3 and 2.
+    _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^([a-zA-Z]+)_/"])
+    out = json.loads(capsys.readouterr().out)
+    smith = next(b for b in out["buckets"] if b["value"] == "smith")
+    jones = next(b for b in out["buckets"] if b["value"] == "jones")
+    assert smith["count"] == 3, f"Expected 3 (per-doc), got {smith['count']}"
+    assert jones["count"] == 2, f"Expected 2 (per-doc), got {jones['count']}"
+
+
+def test_count_by_field_non_matching_excluded(filename_corpus, capsys):
+    """Documents whose filename doesn't match the capture are excluded from buckets."""
+    # "readme.txt" has no underscore-prefixed member name — excluded.
+    _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^([a-zA-Z]+)_/"])
+    out = json.loads(capsys.readouterr().out)
+    bucket_values = {b["value"] for b in out["buckets"]}
+    assert "readme" not in bucket_values
+    assert len(out["buckets"]) == 2   # only smith and jones
+
+
+def test_count_by_field_pagination(filename_corpus, capsys):
+    """--limit/--offset paginate buckets; rollup totals stay full."""
+    _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^([a-zA-Z]+)_/",
+                           "--limit", "1"])
+    p1 = json.loads(capsys.readouterr().out)
+    assert p1["buckets"] == [{"value": "smith", "count": 3}]
+    assert p1["distinct_value_count"] == 2   # full, unpaginated
+    assert p1["total_match_count"] == 5
+
+    _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^([a-zA-Z]+)_/",
+                           "--limit", "1", "--offset", "1"])
+    p2 = json.loads(capsys.readouterr().out)
+    assert p2["buckets"] == [{"value": "jones", "count": 2}]
+    assert p2["distinct_value_count"] == 2
+
+
+def test_count_by_field_invalid_field_errors(filename_corpus, capsys):
+    """An unsupported field name raises INVALID_COUNT_BY_FIELD."""
+    with pytest.raises(SystemExit) as exc:
+        _run(filename_corpus, ["Content chunk", "--count-by", r"bogus_field:/^(\w+)/"])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "INVALID_COUNT_BY_FIELD"
+    assert "file_name" in out["supported_fields"]
+
+
+def test_count_by_field_rejects_preview_and_brief(filename_corpus, capsys):
+    """Cannot combine --count-by 'file_name:/regex/' with --preview or --brief."""
+    for bad in (["--preview", "100"], ["--brief"]):
+        with pytest.raises(SystemExit) as exc:
+            _run(filename_corpus, ["Content chunk", "--count-by",
+                                   "file_name:/^([a-zA-Z]+)_/", *bad])
+        assert exc.value.code == 1
+        assert json.loads(capsys.readouterr().out)["code"] == "USAGE_ERROR"
+
+
+def test_count_by_field_rejects_returning(filename_corpus, capsys):
+    """--returning is rejected for field histograms (no citable id to project)."""
+    with pytest.raises(SystemExit) as exc:
+        _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^([a-zA-Z]+)_/",
+                               "--returning", "chunk_id"])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "RETURNING_NOT_APPLICABLE"
+
+
+def test_count_by_field_invalid_regex_errors(filename_corpus, capsys):
+    """An uncompilable regex in the field form errors cleanly."""
+    with pytest.raises(SystemExit) as exc:
+        _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/(/"])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "INVALID_CAPTURE_REGEX"
+
+
+def test_count_by_field_no_capture_group_errors(filename_corpus, capsys):
+    """A regex with no capture group in the field form errors cleanly."""
+    with pytest.raises(SystemExit) as exc:
+        _run(filename_corpus, ["Content chunk", "--count-by", "file_name:/^[a-zA-Z]+_/"])
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "CAPTURE_NO_GROUP"
+
+
+def test_count_by_body_regex_still_works_after_field_addition(
+    templated_corpus, capsys
+):
+    """Existing ``--count-by '/regex/'`` body-text behavior is unchanged."""
+    _run(templated_corpus, [BILL_MARKER, "--count-by", BILL_RE])
+    out = json.loads(capsys.readouterr().out)
+    assert out["groups"] == [
+        {"value": "4346", "count": 3},
+        {"value": "815", "count": 1},
+    ]
+    assert "buckets" not in out


### PR DESCRIPTION
Part of #656

## Summary
- Extends `scan --count-by` to tally captures from `file_name` document field via `field_name:/regex/` syntax (e.g. `--count-by 'file_name:/^([A-Za-z]+)_/'`)
- Per-document counting: first capture per document, avoiding double-counting
- Reuses existing `CaptureSpec`/`parse_capture_regex` and bucket output envelope
- No schema changes

## Test plan
- [ ] `--count-by 'file_name:/regex/'` produces correct histogram
- [ ] Per-document de-dup: each file_name counts once regardless of chunk count
- [ ] Non-matching filenames excluded from output
- [ ] Invalid field name produces error JSON with non-zero exit
- [ ] Existing `--count-by '/regex/'` body-text behavior unchanged

🤖 Generated with Claude Code