### PR TITLE
fix(web): hide native PDF nav pane in findings/documents viewer (#673)

### DIFF
--- a/bartleby/web/src/routes/documents/[id]/+page.svelte
+++ b/bartleby/web/src/routes/documents/[id]/+page.svelte
@@ -14,7 +14,7 @@
     const n = parseInt($page.url.searchParams.get("page"), 10);
     return Number.isInteger(n) && n > 0 ? n : null;
   })();
-  $: viewerSrc = `/files/${doc.document_id}${pageNum ? `#page=${pageNum}` : ""}`;
+  $: viewerSrc = `/files/${doc.document_id}${pageNum ? `#page=${pageNum}&navpanes=0` : "#navpanes=0"}`;
 </script>
 
 <div class="split">

--- a/bartleby/web/src/routes/findings/[id]/+page.svelte
+++ b/bartleby/web/src/routes/findings/[id]/+page.svelte
@@ -180,7 +180,7 @@
 
   function citationUrl(c) {
     if (c.document_id == null) return null;
-    const page = c.page_number ? `#page=${c.page_number}` : "";
+    const page = c.page_number ? `#page=${c.page_number}&navpanes=0` : "#navpanes=0";
     return `/files/${c.document_id}${page}`;
   }
 


### PR DESCRIPTION
Part of #674. Appends `navpanes=0` to the PDF-viewer URL fragment in the findings and documents views so the browser's native PDF thumbnail/bookmark pane is hidden. Client-side only; no backend change. — 🤖 Generated with [Claude Code](https://claude.com/claude-code)