### PR TITLE
fix(deps): declare shapely as a core dependency (#671)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "rich>=14.2.0",
     "sentence-transformers>=5.1.2",
+    "shapely>=2.0.0",
     "sqlite-vec>=0.1.9",
     "tiktoken>=0.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sentence-transformers" },
+    { name = "shapely" },
     { name = "sqlite-vec" },
     { name = "tiktoken" },
 ]
@@ -226,6 +227,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "sec2md", marker = "extra == 'sec2md'", specifier = "==0.1.22" },
     { name = "sentence-transformers", specifier = ">=5.1.2" },
+    { name = "shapely", specifier = ">=2.0.0" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
     { name = "tiktoken", specifier = ">=0.12.0" },
 ]


### PR DESCRIPTION
Part of #674. Adds `shapely>=2.0.0` to `[project].dependencies` (it was only reaching the lockfile transitively via the docling extra) so the default pdfplumber backend imports cleanly on a plain install. Re-locked. — 🤖 Generated with [Claude Code](https://claude.com/claude-code)