### PR TITLE
docs: wsjpt install troubleshooting for SSH passphrase hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ On macOS, persist it across reboots with `ssh-add --apple-use-keychain ~/.ssh/id
 
 ```
 Host github.dowjones.net
-  AddKeysToKeychain yes
+  AddKeysToAgent yes
   UseKeychain yes
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,29 @@ The wsjpt provider (routes Gemini through WSJ's parsing toolkit; WSJ-internal) i
 uv tool install '.[docling,sec2md]' --with 'pydantic-ai>=1,<2' --with 'git+ssh://git@github.dowjones.net/data/wsjpt.git' --force
 ```
 
+If you'd rather sidestep SSH entirely, swap the wsjpt source for HTTPS — git then authenticates through the normal credential helper (a PAT, usually already cached in the macOS keychain from prior HTTPS clones):
+
+```
+--with 'git+https://github.dowjones.net/data/wsjpt.git'
+```
+
+Sticking with SSH: if the install hangs indefinitely at `resolving dependencies...`, a passphrase-protected SSH key is the likely cause — `uv` runs git non-interactively, so the key can't prompt for its passphrase and the fetch silently blocks rather than erroring. Fix by loading the key into `ssh-agent`:
+
+```
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+On macOS, persist it across reboots with `ssh-add --apple-use-keychain ~/.ssh/id_ed25519` and this `~/.ssh/config` stanza:
+
+```
+Host github.dowjones.net
+  AddKeysToKeychain yes
+  UseKeychain yes
+```
+
+With a local wsjpt checkout, `--with '/abs/path/to/wsjpt'` avoids the network fetch entirely.
+
 For development:
 
 ```


### PR DESCRIPTION
## Summary
- The documented wsjpt install command uses `git+ssh://git@github.dowjones.net/data/wsjpt.git`; for a user with a passphrase-protected SSH key, `uv` runs git non-interactively, so the fetch silently blocks at `resolving dependencies...` instead of erroring.
- Adds a short troubleshooting note right after the install command block: the HTTPS alternative (simplest, sidesteps SSH), the symptom/root-cause/`ssh-agent` fix for SSH users, and the local-path `--with` fallback.

Closes #687

## Test plan
- [x] Diff is wholly within README.md, matching `.claude/ship.toml`'s `docs_only_globs` — pytest suite auto-skips per repo convention (not run).
- [x] Reread the added prose against the README's existing register (dense plain prose, small fenced blocks, no new mega-section).
- [x] Commands and `~/.ssh/config` stanza copied verbatim from the issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)