### PR TITLE
fix long file names overflowing document cards

### DIFF
--- a/bartleby/web/src/app.css
+++ b/bartleby/web/src/app.css
@@ -224,6 +224,9 @@ p.meta,
   font-size: var(--text-2xs);
   color: var(--color-off);
   margin-top: var(--space-3xs);
+  /* Long unbroken file names would otherwise overflow the card, bleeding
+     into neighboring grid columns. */
+  overflow-wrap: break-word;
 }
 
 /* The finding_id, surfaced so users can match what the agent says in chat


### PR DESCRIPTION
the document cards in the `.card-grid` (docs, tags) have a `.ident` line showing the source file name, and long ones with no spaces (court filing exports, etc.) overflow past the card border into the next column instead of wrapping.

added `overflow-wrap: break-word` on `.ident`, same treatment `.markdown-body` already uses for long tokens. tested by ingesting a scratch project with a long-filename doc and confirming the card wraps instead of bleeding into the next column.
