### PR TITLE
feat(web): "Save as HTML" standalone finding export

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -25,7 +25,7 @@ are the set, assembled on an omnibus branch, then promoted.
 |---|---|---|---|
 | **director** | plan, dispatch, triage, assemble, promote | the session (you) — but omnibus work runs in its own **director worktree**, never the shared checkout | strong |
 | **players** | implement one issue — code, test, self-tidy, commit, PR | subagents, in parallel, each its own sibling worktree | cheap |
-| **critics** | review the work — a **correctness critic** and a **simplicity critic** | subagents the director spools | strong (per-unit simplicity: cheap) |
+| **critics** | review the work — one fused **leaf critic** (both briefs) for a leaf; a **correctness critic** and a **cross-cutting simplicity critic** for an assembled omnibus | subagents the director spools | strong |
 
 The director runs the show — plan, dispatch, triage, assemble, promote — and
 never grinds: the implementation churn (big reads, test loops, edits) lives in
@@ -177,8 +177,7 @@ Two tiers, resolved **flag > config > default**:
 - **director** — strong.
 - **players** — cheap by default (`player_tier`); there are many of them, and
   that's where token spend concentrates.
-- **critics** — strong, except the simplicity critic's **per-unit** pass (a
-  focused review of one small diff), which is cheap.
+- **critics** — strong.
 - **`--strong`** lifts everything to strong; **`--thrifty`** drops everything to
   cheap.
 
@@ -200,6 +199,12 @@ Config loaded (detect+persist on first run; see *Detection & first run*). Signet
 self-check honored. `gh` authed. Working tree of the base is clean. Honor
 `guardrails` verbatim throughout. `guard_hook`, if set, is informational — the
 worktree discipline below is what keeps work off the base.
+
+**Test-output discipline:** whenever the director runs `test_cmd` in-session
+(merge-train, triage re-runs, a docs sweep that touched source), redirect the
+output to a file and surface only the one-line summary on green, or the failing
+tail on red — never the full scroll. Players run the suite inside their own
+throwaway contexts; this rule keeps the director's session lean.
 
 ## 1. Resolve target and argument
 Target = `--onto <branch>` if given, else `base_branch`. Fetch the issue **and
@@ -246,9 +251,10 @@ proceed.
    so they reach the player even when the plan gate was skipped.
 3. The player runs its loop (§The players) → pushes its branch → opens the
    **issue → target** PR.
-4. On the player's branch, in parallel: the **simplicity critic** and the
-   **correctness critic** review it (§The critics). Then the triage loop
-   (§Triage). (No cross-cutting pass — a leaf is a set of one.)
+4. On the player's branch, the **fused leaf critic** reviews it — one subagent
+   carrying both briefs, reporting correctness and simplicity findings
+   separately (§The critics). Then the triage loop (§Triage). (No cross-cutting
+   pass — a leaf is a set of one.)
 5. **Docs sweep** (§Docs sweep) on the player's branch.
 6. **Stop.** The PR is the deliverable; the human merges. (Target is `main` in
    the common case → no promotion. Target is an omnibus branch → that omnibus's
@@ -278,10 +284,11 @@ proceed.
    **comment-derived corrections** in the dispatch payload (as in §2.2). Each
    player lands its sub-issue and opens a **"Part of #<omnibus>"** sub-PR onto the
    omnibus branch (no `Closes`).
-4. **Merge-train** (serial, never N-way): for each sub-PR, the **simplicity
-   critic** reviews its diff before integrating; apply accepted fixes to the
-   sub-PR branch. Then integrate and run the integration `test_cmd` on the
-   post-merge omnibus branch — green + clean → `gh pr merge`, then **tick this
+4. **Merge-train** (serial, never N-way): for each sub-PR, integrate and run the
+   integration `test_cmd` on the post-merge omnibus branch — no per-unit critic
+   here; the player's self-tidy (§The players 2b) is the per-unit backstop, and
+   the cross-cutting pass (§3.5) re-covers the assembled result. Green + clean
+   → `gh pr merge`, then **tick this
    sub-issue's checklist line** `[ ]→[x]` with its sub-PR number (see *Live
    progress*); conflict or red → **park** (leave the sub-PR open, record it). No
    unattended conflict resolution.
@@ -325,8 +332,9 @@ inherits the session's permission posture. Its loop:
       within `auto_skip_globs`, or `test_cmd` is `""`. Note once when skipped.
    b. **Self-tidy** — reread your own diff and remove the obvious: dead code,
       needless abstraction, a thing you just wrote that the codebase already had.
