### PR TITLE
docs(readme): callout for pre-[^chunk:N] findings with stale citations (#699)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ bartleby project upgrade <name>
 
 Most updates upgrade in place. When a change isn't backward-compatible, `upgrade` tells you to **re-ingest** instead (recreate the project and run `bartleby scribe` again) — there's no automatic migration for those.
 
+**If you have findings older than the `[^chunk:N]` citation format** ([#624](https://github.com/jswest/bartleby/issues/624)), check them: an old-style citation marker doesn't error, it just silently stops being recognized, so that finding's `finding_citations` can quietly go stale with no signal that anything broke. A one-time backfill already fixed every corpus present on a given machine when it ran ([#642](https://github.com/jswest/bartleby/issues/642)), but a corpus adopted from elsewhere, or one that predates that fix, can still carry unrecognized markers. `bartleby project upgrade` won't touch this — it's a data issue, not a schema one. Fix a stale finding by rewriting its body through `edit_finding` (see the [skill reference](./bartleby/skill/README.md)) — it re-extracts citations from the body and rebuilds `finding_citations` under the current grammar.
+
 ### Gotchas
 
 - Don't keep the repo (or its `.venv`) in a synced folder like Dropbox, iCloud, or OneDrive — syncing rewrites file paths and quietly breaks the install.

--- a/docs/decisions/GH-0699-citation-upgrade-note-0001.md
+++ b/docs/decisions/GH-0699-citation-upgrade-note-0001.md
@@ -1,0 +1,47 @@
+# A README "After updating Bartleby" callout, not a new doc, tells users to check pre-`[^chunk:N]` findings (issue #699)
+
+> Source: [#699](https://github.com/jswest/bartleby/issues/699)
+
+## The problem
+
+Findings authored before the `[^chunk:N]`-typed citation format landed
+([#624](https://github.com/jswest/bartleby/issues/624)) keep whatever
+untyped/old-style marker they had. That doesn't error on read — it just
+silently stops being recognized as a citation, so the finding's
+`finding_citations` rows go stale with no signal. `edit_finding` with a
+rewritten body is the working fix (it re-extracts citations from the body and
+rebuilds `finding_citations`), but nothing in the product tells a user this is
+necessary.
+
+This repo has no `CHANGELOG.md` — release notes live in GitHub Releases,
+auto-generated from `git log`
+([GH-0100](./GH-0100-semi-automated-releases-tags-version-pins-minor-0001.md)).
+So a durable, discoverable callout needs a different home.
+
+## Decision — extend the existing "After updating Bartleby" section
+
+`README.md`'s "After updating Bartleby" section is already the established
+convention for "what to check after you pull/update the tool" — it covers the
+schema-mismatch case (`bartleby project upgrade <name>` vs. re-ingest)
+immediately above. The citation-staleness issue is the same shape of problem
+(an update can leave existing data behind) even though it isn't a schema
+change, so a new paragraph was added directly after the schema-upgrade
+paragraph, before the "Gotchas" section, rather than inventing a new doc.
+
+The callout explicitly notes that a one-time backfill
+([#642](./GH-0642-backfill-legacy-citation-markers-0001.md)) already fixed
+every corpus present on a given machine when it ran, so this note is really
+for two remaining cases: a corpus adopted from elsewhere (corpus-share,
+per [no-natural-key-citation-resolver](../../ARCHITECTURE.md)), or one that
+predates the #642 fix on its machine. Omitting that context would have made
+the README claim *all* old findings are currently stale, which is false for
+already-backfilled corpora and would be needless alarm.
+
+## Why not `bartleby/skill/SKILL.md` or `README.md`
+
+The skill docs already describe `edit_finding` as the tool to "fix malformed
+citations or revise" — that's the *mechanism*, aimed at an agent mid-session.
+This callout is aimed at a *human* deciding whether to go check their old
+findings after updating the tool, which is a README-shaped concern (install/
+upgrade guidance), not a skill-contract concern. No change was made to the
+skill docs.


### PR DESCRIPTION
Part of #702

Findings authored before the typed `[^chunk:N]` citation format landed (#624) keep whatever old-style marker they had. That doesn't error on read — it just silently stops being recognized as a citation, so the finding's `finding_citations` rows go stale with no signal. `edit_finding` with a rewritten body is the working fix (it re-extracts citations from the body and rebuilds `finding_citations`), but nothing told users this was necessary — issue #699.

## What changed

- Added a callout to README.md's existing "After updating Bartleby" section (right after the schema-mismatch/`bartleby project upgrade` paragraph, which is the established convention for "what to check after you update the tool"). It covers what's affected (pre-`[^chunk:N]` findings), the symptom (citations silently unrecognized, `finding_citations` going stale), and the fix (rewrite the body via `edit_finding`). It also notes that `project upgrade` doesn't touch this (data issue, not schema) and that #642's one-time backfill already covered corpora present on a machine when it ran — so this mainly matters for a corpus adopted from elsewhere or one predating that fix.
- Added `docs/decisions/GH-0699-citation-upgrade-note-0001.md` recording the placement judgment call (README vs. a new doc, and why the skill docs weren't touched).

Docs-only diff; no code, no schema change, no `docs/decisions/README.md` index edit (left for the omnibus sweep per player instructions).

## Test plan

- [x] Docs-only diff — `uv run pytest` unaffected
- [x] Reviewed rendered README section for accuracy against #624/#642 history

🤖 Generated with [Claude Code](https://claude.com/claude-code)