### PR TITLE
Omnibus #674: fresh-install fixes + findings PDF-viewer trim (Closes #671, #672, #673)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ uv tool install '.[sec2md]'
 
 You can combine extras: `uv tool install '.[docling,sec2md]'`.
 
-The wsjpt provider (routes Gemini through WSJ's parsing toolkit; WSJ-internal) is **not** in the locked dependency set — its git source is unreachable outside WSJ, which would break `uv lock`/`uv sync` for everyone. Inject it into the **tool's** environment with `--with` — extras and out-of-band packages have to go there, not a separate `uv pip install` (which lands somewhere the running tool can't see). `--force` re-applies to an already-installed tool:
+The wsjpt provider (routes Gemini through WSJ's parsing toolkit; WSJ-internal) is **not** in the locked dependency set — its git source is unreachable outside WSJ, which would break `uv lock`/`uv sync` for everyone. Inject it into the **tool's** environment with `--with` — extras and out-of-band packages have to go there, not a separate `uv pip install` (which lands somewhere the running tool can't see). `--force` re-applies to an already-installed tool. Also pin `pydantic-ai>=1,<2`: wsjpt's keyless Vertex/ADC path passes `vertexai=`/`project=`/`location=` to `GoogleProvider`, and pydantic-ai 2.0 dropped those kwargs, so an unpinned install resolves to 2.x and crashes:
 
 ```
-uv tool install '.[docling,sec2md]' --with 'git+ssh://git@github.dowjones.net/data/wsjpt.git' --force
+uv tool install '.[docling,sec2md]' --with 'pydantic-ai>=1,<2' --with 'git+ssh://git@github.dowjones.net/data/wsjpt.git' --force
 ```
 
 For development:

--- a/bartleby/web/src/routes/documents/[id]/+page.svelte
+++ b/bartleby/web/src/routes/documents/[id]/+page.svelte
@@ -14,7 +14,7 @@
     const n = parseInt($page.url.searchParams.get("page"), 10);
     return Number.isInteger(n) && n > 0 ? n : null;
   })();
-  $: viewerSrc = `/files/${doc.document_id}${pageNum ? `#page=${pageNum}` : ""}`;
+  $: viewerSrc = `/files/${doc.document_id}${pageNum ? `#page=${pageNum}&navpanes=0` : "#navpanes=0"}`;
 </script>
 
 <div class="split">

--- a/bartleby/web/src/routes/findings/[id]/+page.svelte
+++ b/bartleby/web/src/routes/findings/[id]/+page.svelte
@@ -180,7 +180,7 @@
 
   function citationUrl(c) {
     if (c.document_id == null) return null;
-    const page = c.page_number ? `#page=${c.page_number}` : "";
+    const page = c.page_number ? `#page=${c.page_number}&navpanes=0` : "#navpanes=0";
     return `/files/${c.document_id}${page}`;
   }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "rich>=14.2.0",
     "sentence-transformers>=5.1.2",
+    "shapely>=2.0.0",
     "sqlite-vec>=0.1.9",
     "tiktoken>=0.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "sentence-transformers" },
+    { name = "shapely" },
     { name = "sqlite-vec" },
     { name = "tiktoken" },
 ]
@@ -226,6 +227,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.2.0" },
     { name = "sec2md", marker = "extra == 'sec2md'", specifier = "==0.1.22" },
     { name = "sentence-transformers", specifier = ">=5.1.2" },
+    { name = "shapely", specifier = ">=2.0.0" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
     { name = "tiktoken", specifier = ">=0.12.0" },
 ]


### PR DESCRIPTION
## At-a-glance triage

**🟢 OK** — Full suite green (`1259 passed, 2 skipped`) on the post-merge omnibus after **each** integration; both strong critics (correctness + cross-cutting simplicity) returned a clean bill; 3/3 sub-PRs landed with no conflicts and no parks.

**🟡 FYI**
- **Tier:** cheap (Sonnet) players; strong (Opus) critics + director. Weigh the diff accordingly — though all three changes are small and were independently critic-reviewed.
- **Cross-issue coordination:** the README pin (#672) intentionally does **not** add `--with shapely` — #671 makes `shapely` a core dependency, so the plain `.[docling,sec2md]` install already provides it. Correctness critic confirmed no conflict.
- **Scope note on #673:** the issue names only `/findings/[id]`, but the same `navpanes=0` fragment fix was also applied to the shared `/documents/[id]` viewer for consistency (surfaced and approved at the plan gate). The simplicity critic confirmed the two-site inline edit is correct — a shared helper would be premature abstraction.
- **No browser verification for #673:** `--with-playwright` was not requested, so the PDF nav-pane change was reviewed by reading, not driven in a real browser. The param is honored by Chromium's native viewer and harmlessly ignored by Firefox's pdf.js. A quick manual eyeball on merge is reasonable but not required.

**🔴 CHECK** — none.

## What landed

Three independent field-reported fixes, disjoint surfaces, assembled on `omnibus/674-fresh-install-fixes`:

- **Closes #671** — `shapely>=2.0.0` added to `[project].dependencies` (+ re-locked). The default `pdfplumber` backend imports `shapely` at module top level but it was only reaching the lockfile transitively via the optional `docling` extra, so a plain install crashed on first `scribe`. (`>=2.0.0` is the correct floor — the top-level `box`/`unary_union` aliases are 2.0+.) — sub-PR #677
- **Closes #672** — README wsjpt install line pins `pydantic-ai>=1,<2` (+ a prose sentence explaining why). pydantic-ai 2.0 dropped the `vertexai=`/`project=`/`location=` kwargs wsjpt's keyless Vertex/ADC path passes to `GoogleProvider`; unpinned resolves to 2.x and crashes. — sub-PR #675
- **Closes #673** — `navpanes=0` appended to the PDF-viewer URL fragment in the findings and documents views, hiding the browser-native PDF thumbnail/nav pane. Client-side only; no backend change. — sub-PR #676

No parked items. No unresolved critic findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