-      (The simplicity critic reviews independently once you open your PR — just
-      don't leave obvious mess.)
+      (A critic still reviews downstream — the fused leaf critic on a leaf, the
+      cross-cutting pass on an assembled omnibus — but a sub-PR gets no per-unit
+      review of its own, so your self-tidy is the only tidy pass it sees.)
    c. Commit (in the worktree; never on the base branch).
 3. If `decisions_dir` is set, record any decision as its own additive **file**,
    `<decisions_dir>/GH-<issue:0000>-<slug>-0001.md` (issue number four-zero-padded;
@@ -344,30 +352,37 @@ inherits the session's permission posture. Its loop:
 ## The critics
 The director spools the critics as subagents, independent of the authors. Their
 findings are **advisory** — the director triages them (§Triage); critics never
-commit. Two of them:
+commit. Two briefs, spooled differently per path:
 
-### The correctness critic
+- **Leaf** — one **fused leaf critic**: a single subagent carrying both briefs
+  over the leaf branch, reporting correctness and simplicity findings
+  separately. One spool, one diff read — a leaf diff is small enough that
+  neither lens loses focus.
+- **Omnibus, after assembly** — the **correctness critic** and the
+  **cross-cutting simplicity critic**, in parallel: the assembled diff is big
+  enough that each brief warrants its own context. Sub-PRs get no critic of
+  their own in the merge-train — the player's self-tidy is the per-unit
+  backstop, and the cross-cutting pass re-covers the assembled result.
+
+### The correctness brief
 Hunts bugs, especially at integration seams. Risk-ranked, plain-language
-findings. Reviews the leaf branch, or the assembled omnibus.
+findings. Reads the leaf branch, or the assembled omnibus.
 
-### The simplicity critic
-Reviews for needless complexity, at two moments:
+### The simplicity brief
+Reviews for needless complexity. On a leaf it reads the one diff. Cross-cutting
+— after omnibus assembly — it hunts what only a wide view shows: **cross-issue
+and cross-codebase duplication** (two sub-issues built the same helper; a player
+reinvented an existing util) and seam-level over-engineering — overlaps, not the
+per-diff nits self-tidy already handled.
 
-- **Per-unit** (cheap) — reviews each leaf branch, and each sub-PR as it lands in
-  the merge-train, before it's integrated.
-- **Cross-cutting** (strong) — after assembly, reviews the whole omnibus for what
-  only a wide view shows: **cross-issue and cross-codebase duplication** (two
-  sub-issues built the same helper; a player reinvented an existing util) and
-  seam-level over-engineering. It hunts overlaps, not the per-diff nits the
-  per-unit pass already covered.
-
-Its brief, over the given diff:
+The brief, over the given diff:
 
 > You are a refactoring specialist with one conviction: the best code is the
 > least code that clearly expresses intent. Every line must earn its place — you
 > *remove* complexity, you do not add cleverness. Review in three passes, macro
 > to micro, and report **only what you're confident about** — never taste, style,
-> or bikeshedding, and **never bugs** (the correctness critic owns those).
+> or bikeshedding, and **never bugs under this lens** (the correctness brief
+> owns those; a fused leaf critic reports them there, separately).
 >
 > 1. **Architectural.** Does this component need to exist, or can its
 >    responsibility be absorbed elsewhere? Unnecessary layers of indirection,
@@ -399,9 +414,9 @@ Its brief, over the given diff:
 > Output: per finding, 1–2 sentences on what you found and why it's a problem,
 > then the simpler form.
 
-Either critic may be **skipped for a trivial or docs-only diff** (same spirit as
-the test auto-skip) — say so when you do. A leaf has no cross-issue dimension, so
-its per-unit simplicity pass plus the correctness critic are the whole review.
+A critic may be **skipped for a trivial or docs-only diff** (same spirit as
+the test auto-skip) — say so when you do. A leaf has no cross-issue dimension,
+so the fused leaf critic is the whole review.
 
 ## Triage (the loop)
 Union the critics' findings and dedupe. Then, up to `max_critic_passes`:

--- a/bartleby/web/src/lib/citations.js
+++ b/bartleby/web/src/lib/citations.js
@@ -1,0 +1,150 @@
+// Pure citation-marker → dagger-note parsing, shared by the live finding view
+// (routes/findings/[id]/+page.svelte) and the standalone HTML export
+// (routes/findings/[id]/export.html/+server.js — GH-0690). Both need the
+// *same* `[^scheme:ref]` substitution for the export's "looks exactly like
+// the live page" promise to hold; only the final render shell differs (a
+// Svelte reactive template vs. a hand-built static document), so this module
+// owns just the parsing/note-building and leaves rendering (marked.parse,
+// the surrounding HTML/DOM shape) to each caller.
+//
+// One type-tagged marker grammar (issue #624): [^<scheme>:<ref>].
+//   [^chunk:N]         corpus-chunk citation. Resolves against byId →
+//                        resolved  → ¶ "source" note (amber, filename, jumps)
+//                        unresolved → ‡ "no longer available" note (danger)
+//   [^finding:N]       finding-to-finding link (#654) → § note with a link
+//                        to /findings/N. No DB row — validated at save time,
+//                        rendered from body text on read.
+//   [^url:…]/[^doc:…]   external citation → † "source" note (link / ref)
+// Glyph mapping (supersedes GH-0654): ¶ corpus chunk (resolved), ‡ chunk
+// gone, § finding-to-finding link, † external url/doc — the glyph alone
+// tells the kind apart; the ordinal stays the tie-back.
+// Mirrors the backend grammar in skill_scripts/_common.py: `chunk` and
+// `finding` are internal schemes; `url`/`doc` are external; any other scheme
+// (incl. `document`) is dropped, not rendered as a citation.
+import { escapeHtml, stripExt } from "./format.js";
+
+// Replace every `[^scheme:ref]` marker in `body` with an inline
+// `<sup class="cite-ref ...">` anchor and collect the matching gutter note,
+// in one left-to-right pass (so gutter order matches reading order).
+// Returns `{ markdown, notes }` — `markdown` still needs a `marked.parse()`
+// pass (the caller's own marked instance + sanitizer); `notes` is the ordered
+// gutter-note data, rendered into markup by the caller.
+export function substituteCitations(body, byId, active = null) {
+  const collected = [];
+  let n = 0;
+  const markdown = body.replace(/\[\^([A-Za-z]+):([^\]]+)\]/g, (match, scheme, ref) => {
+    const s = scheme.toLowerCase();
+    if (s === "chunk") {
+      const id = Number(ref.trim());
+      // A non-numeric chunk ref can't resolve; leave the marker verbatim.
+      if (!Number.isInteger(id)) return escapeHtml(match);
+      const c = byId.get(id);
+      const note = c
+        ? sourceNote(++n, c, c === active)
+        : goneNote(++n, id);
+      collected.push(note);
+      return marker(note);
+    }
+    if (s === "finding") {
+      const id = Number(ref.trim());
+      // A non-numeric finding ref can't resolve; leave the marker verbatim.
+      if (!Number.isInteger(id)) return escapeHtml(match);
+      const note = findingNote(++n, id);
+      collected.push(note);
+      return marker(note);
+    }
+    const note = externalNote(++n, s, ref.trim());
+    if (!note) {
+      n--; // unknown scheme: drop, don't burn an ordinal
+      return escapeHtml(match);
+    }
+    collected.push(note);
+    return marker(note);
+  });
+  return { markdown, notes: collected };
+}
+
+// The inline dagger anchor that sits at the cited point in the prose. A
+// superscript <sup> with the dagger glyph + ordinal; the ordinal ties it to
+// its gutter note. Stable class hooks (`cite-ref`, kind modifier) so R3 (#592)
+// can splice a pixel icon in without touching this code.
+function marker(note) {
+  const kindCls = note.gone
+    ? "cite-ref--gone"
+    : note.finding
+      ? "cite-ref--finding"
+      : "cite-ref--source";
+  const title = note.gone
+    ? `${note.dagger} cited source no longer available`
+    : note.finding
+      ? `${note.dagger} finding · ${note.title}`
+      : `${note.dagger} source · ${note.title}`;
+  return `<sup class="cite-ref ${kindCls}" data-note="${note.n}" title="${escapeHtml(title)}">${note.dagger}${note.n}</sup>`;
+}
+
+function sourceNote(n, c, isActive) {
+  const name = stripExt(c.file_name);
+  const label =
+    name && c.page_number ? `${name} p.${c.page_number}`
+    : name ? name
+    : c.page_number ? `p.${c.page_number}`
+    : `chunk ${c.chunk_id}`;
+  const title = [
+    c.file_name,
+    c.page_number && `page ${c.page_number}`,
+    `chunk ${c.chunk_id}`,
+  ].filter(Boolean).join(" · ");
+  return {
+    n,
+    dagger: "¶",
+    gone: false,
+    chunkId: c.chunk_id,
+    active: isActive,
+    label,
+    title,
+  };
+}
+
+// An unresolved [^chunk:N]: the cited source has been removed (deleted, or
+// rebuilt under new chunk ids by an edit/merge), so only the id survives.
+// Danger-toned gutter note rather than leaking raw [^N] text.
+function goneNote(n, chunkId) {
+  return {
+    n,
+    dagger: "‡",
+    gone: true,
+    chunkId,
+    label: "no longer available",
+    title: `chunk ${chunkId} · cited source no longer available`,
+  };
+}
+
+// A [^finding:N] link — a unidirectional reference to another finding (#654).
+// Carries an `href` to /findings/N for the live page; the export renderer
+// (GH-0690) deliberately ignores it and renders an inert note instead — the
+// other finding isn't in the standalone file.
+function findingNote(n, findingId) {
+  return {
+    n,
+    dagger: "§",
+    gone: false,
+    finding: true,
+    findingId,
+    href: `/findings/${findingId}`,
+    label: `finding #${findingId}`,
+    title: `finding #${findingId}`,
+  };
+}
+
+// An external (URL / external-dataset doc) citation parsed straight from the
+// body marker — no DB row backs it. A url scheme becomes a real link, a doc
+// scheme a muted ref. Unknown schemes return null (dropped upstream).
+function externalNote(n, scheme, ref) {
+  if (scheme === "url") {
+    return { n, dagger: "†", gone: false, external: "url", href: ref, label: ref, title: `external source · ${ref}` };
+  }
+  if (scheme === "doc") {
+    return { n, dagger: "†", gone: false, external: "doc", label: ref, title: `external dataset doc · ${ref}` };
+  }
+  return null;
+}

--- a/bartleby/web/src/lib/components/SourceViewer.svelte
+++ b/bartleby/web/src/lib/components/SourceViewer.svelte
@@ -1,6 +1,7 @@
 <script>
   import { marked } from "marked";
   import { escapeHtml } from "$lib/format.js";
+  import { wrapViewerDocument } from "$lib/viewerDoc.js";
 
   // The right-hand source pane, shared by /findings/[id] and /documents/[id].
   // Dispatches on file type: markdown renders to a sandboxed iframe (below),
@@ -59,50 +60,17 @@
 
   // marked.parse flows through the global DOMPurify hook (+layout.svelte), so the
   // HTML is already script-free. We still render it inside a sandboxed iframe
-  // carrying `default-src 'none'`: the sandbox blocks scripts as defense in
-  // depth, and the CSP is the *only* control that stops passive remote
-  // subresource loads — a tracking-pixel `<img>` in untrusted source markdown,
-  // which DOMPurify keeps, would otherwise beacon the host's IP on view.
-  // `default-src 'none'` ⇒ zero outbound requests; `style-src 'unsafe-inline'`
-  // only enables the inlined stylesheet below.
+  // via wrapViewerDocument ($lib/viewerDoc.js, shared with the GH-0690 HTML
+  // export): the sandbox blocks scripts as defense in depth, and its CSP is the
+  // *only* control that stops passive remote subresource loads — a
+  // tracking-pixel <img> in untrusted source markdown, which DOMPurify keeps,
+  // would otherwise beacon the host's IP on view.
   $: srcdoc =
     text == null
       ? null
       : isMarkdown
-        ? wrapDocument(marked.parse(text))
-        : wrapDocument(`<pre>${escapeHtml(text)}</pre>`);
-
-  function wrapDocument(inner) {
-    return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'" />
-<style>${VIEWER_CSS}</style>
-</head>
-<body>${inner}</body>
-</html>`;
-  }
-
-  // The iframe is its own document and can't reach app.css or its CSS variables,
-  // so the source styling is inlined. Neutral and compact — readable evidence,
-  // not a pixel-match to the prose pane.
-  const VIEWER_CSS = `
-    body { margin: 0; padding: 1.25rem 1.5rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; font-size: 0.9rem; line-height: 1.6; color: #1a1a1a; background: #fff; overflow-wrap: anywhere; }
-    h1, h2, h3, h4 { line-height: 1.25; margin: 1.4em 0 0.5em; }
-    h1 { font-size: 1.5rem; } h2 { font-size: 1.25rem; } h3 { font-size: 1.05rem; }
-    p, ul, ol, blockquote, table, pre { margin: 0 0 1em; }
-    a { color: #0645ad; }
-    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85em; background: #f2f2f2; padding: 0.1em 0.3em; border-radius: 3px; }
-    pre { background: #f6f6f6; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
-    pre code { background: none; padding: 0; }
-    blockquote { border-left: 3px solid #ddd; padding-left: 1em; color: #555; }
-    table { border-collapse: collapse; width: 100%; }
-    th, td { border: 1px solid #ddd; padding: 0.4em 0.6em; text-align: left; }
-    th { background: #f6f6f6; }
-    img { max-width: 100%; }
-    hr { border: none; border-top: 1px solid #ddd; margin: 1.5em 0; }
-  `;
+        ? wrapViewerDocument(marked.parse(text))
+        : wrapViewerDocument(`<pre>${escapeHtml(text)}</pre>`);
 </script>
 
 {#if isInline}

--- a/bartleby/web/src/lib/components/SourceViewer.svelte
+++ b/bartleby/web/src/lib/components/SourceViewer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { marked } from "marked";
   import { escapeHtml } from "$lib/format.js";
-  import { wrapViewerDocument } from "$lib/viewerDoc.js";
+  import { wrapViewerDocument, RE_MARKDOWN, RE_TEXT, RE_PDF } from "$lib/viewerDoc.js";
 
   // The right-hand source pane, shared by /findings/[id] and /documents/[id].
   // Dispatches on file type: markdown renders to a sandboxed iframe (below),
@@ -15,14 +15,14 @@
   export let src = null;
   export let sourceText = null;
 
-  $: isMarkdown = /\.(md|markdown)$/i.test(fileName ?? "");
+  $: isMarkdown = RE_MARKDOWN.test(fileName ?? "");
   // Plain text stays literal — never routed through marked. marked runs with
   // breaks: false (see +layout.svelte), so single newlines would collapse into
   // run-on paragraphs and stray #/*/_ chars would be misread as markdown.
-  $: isText = /\.(txt|text|log)$/i.test(fileName ?? "");
+  $: isText = RE_TEXT.test(fileName ?? "");
   // PDFs need the native viewer (and #page= jumps), which a sandbox would hobble;
   // every other raw file is sandboxed so an ingested HTML doc can't run scripts.
-  $: isPdf = /\.pdf$/i.test(fileName ?? "");
+  $: isPdf = RE_PDF.test(fileName ?? "");
   // Markdown and plain text both render inline (into the iframe below);
   // everything else falls through to the raw-file iframe branch.
   $: isInline = isMarkdown || isText;

--- a/bartleby/web/src/lib/format.js
+++ b/bartleby/web/src/lib/format.js
@@ -42,6 +42,15 @@ export function formatDateRange(a, b) {
   return lo === hi ? lo : `${lo} – ${hi}`;
 }
 
+// Filename slug: lowercase, non-alphanumerics collapsed to a single '-', with
+// leading/trailing '-' trimmed. Mirrors `_slug()` in bartleby/commands/finding.py
+// so a finding's exported filename is stable across the CLI and both web
+// export paths (Download .md, Save as HTML).
+export function slugify(title) {
+  const s = (title || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return s || "finding";
+}
+
 // Strip a trailing extension (e.g. .pdf) so a file name reads as a title when
 // no summary-derived title exists. Returns falsy input unchanged so callers can
 // chain a further `?? fallback`. Shared by the list, detail, and search views.

--- a/bartleby/web/src/lib/server/exportHtml.js
+++ b/bartleby/web/src/lib/server/exportHtml.js
@@ -13,10 +13,10 @@ import path from 'node:path';
 import { Marked } from 'marked';
 import DOMPurify from 'isomorphic-dompurify';
 import { getFinding, getDocumentFilePath, getImageFilePath } from './queries.js';
-import { MIME_BY_EXT } from './mime.js';
+import { MIME_BY_EXT, IMAGE_EXTS } from './mime.js';
 import { substituteCitations } from '../citations.js';
-import { escapeHtml } from '../format.js';
-import { wrapViewerDocument } from '../viewerDoc.js';
+import { escapeHtml, slugify } from '../format.js';
+import { wrapViewerDocument, RE_MARKDOWN, RE_TEXT, RE_PDF } from '../viewerDoc.js';
 
 // ---------------------------------------------------------------------------
 // Markdown rendering — an ISOLATED Marked instance, not the app's global
@@ -34,10 +34,6 @@ exportMarked.use({
       DOMPurify.sanitize(html).replace(/<a /g, '<a target="_blank" rel="noopener noreferrer" ')
   }
 });
-
-function renderMarkdown(text) {
-  return exportMarked.parse(text);
-}
 
 // ---------------------------------------------------------------------------
 // Fonts. `bartleby serve` always runs the vite DEV server out of
@@ -244,13 +240,10 @@ p.meta, .meta { font-family: var(--font-sans); font-size: var(--text-xs); font-w
 `;
 
 // ---------------------------------------------------------------------------
-// Source classification + embedding. Mirrors SourceViewer.svelte's own
-// isMarkdown/isText/isPdf dispatch regexes exactly, so a cited file renders
-// through the same branch live and in the export.
-const RE_MARKDOWN = /\.(md|markdown)$/i;
-const RE_TEXT = /\.(txt|text|log)$/i;
-const RE_PDF = /\.pdf$/i;
-const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tiff', '.tif']);
+// Source classification + embedding. RE_MARKDOWN/RE_TEXT/RE_PDF/IMAGE_EXTS are
+// shared with SourceViewer.svelte's own dispatch ($lib/viewerDoc.js,
+// $lib/server/mime.js), so a cited file renders through the same branch live
+// and in the export.
 
 // One citation → one embed key + page. `key` dedupes: several citations
 // against the same document (at different pages) share one embedded payload,
@@ -285,8 +278,6 @@ function buildEmbedPayload(classified, c) {
   // the live citationUrl/label — see its comment); the archived jpg on disk
   // has its own name, which is what's actually being embedded here.
   const fileName = isImageChunk ? path.basename(filePath) : (c.file_name ?? path.basename(filePath));
-  const ext = path.extname(filePath).toLowerCase();
-  const mime = MIME_BY_EXT[ext] ?? 'application/octet-stream';
   const data = fs.readFileSync(filePath);
 
   if (classified.embedKind === 'pdf') {
@@ -296,8 +287,9 @@ function buildEmbedPayload(classified, c) {
     return { kind: 'inline', srcdoc: wrapViewerDocument(`<pre>${escapeHtml(data.toString('utf-8'))}</pre>`), fileName };
   }
   if (classified.embedKind === 'markdown') {
-    return { kind: 'inline', srcdoc: wrapViewerDocument(renderMarkdown(data.toString('utf-8'))), fileName };
+    return { kind: 'inline', srcdoc: wrapViewerDocument(exportMarked.parse(data.toString('utf-8'))), fileName };
   }
+  const mime = MIME_BY_EXT[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream';
   if (classified.embedKind === 'image') {
     return { kind: 'image', dataUri: `data:${mime};base64,${data.toString('base64')}`, fileName };
   }
@@ -307,14 +299,25 @@ function buildEmbedPayload(classified, c) {
   return { kind: 'raw', dataUri: `data:${mime};base64,${data.toString('base64')}`, fileName };
 }
 
+// Only an http(s) URL becomes a real, clickable href — this file is meant to
+// be emailed/archived and opened by third parties, so a note carrying e.g.
+// `[^url:javascript:alert(1)]` must not become an active link. (The live page
+// has this same pre-existing gap in its own externalNote() rendering; left
+// alone there — this export-only guard doesn't change live behavior.)
+const RE_HTTP_URL = /^https?:\/\//i;
+
 // ---------------------------------------------------------------------------
 // Margin-note HTML. Head label is always "source" / "missing source" — the
 // live template (+page.svelte) uses that generic label regardless of dagger
-// kind, so this matches. Two deliberate departures from the live markup
-// (GH-0690 resolved questions): a [^finding:N] note renders inert (no link —
-// the other finding isn't in this file) and a resolved chunk note drops the
-// "open chunk" icon link (/chunks/N doesn't exist standalone either).
-function renderMarginNoteHtml(note) {
+// kind, so this matches. Deliberate departures from the live markup (GH-0690
+// resolved questions): a [^finding:N] note renders inert (no link — the other
+// finding isn't in this file); a resolved chunk note drops the "open chunk"
+// icon link (/chunks/N doesn't exist standalone either); a resolved chunk
+// note whose archived file was missing at export time (`embeddedChunkIds`
+// doesn't have it) renders inert with a visible hint instead of a dead,
+// still-clickable button — same ¶/"source" glyph and head (it did resolve
+// against the DB; only the file embed failed), just non-interactive body text.
+function renderMarginNoteHtml(note, embeddedChunkIds) {
   const headLabel = note.gone ? 'missing source' : 'source';
   const kindClass = note.gone ? 'gone' : note.finding ? 'finding' : 'source';
   let bodyHtml;
@@ -323,11 +326,15 @@ function renderMarginNoteHtml(note) {
   } else if (note.finding) {
     bodyHtml = `<p class="margin-note__body">${escapeHtml(note.label)}</p>`;
   } else if (note.external === 'url') {
-    bodyHtml = `<p class="margin-note__body"><a href="${escapeHtml(note.href)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</a></p>`;
+    bodyHtml = RE_HTTP_URL.test(note.href)
+      ? `<p class="margin-note__body"><a href="${escapeHtml(note.href)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</a></p>`
+      : `<p class="margin-note__body">${escapeHtml(note.label)}</p>`;
   } else if (note.external === 'doc') {
     bodyHtml = `<p class="margin-note__body margin-note__body--doc" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</p>`;
-  } else {
+  } else if (embeddedChunkIds.has(note.chunkId)) {
     bodyHtml = `<span class="margin-note__body margin-note__source-row"><button type="button" class="margin-note__link" data-chunk-id="${note.chunkId}" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</button></span>`;
+  } else {
+    bodyHtml = `<p class="margin-note__body margin-note__body--doc" title="${escapeHtml(note.title)}">${escapeHtml(note.label)} — source file missing at export time</p>`;
   }
   return `<div class="margin-note margin-note--${kindClass}" data-note="${note.n}">
     <p class="margin-note__head"><span class="margin-note__dagger">${note.dagger}${note.n}</span> ${headLabel}</p>
@@ -343,13 +350,6 @@ function buildMetaLine(finding) {
     : null;
   const bits = [finding.session_name, modelMeta, finding.created_at].filter(Boolean);
   return `<span class="finding-id">#${finding.finding_id}</span> · ${escapeHtml(bits.join(' · '))}`;
-}
-
-// Filename slug — mirrors _slug() in bartleby/commands/finding.py and the web
-// viewer's downloadMarkdown().
-function slug(title) {
-  const s = (title || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-  return s || 'finding';
 }
 
 // Escapes `<` out of a JSON payload before it goes inside a <script> tag, so a
@@ -559,9 +559,17 @@ export function buildFindingExportHtml(findingId) {
 
   const byId = new Map(finding.citations.map((c) => [c.chunk_id, c]));
   const { markdown, notes } = substituteCitations(finding.body, byId, null);
-  const bodyHtml = renderMarkdown(markdown);
+  const bodyHtml = exportMarked.parse(markdown);
 
+  // One embed payload per unique document/image id — `sources` is set
+  // unconditionally (including `null`, when the archived file is missing),
+  // so a repeat citation against the same key is a single lookup rather than
+  // a re-stat-and-retry. `embeddedChunkIds` (only the chunks whose payload
+  // came back non-null) gates both the runtime's CITATIONS wiring and the
+  // margin note's clickability — a chunk that resolved in the DB but whose
+  // file is gone renders inert, not a dead-but-clickable button.
   const sources = new Map();
+  const embeddedChunkIds = new Set();
   const citationMeta = {};
   for (const note of notes) {
     if (note.gone || note.finding || note.external) continue;
@@ -569,10 +577,10 @@ export function buildFindingExportHtml(findingId) {
     const classified = c && classifyCitation(c);
     if (!classified) continue;
     if (!sources.has(classified.key)) {
-      const payload = buildEmbedPayload(classified, c);
-      if (payload) sources.set(classified.key, payload);
+      sources.set(classified.key, buildEmbedPayload(classified, c));
     }
-    if (sources.has(classified.key)) {
+    if (sources.get(classified.key)) {
+      embeddedChunkIds.add(note.chunkId);
       citationMeta[note.chunkId] = { key: classified.key, page: classified.page ?? null };
     }
   }
@@ -582,10 +590,12 @@ export function buildFindingExportHtml(findingId) {
     metaLine: buildMetaLine(finding),
     description: finding.description,
     bodyHtml,
-    notesHtml: notes.map(renderMarginNoteHtml).join('\n'),
+    notesHtml: notes.map((note) => renderMarginNoteHtml(note, embeddedChunkIds)).join('\n'),
     citationMetaJson: jsonScriptSafe(citationMeta),
-    sourcesJson: jsonScriptSafe(Object.fromEntries(sources))
+    sourcesJson: jsonScriptSafe(
+      Object.fromEntries([...sources].filter(([, payload]) => payload != null))
+    )
   });
 
-  return { html, filename: `${slug(finding.title)}.html` };
+  return { html, filename: `${slugify(finding.title)}.html` };
 }

--- a/bartleby/web/src/lib/server/exportHtml.js
+++ b/bartleby/web/src/lib/server/exportHtml.js
@@ -1,0 +1,591 @@
+// Builds the standalone "Save as HTML" export of one finding (GH-0690): a
+// single self-contained file — no network, no server — that reproduces the
+// live /findings/[id] view: the two-column split, drop-capped serif prose,
+// Tufte-style margin notes, and every cited source embedded inline (fonts as
+// base64 @font-face, PDFs/images as base64 data: URIs, .txt/.md rendered the
+// same way the live SourceViewer does). See
+// docs/decisions/GH-0690-finding-html-export-0001.md for the resolved open
+// questions this implements (PDF fallback download link, inert
+// cross-finding/external notes, image-chunk embedding) and why the CSS below
+// is a hand-copied snapshot of app.css rather than a shared import.
+import fs from 'node:fs';
+import path from 'node:path';
+import { Marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+import { getFinding, getDocumentFilePath, getImageFilePath } from './queries.js';
+import { MIME_BY_EXT } from './mime.js';
+import { substituteCitations } from '../citations.js';
+import { escapeHtml } from '../format.js';
+import { wrapViewerDocument } from '../viewerDoc.js';
+
+// ---------------------------------------------------------------------------
+// Markdown rendering — an ISOLATED Marked instance, not the app's global
+// `marked` singleton. That singleton gets its DOMPurify-sanitize + target/rel
+// hook registered once, at module-load time, by routes/+layout.svelte's
+// module-context script (see the comment there) — a page component this
+// server-only export route never imports. Depending on whether some page
+// happened to render first in the same process (registering the hook) would
+// make this route's sanitization order-dependent; a private instance with the
+// same hook sanitizes unconditionally instead.
+const exportMarked = new Marked();
+exportMarked.use({
+  hooks: {
+    postprocess: (html) =>
+      DOMPurify.sanitize(html).replace(/<a /g, '<a target="_blank" rel="noopener noreferrer" ')
+  }
+});
+
+function renderMarkdown(text) {
+  return exportMarked.parse(text);
+}
+
+// ---------------------------------------------------------------------------
+// Fonts. `bartleby serve` always runs the vite DEV server out of
+// ~/.bartleby/serve (commands/serve.py's _sync_web copies/symlinks this app's
+// `static/` tree verbatim alongside `src/`, then `os.chdir`s there before
+// exec) — so `static/fonts/` is a stable process.cwd()-relative path in the
+// one way this app is actually run.
+const FONTS_DIR = path.join(process.cwd(), 'static', 'fonts');
+
+// Mirrors fonts.css's six @font-face declarations exactly (family, weight
+// range, style) — only the `src` changes, from a `/fonts/...` URL to a base64
+// `data:` URI so the export carries the font data itself.
+const FONT_FACES = [
+  { family: 'Doto', file: 'Doto-Variable.woff2', weight: '100 900', style: 'normal' },
+  { family: 'Iosevka Term', file: 'IosevkaTerm-Regular.woff2', weight: '400', style: 'normal' },
+  { family: 'Iosevka Term', file: 'IosevkaTerm-Medium.woff2', weight: '500', style: 'normal' },
+  { family: 'Iosevka Term', file: 'IosevkaTerm-Bold.woff2', weight: '600 900', style: 'normal' },
+  { family: 'Source Serif 4', file: 'SourceSerif4-Variable.woff2', weight: '200 900', style: 'normal' },
+  { family: 'Source Serif 4', file: 'SourceSerif4-Italic-Variable.woff2', weight: '200 900', style: 'italic' }
+];
+
+function buildFontFaceCss() {
+  return FONT_FACES.map(({ family, file, weight, style }) => {
+    const data = fs.readFileSync(path.join(FONTS_DIR, file));
+    const dataUri = `data:font/woff2;base64,${data.toString('base64')}`;
+    return `@font-face { font-family: "${family}"; src: url("${dataUri}") format("woff2"); font-weight: ${weight}; font-style: ${style}; font-display: swap; }`;
+  }).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// CSS — a hand-curated snapshot of the app.css/SourceViewer.svelte rules the
+// ledger view actually uses (tokens, base typography, .surface/.markdown-body,
+// the R4 split/ledger/margin-note/cite-ref treatment, the R3 dagger bookmark,
+// and SourceViewer's placeholder states), plus a handful of `.export-*` rules
+// for pieces that only exist in the export (the PDF fallback link, the
+// image-chunk viewer). It is NOT generated from app.css at request time, so a
+// future visual change there won't automatically reach old or new exports —
+// an accepted, documented trade-off (see the decision doc) given fonts must
+// already be captured as a base64 snapshot for the same reason.
+const EXPORT_CSS = `
+:root {
+  --font-display: "Doto", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans: "Iosevka Term", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-serif: "Source Serif 4", Georgia, "Times New Roman", serif;
+  --font-mono: "Iosevka Term", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --text-display-floor: 1.25rem;
+  --color-off: #698879;
+  --color-off-light: #dbfaeb;
+  --color-token: #ffecb9;
+  --color-token-dark: #ffbd08;
+  --color-token-dark-rgb: 255, 189, 8;
+  --color-off-light-rgb: 219, 250, 235;
+  --color-rule: #e3e1d5;
+  --color-bg-soft: #f6f5ef;
+  --color-shell: #14171a;
+  --color-shell-text: #e8eae6;
+  --color-text: #222;
+  --color-text-soft: #444;
+  --color-surface: #fff;
+  --color-surface-card: #fafaf6;
+  --color-link: #2f5a44;
+  --color-token-text: #9a6700;
+  --color-danger-text: #8a2b22;
+  --space-2xs: 0.25rem;
+  --space-3xs: 0.125rem;
+  --space-xs: 0.375rem;
+  --space-sm: 0.5rem;
+  --space-md: 0.75rem;
+  --space-lg: 1rem;
+  --space-xl: 1.5rem;
+  --space-2xl: 2rem;
+  --text-2xs: 0.72rem;
+  --text-xs: 0.8rem;
+  --text-sm: 0.9rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --text-3xl: 1.75rem;
+  --tracking-wide: 0.05em;
+  --shadow-card: 0 0 0 1px rgba(0, 0, 0, 0.04);
+  --unit: 18px;
+  --pixel-bookmark: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%3E%3Cpath%20d%3D%22M6%202h12v2H6zM4%204h2v18H4zm14%200h2v18h-2zm-2%2016h2v2h-2zm-2-2h2v2h-2zm-8%202h2v2H6zm2-2h2v2H8zm2-2h4v2h-4z%22%2F%3E%3C%2Fsvg%3E");
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-size: var(--unit);
+  color: var(--color-shell-text);
+  background: var(--color-shell);
+  padding: var(--space-2xl) var(--space-lg);
+}
+h1, h2, h3, h4, h5 { font-family: var(--font-sans); line-height: 1.2; }
+li, p { font-family: var(--font-serif); line-height: 1.55; font-feature-settings: "onum" 1; }
+.surface, .report { color: var(--color-text); }
+.surface {
+  background: var(--color-surface-card);
+  border: 1px solid var(--color-rule);
+  border-radius: 0;
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-card);
+}
+.surface--finding { background: var(--color-off-light); border-color: var(--color-off); }
+.surface--finding .meta { color: var(--color-link); font-weight: 400; }
+p.meta, .meta { font-family: var(--font-sans); font-size: var(--text-xs); font-weight: 200; color: var(--color-off); }
+.finding-id { font-family: var(--font-display); font-weight: 400; }
+
+/* --- markdown-body (shared with /findings, /documents) --- */
+.markdown-body { font-family: var(--font-serif); font-feature-settings: "onum" 1; line-height: 1.6; overflow-wrap: break-word; }
+.markdown-body table { font-feature-settings: "lnum" 1; }
+.markdown-body > * + * { margin-top: var(--space-lg); }
+.markdown-body h1 { font-size: var(--text-2xl); font-weight: 700; margin-top: var(--space-2xl); padding-bottom: var(--space-xs); border-bottom: 1px solid var(--color-rule); }
+.markdown-body h2 { font-size: var(--text-xl); font-weight: 600; margin-top: var(--space-xl); }
+.markdown-body h3 { font-size: var(--text-lg); font-weight: 600; margin-top: var(--space-xl); }
+.markdown-body h4, .markdown-body h5, .markdown-body h6 { font-size: var(--text-base); font-weight: 600; color: var(--color-off); margin-top: var(--space-lg); }
+.markdown-body p { margin: 0; }
+.markdown-body * + p { margin-top: var(--space-lg); }
+.markdown-body strong { font-weight: 700; }
+.markdown-body em { font-style: italic; }
+.markdown-body ul, .markdown-body ol { padding-left: var(--space-xl); }
+.markdown-body li { margin-top: var(--space-xs); }
+.markdown-body li:first-child { margin-top: 0; }
+.markdown-body li > p { margin-top: var(--space-xs); }
+.markdown-body li > ul, .markdown-body li > ol { margin-top: var(--space-xs); }
+.markdown-body a { color: var(--color-link); font-weight: 700; text-decoration: none; }
+.markdown-body a:hover { text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+.markdown-body blockquote { padding: var(--space-2xs) var(--space-lg); border-left: 3px solid var(--color-off); color: var(--color-text-soft); font-style: italic; }
+.markdown-body code { font-family: var(--font-mono); font-size: 0.9em; background: var(--color-bg-soft); padding: 0.1em 0.35em; border-radius: 0; }
+.markdown-body pre { font-family: var(--font-mono); font-size: var(--text-sm); background: var(--color-bg-soft); padding: var(--space-md) var(--space-lg); border-radius: 0; overflow-x: auto; line-height: 1.5; }
+.markdown-body pre code { background: transparent; padding: 0; font-size: inherit; }
+.markdown-body hr { border: 0; border-top: 1px solid var(--color-rule); margin: var(--space-2xl) 0; }
+.markdown-body table { display: block; width: max-content; max-width: 100%; overflow-x: auto; border-collapse: collapse; font-family: var(--font-sans); font-size: var(--text-sm); }
+.markdown-body th, .markdown-body td { background-color: var(--color-surface); border: 1px solid var(--color-rule); padding: var(--space-2xs) var(--space-sm); text-align: left; }
+.markdown-body th { background: var(--color-bg-soft); font-weight: 600; }
+.markdown-body img { max-width: 100%; height: auto; }
+
+/* --- two-column split + R4 ledger treatment (#593) --- */
+.split { display: grid; grid-template-columns: minmax(0, 54rem) minmax(0, 1fr); gap: var(--space-xl); align-items: start; }
+.split .report { min-width: 0; }
+.split .viewer { position: sticky; top: var(--space-lg); height: calc(100vh - 4rem); }
+.split .viewer iframe { width: 100%; height: 100%; border: 1px solid var(--color-rule); }
+.ledger { --ledger-prose-width: 36rem; --ledger-notes-width: 14rem; }
+.ledger-hed { font-family: var(--font-sans); font-weight: 700; letter-spacing: -0.01em; max-width: var(--ledger-prose-width); }
+.ledger .meta { max-width: var(--ledger-prose-width); }
+.ledger-dek { font-family: var(--font-sans); font-weight: 400; font-size: var(--text-base); font-feature-settings: "lnum" 1; font-style: normal; color: var(--color-text-soft); margin-bottom: var(--space-lg); max-width: var(--ledger-prose-width); }
+.ledger-column { display: grid; grid-template-columns: minmax(0, var(--ledger-prose-width)) minmax(0, var(--ledger-notes-width)); gap: var(--space-xl); align-items: start; margin: var(--space-xl) 0; }
+.ledger-column .body { margin: 0; }
+.drop-cap-body > p:first-of-type::first-letter { font-family: var(--font-display); font-weight: 500; float: left; font-size: 3.1em; line-height: 0.78; margin: 0.02em 0.06em 0 0; color: var(--color-text); }
+
+/* --- margin-note citation gutter --- */
+.cite-notes { position: relative; padding-left: var(--space-xl); }
+.cite-notes .margin-note { left: 0; right: 0; }
+.margin-note { font-family: var(--font-sans); font-size: var(--text-2xs); line-height: 1.4; }
+.margin-note__head { margin: 0; text-transform: uppercase; letter-spacing: var(--tracking-wide); font-weight: 500; }
+.margin-note__dagger { font-weight: 700; }
+.margin-note__dagger::before {
+  content: "";
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  margin-right: 0.25em;
+  vertical-align: -1px;
+  background-color: currentColor;
+  image-rendering: pixelated;
+  -webkit-mask: var(--pixel-bookmark) center / contain no-repeat;
+  mask: var(--pixel-bookmark) center / contain no-repeat;
+}
+.margin-note__body { margin: var(--space-3xs) 0 0; font-feature-settings: "lnum" 1; word-break: break-word; }
+.margin-note__body--doc { font-style: italic; color: var(--color-text-soft); }
+.margin-note__source-row { display: flex; align-items: baseline; gap: var(--space-3xs); }
+.margin-note__link { display: inline; padding: 0; border: 0; background: none; font: inherit; text-align: left; cursor: pointer; color: var(--color-token-text); text-decoration: underline; text-underline-offset: 2px; text-decoration-color: color-mix(in srgb, var(--color-token-text) 35%, transparent); }
+.margin-note__link:hover, .margin-note__link.active { text-decoration-color: var(--color-token-text); }
+.margin-note--source .margin-note__head { color: var(--color-token-text); }
+.margin-note--gone .margin-note__head { color: var(--color-danger-text); }
+.margin-note--gone .margin-note__body { color: var(--color-danger-text); font-style: italic; }
+.margin-note--finding .margin-note__head { color: var(--color-token-text); }
+
+/* --- inline dagger anchors --- */
+.cite-ref { font-family: var(--font-sans); font-weight: 700; font-size: 0.7em; cursor: pointer; padding-left: 0.05em; }
+.cite-ref--source { color: var(--color-token-text); }
+.cite-ref--gone { color: var(--color-danger-text); }
+.cite-ref--finding { color: var(--color-token-text); }
+.cite-ref:hover { text-decoration: underline; }
+
+/* --- viewer pane placeholder (mirrors SourceViewer.svelte) --- */
+.placeholder { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--space-xs); height: 100%; min-height: 8rem; padding: var(--space-2xl); color: var(--color-off); font-family: var(--font-sans); text-align: center; }
+.placeholder__icon { font-size: var(--text-2xl); line-height: 1; opacity: 0.45; margin-bottom: var(--space-xs); }
+.placeholder__msg { font-size: var(--text-sm); color: var(--color-off); font-family: var(--font-sans); }
+.placeholder__detail { font-size: var(--text-xs); color: var(--color-off); opacity: 0.7; font-family: var(--font-sans); max-width: 22ch; line-height: 1.4; }
+
+/* --- export-only additions: PDF fallback link, image-chunk viewer --- */
+.export-pdf-wrap { display: flex; flex-direction: column; height: 100%; gap: var(--space-sm); }
+.export-pdf-wrap iframe { flex: 1; min-height: 0; }
+.export-fallback { font-family: var(--font-sans); font-size: var(--text-xs); }
+.export-fallback a { color: var(--color-off-light); }
+.export-image { max-width: 100%; max-height: 100%; display: block; margin: 0 auto; background: var(--color-surface); }
+
+@media (max-width: 56rem) {
+  .split { grid-template-columns: minmax(0, 1fr); }
+  .split .viewer { height: auto; }
+  .ledger-column { grid-template-columns: minmax(0, 1fr); }
+  .cite-notes { display: flex; flex-direction: column; gap: var(--space-lg); border-top: 1px solid var(--color-rule); padding-left: 0; padding-top: var(--space-lg); margin-top: var(--space-md); height: auto !important; }
+  .cite-notes .margin-note { position: static !important; top: auto !important; }
+}
+`;
+
+// ---------------------------------------------------------------------------
+// Source classification + embedding. Mirrors SourceViewer.svelte's own
+// isMarkdown/isText/isPdf dispatch regexes exactly, so a cited file renders
+// through the same branch live and in the export.
+const RE_MARKDOWN = /\.(md|markdown)$/i;
+const RE_TEXT = /\.(txt|text|log)$/i;
+const RE_PDF = /\.pdf$/i;
+const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.bmp', '.tiff', '.tif']);
+
+// One citation → one embed key + page. `key` dedupes: several citations
+// against the same document (at different pages) share one embedded payload,
+// so a PDF's base64 data isn't repeated per-citation (see the module docs on
+// why this is necessary — an "accepted, massive" file is still not the same
+// as an accidentally-quadratic one).
+function classifyCitation(c) {
+  if (c.source_kind === 'image') {
+    return { embedKind: 'image', key: `image:${c.source_id}` };
+  }
+  if (c.document_id == null) return null;
+  const name = c.file_name ?? '';
+  if (RE_PDF.test(name)) return { embedKind: 'pdf', key: `doc:${c.document_id}`, page: c.page_number ?? null };
+  if (RE_MARKDOWN.test(name)) return { embedKind: 'markdown', key: `doc:${c.document_id}` };
+  if (RE_TEXT.test(name)) return { embedKind: 'text', key: `doc:${c.document_id}` };
+  const ext = path.extname(name).toLowerCase();
+  if (IMAGE_EXTS.has(ext)) return { embedKind: 'image', key: `doc:${c.document_id}` };
+  return { embedKind: 'raw', key: `doc:${c.document_id}` };
+}
+
+// Reads the file for one classified citation and returns its embed payload
+// (or null when the archived file is missing on disk). Image-kind citations
+// (source_kind='image') embed the archived .jpg itself, keyed by image_id —
+// not the parent document's PDF (GH-0690 resolved question #3).
+function buildEmbedPayload(classified, c) {
+  const isImageChunk = classified.embedKind === 'image' && c.source_kind === 'image';
+  const filePath = isImageChunk ? getImageFilePath(c.source_id) : getDocumentFilePath(c.document_id);
+  if (!filePath || !fs.existsSync(filePath)) return null;
+
+  // For an image-chunk citation, `c.file_name` is the PARENT document's name
+  // (resolveSources() in queries.js maps image chunks to their parent doc for
+  // the live citationUrl/label — see its comment); the archived jpg on disk
+  // has its own name, which is what's actually being embedded here.
+  const fileName = isImageChunk ? path.basename(filePath) : (c.file_name ?? path.basename(filePath));
+  const ext = path.extname(filePath).toLowerCase();
+  const mime = MIME_BY_EXT[ext] ?? 'application/octet-stream';
+  const data = fs.readFileSync(filePath);
+
+  if (classified.embedKind === 'pdf') {
+    return { kind: 'pdf', dataUri: `data:application/pdf;base64,${data.toString('base64')}`, fileName };
+  }
+  if (classified.embedKind === 'text') {
+    return { kind: 'inline', srcdoc: wrapViewerDocument(`<pre>${escapeHtml(data.toString('utf-8'))}</pre>`), fileName };
+  }
+  if (classified.embedKind === 'markdown') {
+    return { kind: 'inline', srcdoc: wrapViewerDocument(renderMarkdown(data.toString('utf-8'))), fileName };
+  }
+  if (classified.embedKind === 'image') {
+    return { kind: 'image', dataUri: `data:${mime};base64,${data.toString('base64')}`, fileName };
+  }
+  // 'raw' (html/htm, or anything the ingest pipeline didn't recognize): a
+  // sandboxed iframe on the raw bytes, same as the live "everything else"
+  // branch — no script execution (sandbox=""), whatever the browser can render.
+  return { kind: 'raw', dataUri: `data:${mime};base64,${data.toString('base64')}`, fileName };
+}
+
+// ---------------------------------------------------------------------------
+// Margin-note HTML. Head label is always "source" / "missing source" — the
+// live template (+page.svelte) uses that generic label regardless of dagger
+// kind, so this matches. Two deliberate departures from the live markup
+// (GH-0690 resolved questions): a [^finding:N] note renders inert (no link —
+// the other finding isn't in this file) and a resolved chunk note drops the
+// "open chunk" icon link (/chunks/N doesn't exist standalone either).
+function renderMarginNoteHtml(note) {
+  const headLabel = note.gone ? 'missing source' : 'source';
+  const kindClass = note.gone ? 'gone' : note.finding ? 'finding' : 'source';
+  let bodyHtml;
+  if (note.gone) {
+    bodyHtml = `<p class="margin-note__body">no longer available</p>`;
+  } else if (note.finding) {
+    bodyHtml = `<p class="margin-note__body">${escapeHtml(note.label)}</p>`;
+  } else if (note.external === 'url') {
+    bodyHtml = `<p class="margin-note__body"><a href="${escapeHtml(note.href)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</a></p>`;
+  } else if (note.external === 'doc') {
+    bodyHtml = `<p class="margin-note__body margin-note__body--doc" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</p>`;
+  } else {
+    bodyHtml = `<span class="margin-note__body margin-note__source-row"><button type="button" class="margin-note__link" data-chunk-id="${note.chunkId}" title="${escapeHtml(note.title)}">${escapeHtml(note.label)}</button></span>`;
+  }
+  return `<div class="margin-note margin-note--${kindClass}" data-note="${note.n}">
+    <p class="margin-note__head"><span class="margin-note__dagger">${note.dagger}${note.n}</span> ${headLabel}</p>
+    ${bodyHtml}
+  </div>`;
+}
+
+// A finding's meta line: "#N · session · model (Set by LLM) · created_at" —
+// mirrors +page.svelte's <p class="meta"> markup.
+function buildMetaLine(finding) {
+  const modelMeta = finding.model
+    ? `${finding.model}${finding.model_set_by_llm ? ' (Set by LLM)' : ''}`
+    : null;
+  const bits = [finding.session_name, modelMeta, finding.created_at].filter(Boolean);
+  return `<span class="finding-id">#${finding.finding_id}</span> · ${escapeHtml(bits.join(' · '))}`;
+}
+
+// Filename slug — mirrors _slug() in bartleby/commands/finding.py and the web
+// viewer's downloadMarkdown().
+function slug(title) {
+  const s = (title || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return s || 'finding';
+}
+
+// Escapes `<` out of a JSON payload before it goes inside a <script> tag, so a
+// literal "</script" substring in embedded data (an ingest filename, a cited
+// document's text) can't prematurely close the tag. The HTML tokenizer looks
+// for that literal text regardless of the script's `type`, so this is needed
+// even though these are `type="application/json"` (inert, never executed).
+function jsonScriptSafe(value) {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+// The margin-note layout (Tufte dagger-alignment) + viewer-pane click wiring,
+// re-expressed in vanilla JS — a standalone equivalent of +page.svelte's
+// layoutNotes()/activate()/citationUrl(), since the export carries no Svelte
+// runtime. Embedded sources are pre-built server-side (BARTLEBY_CITATIONS maps
+// a chunk_id to an embed key + page; BARTLEBY_SOURCES holds one payload per
+// unique embed key), so activation here is a pure client-side lookup + DOM
+// swap — no fetch, no network.
+const RUNTIME_JS = `
+(function () {
+  var CITATIONS = JSON.parse(document.getElementById('bartleby-citations').textContent);
+  var SOURCES = JSON.parse(document.getElementById('bartleby-sources').textContent);
+  var container = document.getElementById('report');
+  var citesAside = document.getElementById('cite-notes');
+  var viewer = document.getElementById('viewer');
+
+  function showPlaceholder() {
+    viewer.innerHTML = '';
+    var div = document.createElement('div');
+    div.className = 'placeholder';
+    var icon = document.createElement('span');
+    icon.className = 'placeholder__icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '\\u25E7';
+    var msg = document.createElement('p');
+    msg.className = 'placeholder__msg';
+    msg.textContent = 'No source selected';
+    var detail = document.createElement('p');
+    detail.className = 'placeholder__detail';
+    detail.textContent = 'Click an inline citation to view the source here.';
+    div.appendChild(icon);
+    div.appendChild(msg);
+    div.appendChild(detail);
+    viewer.appendChild(div);
+  }
+
+  function showPdf(dataUri, page, fileName) {
+    viewer.innerHTML = '';
+    var wrap = document.createElement('div');
+    wrap.className = 'export-pdf-wrap';
+    var iframe = document.createElement('iframe');
+    iframe.title = 'Source document';
+    iframe.src = dataUri + (page ? ('#page=' + page + '&navpanes=0') : '#navpanes=0');
+    wrap.appendChild(iframe);
+    var dl = document.createElement('div');
+    dl.className = 'export-fallback';
+    var a = document.createElement('a');
+    a.href = dataUri;
+    a.download = fileName || 'source.pdf';
+    a.textContent = 'Download ' + (fileName || 'this PDF') + ' (if the viewer above stays blank)';
+    dl.appendChild(a);
+    wrap.appendChild(dl);
+    viewer.appendChild(wrap);
+  }
+
+  function showInline(srcdoc, title) {
+    viewer.innerHTML = '';
+    var iframe = document.createElement('iframe');
+    iframe.title = title || 'Source';
+    iframe.setAttribute('sandbox', '');
+    iframe.srcdoc = srcdoc;
+    viewer.appendChild(iframe);
+  }
+
+  function showImage(dataUri, fileName) {
+    viewer.innerHTML = '';
+    var img = document.createElement('img');
+    img.className = 'export-image';
+    img.src = dataUri;
+    img.alt = fileName || 'Source image';
+    viewer.appendChild(img);
+  }
+
+  function showRaw(dataUri, fileName) {
+    viewer.innerHTML = '';
+    var iframe = document.createElement('iframe');
+    iframe.title = fileName || 'Source document';
+    iframe.setAttribute('sandbox', '');
+    iframe.src = dataUri;
+    viewer.appendChild(iframe);
+  }
+
+  function activate(chunkId) {
+    var meta = CITATIONS[chunkId];
+    var src = meta && SOURCES[meta.key];
+    if (!src) { showPlaceholder(); return; }
+    if (src.kind === 'pdf') showPdf(src.dataUri, meta.page, src.fileName);
+    else if (src.kind === 'inline') showInline(src.srcdoc, src.fileName);
+    else if (src.kind === 'image') showImage(src.dataUri, src.fileName);
+    else if (src.kind === 'raw') showRaw(src.dataUri, src.fileName);
+    else { showPlaceholder(); return; }
+
+    var buttons = container.querySelectorAll('.margin-note__link[data-chunk-id]');
+    for (var i = 0; i < buttons.length; i++) {
+      buttons[i].classList.toggle('active', buttons[i].dataset.chunkId === String(chunkId));
+    }
+  }
+
+  container.addEventListener('click', function (e) {
+    var ref = e.target.closest('.cite-ref');
+    if (ref) {
+      e.preventDefault();
+      var note = citesAside && citesAside.querySelector('.margin-note[data-note="' + ref.dataset.note + '"]');
+      if (note) note.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      var btn = note && note.querySelector('[data-chunk-id]');
+      if (btn) activate(btn.dataset.chunkId);
+      return;
+    }
+    var link = e.target.closest('.margin-note__link[data-chunk-id]');
+    if (link) {
+      e.preventDefault();
+      activate(link.dataset.chunkId);
+    }
+  });
+
+  var NOTE_GAP = 8;
+  function layoutNotes() {
+    if (!citesAside) return;
+    var narrow = window.matchMedia('(max-width: 56rem)').matches;
+    var noteEls = Array.prototype.slice.call(citesAside.querySelectorAll('.margin-note'));
+    if (narrow) {
+      noteEls.forEach(function (el) { el.style.position = ''; el.style.top = ''; });
+      citesAside.style.height = '';
+      return;
+    }
+    if (noteEls.length === 0) return;
+    var asideTop = citesAside.getBoundingClientRect().top + window.scrollY;
+    var items = noteEls.map(function (el) {
+      var n = el.dataset.note;
+      var ref = container.querySelector('.cite-ref[data-note="' + n + '"]');
+      var top = 0;
+      if (ref) {
+        top = ref.getBoundingClientRect().top + window.scrollY - asideTop;
+        if (top < 0) top = 0;
+      }
+      el.style.position = 'absolute';
+      el.style.top = top + 'px';
+      return { el: el, top: top };
+    });
+    var runningBottom = 0;
+    items.forEach(function (item) {
+      var height = item.el.offsetHeight;
+      if (item.top < runningBottom) item.top = runningBottom;
+      item.el.style.top = item.top + 'px';
+      runningBottom = item.top + height + NOTE_GAP;
+    });
+    citesAside.style.height = (runningBottom - NOTE_GAP) + 'px';
+  }
+
+  window.addEventListener('resize', layoutNotes);
+  if (typeof ResizeObserver !== 'undefined') {
+    var body = container.querySelector('.body');
+    if (body) new ResizeObserver(layoutNotes).observe(body);
+  }
+  showPlaceholder();
+  layoutNotes();
+})();
+`;
+
+function renderDocument({ title, metaLine, description, bodyHtml, notesHtml, citationMetaJson, sourcesJson }) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width" />
+<title>${escapeHtml(title)} — Bartleby finding export</title>
+<style>${buildFontFaceCss()}
+${EXPORT_CSS}</style>
+</head>
+<body>
+<div class="split">
+  <article class="report surface surface--finding ledger" id="report">
+    <h1 class="ledger-hed">${escapeHtml(title)}</h1>
+    <p class="meta">${metaLine}</p>
+    ${description ? `<p class="ledger-dek">${escapeHtml(description)}</p>` : ''}
+    <div class="ledger-column">
+      <div class="body markdown-body drop-cap-body">${bodyHtml}</div>
+      ${notesHtml ? `<aside class="cite-notes" id="cite-notes" aria-label="Citations">${notesHtml}</aside>` : ''}
+    </div>
+  </article>
+  <aside class="viewer" id="viewer"></aside>
+</div>
+<script type="application/json" id="bartleby-citations">${citationMetaJson}</script>
+<script type="application/json" id="bartleby-sources">${sourcesJson}</script>
+<script>${RUNTIME_JS}</script>
+</body>
+</html>
+`;
+}
+
+// Assembles the standalone export for one finding. Returns null when the
+// finding doesn't exist (the route 404s); returns `{ html, filename }`
+// otherwise.
+export function buildFindingExportHtml(findingId) {
+  const finding = getFinding(findingId);
+  if (!finding) return null;
+
+  const byId = new Map(finding.citations.map((c) => [c.chunk_id, c]));
+  const { markdown, notes } = substituteCitations(finding.body, byId, null);
+  const bodyHtml = renderMarkdown(markdown);
+
+  const sources = new Map();
+  const citationMeta = {};
+  for (const note of notes) {
+    if (note.gone || note.finding || note.external) continue;
+    const c = byId.get(note.chunkId);
+    const classified = c && classifyCitation(c);
+    if (!classified) continue;
+    if (!sources.has(classified.key)) {
+      const payload = buildEmbedPayload(classified, c);
+      if (payload) sources.set(classified.key, payload);
+    }
+    if (sources.has(classified.key)) {
+      citationMeta[note.chunkId] = { key: classified.key, page: classified.page ?? null };
+    }
+  }
+
+  const html = renderDocument({
+    title: finding.title,
+    metaLine: buildMetaLine(finding),
+    description: finding.description,
+    bodyHtml,
+    notesHtml: notes.map(renderMarginNoteHtml).join('\n'),
+    citationMetaJson: jsonScriptSafe(citationMeta),
+    sourcesJson: jsonScriptSafe(Object.fromEntries(sources))
+  });
+
+  return { html, filename: `${slug(finding.title)}.html` };
+}

--- a/bartleby/web/src/lib/server/mime.js
+++ b/bartleby/web/src/lib/server/mime.js
@@ -18,3 +18,13 @@ export const MIME_BY_EXT = {
   '.tiff': 'image/tiff',
   '.tif': 'image/tiff'
 };
+
+// Extensions MIME_BY_EXT maps to an image/* type — derived, not re-enumerated,
+// so the two can't drift apart. Used by the HTML export (GH-0690) to classify
+// an image-typed *document* citation (a .jpg ingested as a whole document,
+// distinct from an extracted image chunk) for embedding.
+export const IMAGE_EXTS = new Set(
+  Object.entries(MIME_BY_EXT)
+    .filter(([, mime]) => mime.startsWith('image/'))
+    .map(([ext]) => ext)
+);

--- a/bartleby/web/src/lib/server/mime.js
+++ b/bartleby/web/src/lib/server/mime.js
@@ -1,0 +1,20 @@
+// Extensions the ingest pipeline accepts (see bartleby/ingest/chunk.py).
+// Anything else falls back to octet-stream — the browser will offer download.
+// Shared by the live /files/[document_id] route (Content-Type header) and the
+// standalone HTML export (routes/findings/[id]/export.html/+server.js —
+// GH-0690, embedded sources' data: URI MIME types) so the two stay in sync.
+export const MIME_BY_EXT = {
+  '.pdf': 'application/pdf',
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  // Browsers download text/markdown — serve as plain text so the iframe shows it.
+  '.md': 'text/plain; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.tiff': 'image/tiff',
+  '.tif': 'image/tiff'
+};

--- a/bartleby/web/src/lib/server/queries.js
+++ b/bartleby/web/src/lib/server/queries.js
@@ -44,6 +44,10 @@ export function getFinding(findingId) {
 // can render a link straight to the archived PDF at the right page.
 // Image chunks pull their page from document_images (image can appear on
 // different pages in different documents — take the lowest-doc, lowest-page).
+// source_kind/source_id ride along unchanged from `chunks` — the live finding
+// view ignores them, but the HTML export (GH-0690) needs source_kind to
+// dispatch embedding (PDF/text/markdown/image) and source_id as the image_id
+// for image-kind citations (getImageFilePath).
 function getCitations(findingId) {
   const { db } = getDb();
   const rows = db.prepare(`
@@ -57,6 +61,8 @@ function getCitations(findingId) {
   const resolved = resolveSources(rows);
   return rows.map((r, i) => ({
     chunk_id: r.chunk_id,
+    source_kind: r.source_kind,
+    source_id: r.source_id,
     ...resolved[i]
   }));
 }
@@ -233,6 +239,17 @@ export function getDocumentFilePath(documentId) {
   const row = db.prepare(
     'SELECT file_path FROM documents WHERE document_id = ?'
   ).get(documentId);
+  return row ? row.file_path : null;
+}
+
+// The archived original of one extracted image (source_kind='image' chunks
+// cite an image_id, not a document_id) — used by the HTML export (GH-0690) to
+// embed the actual cited .jpg rather than its parent document's PDF.
+export function getImageFilePath(imageId) {
+  const { db } = getDb();
+  const row = db.prepare(
+    'SELECT file_path FROM images WHERE image_id = ?'
+  ).get(imageId);
   return row ? row.file_path : null;
 }
 

--- a/bartleby/web/src/lib/viewerDoc.js
+++ b/bartleby/web/src/lib/viewerDoc.js
@@ -1,0 +1,42 @@
+// The sandboxed-iframe document shell for inline (markdown/text) source
+// rendering — shared by SourceViewer.svelte (the live viewer pane) and the
+// standalone HTML export (routes/findings/[id]/export.html/+server.js —
+// GH-0690), so the exported file's embedded sources are styled identically to
+// the live app without a second copy of this CSS to drift out of sync.
+//
+// The iframe is its own document and can't reach app.css or its CSS variables,
+// so the source styling is inlined. Neutral and compact — readable evidence,
+// not a pixel-match to the prose pane.
+export const VIEWER_CSS = `
+    body { margin: 0; padding: 1.25rem 1.5rem; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; font-size: 0.9rem; line-height: 1.6; color: #1a1a1a; background: #fff; overflow-wrap: anywhere; }
+    h1, h2, h3, h4 { line-height: 1.25; margin: 1.4em 0 0.5em; }
+    h1 { font-size: 1.5rem; } h2 { font-size: 1.25rem; } h3 { font-size: 1.05rem; }
+    p, ul, ol, blockquote, table, pre { margin: 0 0 1em; }
+    a { color: #0645ad; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.85em; background: #f2f2f2; padding: 0.1em 0.3em; border-radius: 3px; }
+    pre { background: #f6f6f6; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
+    pre code { background: none; padding: 0; }
+    blockquote { border-left: 3px solid #ddd; padding-left: 1em; color: #555; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ddd; padding: 0.4em 0.6em; text-align: left; }
+    th { background: #f6f6f6; }
+    img { max-width: 100%; }
+    hr { border: none; border-top: 1px solid #ddd; margin: 1.5em 0; }
+  `;
+
+// Wrap `inner` (already-rendered/escaped HTML) in a minimal standalone
+// document for a sandboxed iframe: `default-src 'none'` blocks every outbound
+// request (a tracking-pixel <img> in untrusted source markdown, which
+// DOMPurify keeps, would otherwise beacon out on view); `style-src
+// 'unsafe-inline'` only enables this inlined stylesheet.
+export function wrapViewerDocument(inner) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'" />
+<style>${VIEWER_CSS}</style>
+</head>
+<body>${inner}</body>
+</html>`;
+}

--- a/bartleby/web/src/lib/viewerDoc.js
+++ b/bartleby/web/src/lib/viewerDoc.js
@@ -3,7 +3,13 @@
 // standalone HTML export (routes/findings/[id]/export.html/+server.js —
 // GH-0690), so the exported file's embedded sources are styled identically to
 // the live app without a second copy of this CSS to drift out of sync.
-//
+
+// File-type dispatch by extension — also shared by both, so a cited file
+// renders through the same branch live and in the export.
+export const RE_MARKDOWN = /\.(md|markdown)$/i;
+export const RE_TEXT = /\.(txt|text|log)$/i;
+export const RE_PDF = /\.pdf$/i;
+
 // The iframe is its own document and can't reach app.css or its CSS variables,
 // so the source styling is inlined. Neutral and compact — readable evidence,
 // not a pixel-match to the prose pane.

--- a/bartleby/web/src/routes/files/[document_id]/+server.js
+++ b/bartleby/web/src/routes/files/[document_id]/+server.js
@@ -3,24 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getDocumentFilePath } from '$lib/server/queries.js';
 import { parseIdParam } from '$lib/server/params.js';
-
-// Extensions that the ingest pipeline accepts (see bartleby/ingest/chunk.py).
-// Anything else falls back to octet-stream — the browser will offer download.
-const MIME_BY_EXT = {
-  '.pdf': 'application/pdf',
-  '.html': 'text/html; charset=utf-8',
-  '.htm': 'text/html; charset=utf-8',
-  // Browsers download text/markdown — serve as plain text so the iframe shows it.
-  '.md': 'text/plain; charset=utf-8',
-  '.txt': 'text/plain; charset=utf-8',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.png': 'image/png',
-  '.webp': 'image/webp',
-  '.bmp': 'image/bmp',
-  '.tiff': 'image/tiff',
-  '.tif': 'image/tiff'
-};
+import { MIME_BY_EXT } from '$lib/server/mime.js';
 
 export function GET({ params }) {
   const documentId = parseIdParam(params.document_id, 'document');

--- a/bartleby/web/src/routes/findings/[id]/+page.svelte
+++ b/bartleby/web/src/routes/findings/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import SourceViewer from "$lib/components/SourceViewer.svelte";
   import { substituteCitations } from "$lib/citations.js";
   import { CHUNK_ICON } from "$lib/icons.js";
+  import { slugify } from "$lib/format.js";
 
   export let data;
 
@@ -180,10 +181,9 @@
 
   function downloadMarkdown() {
     const blob = new Blob([data.finding.body], { type: "text/markdown" });
-    const name = data.finding.title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
     const a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
-    a.download = `${name}.md`;
+    a.download = `${slugify(data.finding.title)}.md`;
     a.click();
   }
 

--- a/bartleby/web/src/routes/findings/[id]/+page.svelte
+++ b/bartleby/web/src/routes/findings/[id]/+page.svelte
@@ -3,7 +3,7 @@
   import { marked } from "marked";
   import Button from "$lib/components/Button.svelte";
   import SourceViewer from "$lib/components/SourceViewer.svelte";
-  import { escapeHtml, stripExt } from "$lib/format.js";
+  import { substituteCitations } from "$lib/citations.js";
   import { CHUNK_ICON } from "$lib/icons.js";
 
   export let data;
@@ -48,125 +48,13 @@
   $: bodyHtml = rendered.html;
   $: notes = rendered.notes;
 
+  // Marker substitution + note-building is shared with the HTML export
+  // (GH-0690) via $lib/citations.js; only the final marked.parse() pass (this
+  // app's global, DOMPurify-hooked `marked` singleton — see +layout.svelte)
+  // stays here.
   function renderBody(body, byId, active) {
-    const collected = [];
-    let n = 0;
-    const html = marked.parse(
-      body.replace(/\[\^([A-Za-z]+):([^\]]+)\]/g, (match, scheme, ref) => {
-        const s = scheme.toLowerCase();
-        if (s === "chunk") {
-          const id = Number(ref.trim());
-          // A non-numeric chunk ref can't resolve; leave the marker verbatim.
-          if (!Number.isInteger(id)) return escapeHtml(match);
-          const c = byId.get(id);
-          const note = c
-            ? sourceNote(++n, c, c === active)
-            : goneNote(++n, id);
-          collected.push(note);
-          return marker(note);
-        }
-        if (s === "finding") {
-          const id = Number(ref.trim());
-          // A non-numeric finding ref can't resolve; leave the marker verbatim.
-          if (!Number.isInteger(id)) return escapeHtml(match);
-          const note = findingNote(++n, id);
-          collected.push(note);
-          return marker(note);
-        }
-        const note = externalNote(++n, s, ref.trim());
-        if (!note) {
-          n--; // unknown scheme: drop, don't burn an ordinal
-          return escapeHtml(match);
-        }
-        collected.push(note);
-        return marker(note);
-      }),
-    );
-    return { html, notes: collected };
-  }
-
-  // The inline dagger anchor that sits at the cited point in the prose. A
-  // superscript <sup> with the dagger glyph + ordinal; the ordinal ties it to
-  // its gutter note. Stable class hooks (`cite-ref`, kind modifier) so R3 (#592)
-  // can splice a pixel icon in without touching this code.
-  function marker(note) {
-    const kindCls = note.gone
-      ? "cite-ref--gone"
-      : note.finding
-        ? "cite-ref--finding"
-        : "cite-ref--source";
-    const title = note.gone
-      ? `${note.dagger} cited source no longer available`
-      : note.finding
-        ? `${note.dagger} finding · ${note.title}`
-        : `${note.dagger} source · ${note.title}`;
-    return `<sup class="cite-ref ${kindCls}" data-note="${note.n}" title="${escapeHtml(title)}">${note.dagger}${note.n}</sup>`;
-  }
-
-  function sourceNote(n, c, isActive) {
-    const name = stripExt(c.file_name);
-    const label =
-      name && c.page_number ? `${name} p.${c.page_number}`
-      : name ? name
-      : c.page_number ? `p.${c.page_number}`
-      : `chunk ${c.chunk_id}`;
-    const title = [
-      c.file_name,
-      c.page_number && `page ${c.page_number}`,
-      `chunk ${c.chunk_id}`,
-    ].filter(Boolean).join(" · ");
-    return {
-      n,
-      dagger: "¶",
-      gone: false,
-      chunkId: c.chunk_id,
-      active: isActive,
-      label,
-      title,
-    };
-  }
-
-  // An unresolved [^chunk:N]: the cited source has been removed (deleted, or
-  // rebuilt under new chunk ids by an edit/merge), so only the id survives.
-  // Danger-toned gutter note rather than leaking raw [^N] text.
-  function goneNote(n, chunkId) {
-    return {
-      n,
-      dagger: "‡",
-      gone: true,
-      chunkId,
-      label: "no longer available",
-      title: `chunk ${chunkId} · cited source no longer available`,
-    };
-  }
-
-  // A [^finding:N] link — a unidirectional reference to another finding (#654).
-  // Rendered as a ¶-daggered gutter note with a link to /findings/N. No DB row
-  // backs this link; it is validated at save time and stored only in the body.
-  function findingNote(n, findingId) {
-    return {
-      n,
-      dagger: "§",
-      gone: false,
-      finding: true,
-      findingId,
-      href: `/findings/${findingId}`,
-      label: `finding #${findingId}`,
-      title: `finding #${findingId}`,
-    };
-  }
-
-  // An external (URL / external-dataset doc) citation parsed straight from the
-  // body marker — no DB row backs it. A url scheme becomes a real link, a doc
-  // scheme a muted ref. Unknown schemes return null (dropped upstream).
-  function externalNote(n, scheme, ref) {
-    if (scheme === "url") {
-      return { n, dagger: "†", gone: false, external: "url", href: ref, label: ref, title: `external source · ${ref}` };
-    }
-    if (scheme === "doc") {
-      return { n, dagger: "†", gone: false, external: "doc", label: ref, title: `external dataset doc · ${ref}` };
-    }
-    return null;
+    const { markdown, notes } = substituteCitations(body, byId, active);
+    return { html: marked.parse(markdown), notes };
   }
 
   let active = null;
@@ -298,6 +186,13 @@
     a.download = `${name}.md`;
     a.click();
   }
+
+  // GH-0690: the export route sets Content-Disposition: attachment, so a plain
+  // navigation triggers the browser's normal download flow rather than
+  // replacing the page.
+  function downloadHtml() {
+    window.location.href = `/findings/${data.finding.finding_id}/export.html`;
+  }
 </script>
 
 <div class="split">
@@ -313,6 +208,7 @@
         {copied ? "Copied" : "Copy as Markdown"}
       </Button>
       <Button size="sm" type="button" on:click={downloadMarkdown}>Download .md</Button>
+      <Button size="sm" type="button" on:click={downloadHtml}>Save as HTML</Button>
     </div>
 
     <!-- Ledger column: drop-capped prose + a margin-note gutter. The body

--- a/bartleby/web/src/routes/findings/[id]/export.html/+server.js
+++ b/bartleby/web/src/routes/findings/[id]/export.html/+server.js
@@ -1,0 +1,21 @@
+import { error } from '@sveltejs/kit';
+import { buildFindingExportHtml } from '$lib/server/exportHtml.js';
+import { parseIdParam } from '$lib/server/params.js';
+
+// "Save as HTML" (GH-0690): a single self-contained file reproducing the
+// /findings/[id] view, with every cited source and font embedded so it opens
+// with no server, no network, and no Bartleby install. See
+// bartleby/web/src/lib/server/exportHtml.js for the assembly and
+// docs/decisions/GH-0690-finding-html-export-0001.md for the design.
+export function GET({ params }) {
+  const findingId = parseIdParam(params.id, 'finding');
+  const built = buildFindingExportHtml(findingId);
+  if (!built) throw error(404, 'Not found');
+
+  return new Response(built.html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${built.filename}"`
+    }
+  });
+}

--- a/docs/decisions/GH-0690-finding-html-export-0001.md
+++ b/docs/decisions/GH-0690-finding-html-export-0001.md
@@ -130,3 +130,29 @@ not the parent PDF), the literal (unmangled) `.txt` content including its
 `/chunks/` or cross-finding `/findings/999` links, and balanced `<script>`
 tags. `uv run pytest` (untouched — no Python changed) and `npm run build`
 both pass.
+
+**Post-review hardening (fused-critic pass on PR #692).** Two correctness
+fixes landed after the initial cut, both export-only:
+
+- A `[^url:…]` note's `href` is now only emitted when the ref matches
+  `/^https?:\/\//i`; anything else (a `javascript:` URL being the obvious
+  case) renders as inert text instead of a clickable link. This export is
+  explicitly meant to be emailed or archived and opened by third parties, so
+  an inert-in-the-live-app-but-still-a-real-`<a href>`-in-the-export citation
+  was a real hole — the live page (`externalNote()` in `+page.svelte`) has the
+  same pre-existing gap and was deliberately left alone; this guard is
+  export-only.
+- A resolved `[^chunk:N]` citation whose archived file is missing on disk at
+  export time (`buildEmbedPayload` returns `null`) used to still render as a
+  normal, clickable ¶ "source" note — clicking it did nothing (the runtime's
+  `CITATIONS` map never got an entry for it), silently. It now renders inert
+  — no button, no `CITATIONS` wiring — with the note's usual label plus a
+  visible "— source file missing at export time" suffix, styled the same
+  muted-italic way an external `[^doc:…]` reference already is. The dagger
+  glyph and "source" head stay ¶/amber (unchanged): the citation *did*
+  resolve against the DB; only the archived bytes are absent, which is a
+  different fact from a chunk that no longer exists at all (‡). Font files
+  missing at export time are deliberately NOT given the same soft-fail
+  treatment — `buildFontFaceCss()` still throws (a loud 500) rather than
+  silently shipping a file with wrong fonts, since "exactly as is, including
+  the fonts" is the point of the feature.

--- a/docs/decisions/GH-0690-finding-html-export-0001.md
+++ b/docs/decisions/GH-0690-finding-html-export-0001.md
@@ -1,0 +1,132 @@
+# "Save as HTML" exports a finding as one self-contained file — fonts, sources, and margin-note behavior all embedded, no server.
+
+A new route, `GET /findings/[id]/export.html`, assembles a standalone HTML
+document that reproduces the live `/findings/[id]` view with everything it
+needs baked in: the three self-hosted font families as base64 `data:` URIs
+inside `@font-face`, every cited source embedded (PDF/image as base64 `data:`
+URIs, `.txt`/`.log` as literal escaped `<pre>` per GH-0680, `.md` rendered the
+same way `SourceViewer` renders it live), and a small vanilla-JS re-expression
+of the margin-note layout + note→viewer click wiring so the page works with no
+Svelte runtime, no fetches, and — per the issue — no network at all. The
+finding page's toolbar gained a third button (`Save as HTML`, beside `Copy as
+Markdown`/`Download .md`) that navigates to the endpoint; since the endpoint
+sets `Content-Disposition: attachment`, the browser downloads it instead of
+navigating away.
+
+**Shared logic, not a copy-paste fork.** The citation-marker → dagger-note
+substitution (`[^chunk:N]`/`[^finding:N]`/`[^url:…]`/`[^doc:…]` → ¶/§/†/‡ +
+gutter note) used to live entirely inside `+page.svelte`'s `renderBody()`. It's
+now `$lib/citations.js`'s `substituteCitations()` — a pure function with no
+Svelte, DOM, or `marked` dependency — imported by both `+page.svelte` (which
+still owns its own `marked.parse()` call, unchanged) and the export builder.
+Two more pieces moved to shared modules for the same reason: the sandboxed-
+iframe document wrapper + inline viewer CSS (`SourceViewer.svelte`'s
+`wrapDocument`/`VIEWER_CSS`) became `$lib/viewerDoc.js`, and the
+extension→MIME table (`files/[document_id]/+server.js`'s `MIME_BY_EXT`) became
+`$lib/server/mime.js`. Both the live route and the export now import these
+instead of each holding its own copy. `+page.svelte` and `SourceViewer.svelte`
+are otherwise untouched — no behavior change to the live view.
+
+**Sanitization: an isolated `Marked` instance, not "DOMPurify needs a DOM."**
+The issue's open question here turned out to be moot: `isomorphic-dompurify`
+is already a dependency and already runs server-side in this exact app — the
+global `marked` singleton's DOMPurify-sanitize + target/rel hook is registered
+by `+layout.svelte`'s module-context script, and that code runs during SSR of
+every page, not just in the browser. So there's nothing awkward about running
+DOMPurify in Node here; it's proven. The wrinkle is only that the export route
+is a `+server.js` endpoint, not a page component — it never imports
+`+layout.svelte`, so it can't rely on that hook having been registered (it
+would only be "registered" as a side effect of some other page having
+happened to render first in the same process, which is not something to
+depend on). The fix is a private `new Marked()` instance in
+`exportHtml.js` carrying the identical hook, used for both the finding body
+and any embedded `.md` source — sanitized unconditionally, independent of
+import order, no new dependency.
+
+**The three open questions, resolved as directed:**
+1. *PDF viewing*: embedded as `data:application/pdf;base64,...#page=N&navpanes=0`
+   in an iframe (desktop Chrome/Firefox render this inline) plus a fallback
+   `<a href="{same data URI}" download="{original filename}">` link under the
+   viewer, so a browser that won't render the PDF inline can still save it.
+2. *External/cross-finding citations*: a `[^url:…]` note keeps its real
+   hyperlink (`target="_blank" rel="noopener noreferrer"`, since it's now
+   leaving a local file rather than navigating the SPA); a `[^doc:…]` note was
+   already inert live (a plain label, no link) and stays that way; a
+   `[^finding:N]` note drops its `/findings/N` link entirely in the export —
+   `renderMarginNoteHtml()` in `exportHtml.js` deliberately ignores the `href`
+   that `substituteCitations()` still returns (used by the live page) and
+   renders inert text instead, since the other finding isn't in this file.
+   One more departure follows the same logic: a resolved corpus-chunk note
+   drops the "open chunk" icon link (`/chunks/N` doesn't exist standalone
+   either) — the label is still clickable to load the source in the viewer,
+   just without the secondary navigation affordance.
+3. *Image chunks* (`source_kind='image'`): embedded as the archived `.jpg`
+   itself, not the parent document. `resolveSources()` in `queries.js` maps an
+   image citation to its *parent document's* `document_id`/`file_name` (for the
+   live page's citation label and "open in the PDF at this page" link — that
+   mapping is untouched), but the actual bytes worth embedding are the
+   extracted image's own file. `getCitations()` now also carries `source_kind`/
+   `source_id` through (image chunks: `source_id` is the `image_id`), and a new
+   `getImageFilePath(imageId)` in `queries.js` resolves it to `images.file_path`.
+
+**Source embeds are deduplicated by document/image id, not by citation.**
+Several citations can point at the same document (different pages) or the
+same image. Embedding a fresh copy of the PDF's base64 data per citation would
+turn "large" into "citation-count × file-size" — a 50-page PDF cited eight
+times would repeat its full bytes eight times over. Instead `exportHtml.js`
+builds one `SOURCES` map keyed by `doc:<document_id>` / `image:<image_id>` and
+a small `CITATIONS` map from `chunk_id` → `{key, page}`; the embedded runtime
+JS looks up the shared payload and (for PDFs) appends the per-citation page
+fragment at click time. The file is still explicitly allowed to be massive —
+this just keeps it proportional to the number of *unique* cited sources, which
+is the trade-off actually intended.
+
+**The CSS (and fonts) are a hand-copied snapshot, not a shared import.** Fonts
+must be captured as base64 at request time regardless — there's no way to
+`@import` a `data:` URI from the live `fonts.css`. Given that, `exportHtml.js`
+also carries a curated subset of `app.css`'s rules (tokens, base typography,
+`.surface`/`.markdown-body`, the R4 ledger/margin-note/cite-ref treatment, the
+R3 dagger bookmark, `SourceViewer`'s placeholder states) as one literal
+`EXPORT_CSS` string, rather than parsing/transforming `app.css` at request
+time. This is an accepted trade-off, not an oversight: a future visual change
+to `app.css` won't automatically reach the export until this string is updated
+by hand. Given the fonts already require a hand-triggered re-snapshot on any
+font change, this isn't a new failure mode — just the same one, extended to
+cover the rest of the visual treatment.
+
+**Fonts are read from `static/fonts/` via a `process.cwd()`-relative path.**
+`bartleby serve` (`commands/serve.py`) always launches the vite *dev* server —
+never the `adapter-node` production build — out of `~/.bartleby/serve`, which
+`_sync_web()` populates by copying/symlinking this app's `static/` tree
+verbatim alongside `src/`, then `os.chdir()`s there before `exec`. So
+`static/fonts/*.woff2` is a stable path relative to `process.cwd()` in the one
+way this app is actually run; `exportHtml.js` reads the six font files from
+there rather than trying to resolve a path relative to its own (post-bundling,
+potentially-rolled-up) module location, which would not survive a production
+build's chunk reshuffling.
+
+**Endpoint shape.** `routes/findings/[id]/export.html/+server.js` — the `.html`
+segment gives the route a natural, memorable URL; the `Content-Disposition:
+attachment; filename="<slug>.html"` header (slug matching `_slug()` in
+`bartleby/commands/finding.py` / the web `downloadMarkdown()`) is what actually
+drives the download, not the URL shape. No CLI counterpart was added (the
+issue treats that as optional/deferred); the web button is the whole ask here.
+
+**Verification.** No automated test seam exists for exercising a SvelteKit
+route end-to-end from the Python suite, so this was verified by hand: a
+throwaway sandbox (`BARTLEBY_HOME` pointed at a temp dir, never a real
+project) with a project seeded directly through the typed chunk-insert
+helpers — a 3-page generated PDF, a `.txt` file (including a literal
+`</script>` in its body, to probe the JSON-embedding escape), a small JPEG
+registered as an extracted image chunk, and a finding citing all three plus a
+`[^url:…]`, a `[^doc:…]`, a `[^finding:999]`, and a dangling `[^chunk:999999]`
+— then the vite dev server was run against that sandbox only and the endpoint
+hit directly. The resulting file was checked for: all three `@font-face`
+families as base64 `data:font/woff2`, an embedded `data:application/pdf`, an
+embedded `data:image/jpeg` (correctly named after the archived `figure.jpg`,
+not the parent PDF), the literal (unmangled) `.txt` content including its
+`</script>` probe text, all four dagger glyphs present, zero `http://` or bare
+`https://` references other than the one `[^url:…]` citation's own href, no
+`/chunks/` or cross-finding `/findings/999` links, and balanced `<script>`
+tags. `uv run pytest` (untouched — no Python changed) and `npm run build`
+both pass.


### PR DESCRIPTION
## Summary

Adds a "Save as HTML" export for a finding: a single, fully self-contained HTML file (no network, no server) that reproduces the current `/findings/[id]` web view — the two-column split, drop-capped serif prose, Tufte-style margin notes with dagger glyphs, clickable note→source-viewer behavior seeked to the cited page, and the app's three self-hosted font families (Doto, Iosevka Term, Source Serif 4) embedded as base64 `data:` URIs.

Every cited source is embedded *in* the file:
- PDFs as base64 `data:application/pdf` URIs, plus a fallback `download` link (desktop-browser target, per the issue's resolved open question).
- `.txt`/`.log` as literally-escaped `<pre>` — never through `marked` (GH-0680).
- `.md` rendered via `marked` into the same sandboxed-viewer styling as the live app.
- Cited image chunks (`source_kind='image'`) embed the archived `.jpg` itself (not the parent PDF) as a base64 data URI.

External (`†`) citations keep their real, clickable URL; cross-finding (`§`) citations render as inert margin notes (no link — the other finding isn't in the file).

Files touched:
- `bartleby/web/src/routes/findings/[id]/export.html/+server.js` — the new endpoint (`Content-Disposition: attachment`, filename slug matching the CLI's `_slug()`/the web `downloadMarkdown()` convention).
- `bartleby/web/src/lib/server/exportHtml.js` — assembles the standalone document: rendered body, embedded fonts/CSS, embedded sources, the vanilla-JS margin-note-layout + viewer-switcher runtime.
- `bartleby/web/src/lib/citations.js` — the citation-marker → dagger-note substitution, extracted out of `+page.svelte`'s `renderBody()` so the live page and the export share one implementation (only the final `marked.parse()` differs per caller).
- `bartleby/web/src/lib/viewerDoc.js` — `SourceViewer.svelte`'s sandboxed-iframe wrapper + inline CSS, extracted so the export reuses the exact same viewer-pane rendering.
- `bartleby/web/src/lib/server/mime.js` — the extension→MIME table, extracted out of `/files/[document_id]/+server.js` so the export's embedded data URIs use the same mapping.
- `bartleby/web/src/lib/server/queries.js` — `getCitations()` now also returns `source_kind`/`source_id`; new `getImageFilePath()` for image-chunk citations.
- `bartleby/web/src/routes/findings/[id]/+page.svelte` — a "Save as HTML" button beside the existing Copy/Download-Markdown actions; `renderBody()` now delegates to the shared `citations.js`.
- `docs/decisions/GH-0690-finding-html-export-0001.md` — the resolved open questions, the sanitization approach (an isolated `Marked` instance, not "DOMPurify needs a DOM" — `isomorphic-dompurify` already runs server-side in this app's SSR path), the source-dedup rationale, and the CSS/font snapshot trade-off.

## How this was verified

No automated seam exists for exercising a SvelteKit endpoint from the Python test suite, so this was verified by hand, per the repo's live-data redline (never against a real corpus/Ollama):

- Built a throwaway sandbox (`BARTLEBY_HOME` pointed at a temp dir) seeded directly through the typed chunk-insert helpers: a 3-page generated PDF, a `.txt` file (including a literal `</script>` in its body to probe the JSON-embedding escape), a small JPEG registered as an extracted image chunk, and a finding citing all three plus a `[^url:…]`, a `[^doc:…]`, a `[^finding:999]`, and a dangling `[^chunk:999999]`.
- Ran the vite dev server against that sandbox only and hit `/findings/1/export.html` directly.
- Asserted on the output: all three `@font-face` families present as base64 `data:font/woff2`, an embedded `data:application/pdf`, an embedded `data:image/jpeg` (correctly named after the archived `figure.jpg`, not the parent PDF), the `.txt` content literal and unmangled (including the `</script>` probe), all four dagger glyphs (¶ § † ‡) present, zero `http://` references and no bare `https://` other than the one `[^url:…]` citation's own href, no `/chunks/` or cross-finding `/findings/999` links, and balanced `<script>` tags.
- `uv run pytest` — 1267 passed, 2 skipped (no Python changed).
- `cd bartleby/web && npm install && npm run build` — succeeds.

## Note

This branch is stacked on PR #691 (the ship-skill re-press); its diff will shrink to just this feature once #691 merges.

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)