### PR TITLE
fix(scribe): silence HF advisory that clobbers the live progress display

### DIFF
--- a/bartleby/lib/quiet.py
+++ b/bartleby/lib/quiet.py
@@ -101,6 +101,10 @@ def setup_quiet_third_party(
     os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
     os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
     os.environ.setdefault("HF_HUB_DISABLE_TELEMETRY", "1")
+    # huggingface_hub re-reads this at import and resets its root logger
+    # level, clobbering the setLevel(ERROR) below — the env knob is what
+    # actually silences it.
+    os.environ.setdefault("HF_HUB_VERBOSITY", "error")
     os.environ.setdefault("TQDM_DISABLE", "1")
     os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
     os.environ["BARTLEBY_VERBOSE"] = "0"


### PR DESCRIPTION
Closes #679

`setup_quiet_third_party()` sets `logging.getLogger("huggingface_hub").setLevel(logging.ERROR)`, but `huggingface_hub` re-runs `_configure_library_root_logger()` at import time and resets its logger level from the `HF_HUB_VERBOSITY` env var (default WARNING), clobbering our imperative `setLevel(ERROR)`. This let the per-worker "unauthenticated requests to the HF Hub" advisory leak and stomp the scribe's live progress display. The fix adds `os.environ.setdefault("HF_HUB_VERBOSITY", "error")` alongside the other `HF_HUB_*`/`TRANSFORMERS_VERBOSITY` env knobs already set in that block, so the env var wins before the import-time reset happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)