### PR TITLE
docs(skill): tighten save_finding contract against diary-entry findings

### DIFF
--- a/bartleby/skill/SKILL.md
+++ b/bartleby/skill/SKILL.md
@@ -160,6 +160,8 @@ Read the `verdict`, then act:
 
 The diagnosis is a hint, not a guarantee: a purely-semantic presence (the chunk is *about* the term but never spells it) is invisible to these COUNTs — only `search` confirms that. An empty query carries no diagnosis. **Not** a substitute for `search`: scan stays a strict body-text grep by design (every returned snippet contains the query); the diagnosis only *reports* where the signal is.
 
+**FTS5 has no stemming.** `scan` and `search`'s FTS leg match the literal token — singular and plural are different queries (`grant` won't match `grants`), and so are other inflections (`file` / `filed` / `filing`). A zero or a low count can mean "wrong word form," not "absent." Before recording an absence, try the plausible inflections, or confirm with `search`'s semantic leg, which isn't sensitive to this.
+
 ### Undated corpus, temporal task: verify before you prompt
 
 When your task needs dates (filtering, ordering, "what happened before X") and `describe_corpus` shows a high `undated_document_count`, the dates may still be recoverable from the filenames in bulk — but **don't prompt the human blindly**. Verify a candidate regex first with `probe_dates` (read-only — it writes nothing):
@@ -188,6 +190,8 @@ Default search returns no context — the hit text alone. Reach for `--add-conte
 - **Citing chunks you haven't read in full.** A chunk_id you saw in a search result is a *candidate*. Before citing it in a finding — especially for claims that carry weight or anything quoted verbatim — run `read_chunks --chunks chunk:<id>` and confirm the chunk says what you're attributing to it.
 
 A useful heuristic: if a `chunk_id` appears in a finding you're about to save and it never showed up earlier in your conversation as something you read in full, you're guessing. Stop and fetch.
+
+**A claim can straddle a chunk boundary.** Chunking splits on length, not on where a sentence or a fact happens to end — the text you need may finish in the next chunk, or start in the one before. One chunk's silence on a claim is not evidence the document is silent: before recording a negative ("the document doesn't mention X"), read the chunk's neighbors with `read_chunks --around-chunk chunk:<id> --window N` and confirm the gap holds across all of them, not just the one chunk you happened to read.
 
 ## Image chunks
 
@@ -260,6 +264,15 @@ Rules:
 When the user asks for a structured deliverable (table, comparison, timeline), produce it directly — with `[^chunk:N]` markers in each cell as needed.
 
 When you've reached a conclusion worth preserving — even a partial one — call `save_finding`. The body is your markdown answer with `[^chunk:N]` markers throughout; **no separate citations argument exists**, and a body without any markers is rejected. Findings are how the next agent builds on your work.
+
+**A finding is one fact about the documents, written for a reader who has none of your session's context.** That contract cuts a few ways:
+
+- **One claim per finding.** If the body would need "also" or a numbered list to hold everything, it's more than one finding — split it, or save the one claim that's actually load-bearing and drop the rest.
+- **Write for a stranger, not for yourself.** The next reader — a different agent, a different session, the human — wasn't in your conversation. Don't reference "this session," "my earlier answer," or any internal tier/numbering scheme that only means something to you; it means nothing to them.
+- **No correction narratives.** If you made a mistake mid-session and caught it before saving anything, there's nothing to correct in the record — just save the correct fact, stated plainly, as if you'd had it right from the start. An error that was never saved doesn't need a finding that narrates catching it.
+- **No methodology, no diary, no self-assessment.** How you searched, which retrieval trap you hit, how much you trust a source — none of that is a fact about the documents, so none of it belongs in `findings`. Put it in your reply to the human instead; that's a process note, not memory for future research.
+
+When you have a process observation that isn't a fact about the documents — a caveat, a retrospective, a note on how you worked — say it in your reply and leave `save_finding` for the documents' facts.
 
 ## Plain language
 

--- a/docs/decisions/GH-0700-finding-contract-placement-0001.md
+++ b/docs/decisions/GH-0700-finding-contract-placement-0001.md
@@ -1,0 +1,50 @@
+# The tightened `save_finding` contract lives where findings are already discussed in prose, not in a new section — and the two tool-knowledge facts go where their failure mode already gets diagnosed.
+
+Issue #700: an agent saved a session diary entry (a correction narrative for
+an in-session mistake that was never itself saved, several unrelated claims
+bundled into one record, addressed to itself rather than a future reader) as
+a `save_finding` call. The findings UI then presented it with the same
+evidentiary chrome as a real finding, and it fed forward into later
+sessions' memory search. The issue specified two skill-layer fixes and no
+schema/code changes; the judgment calls below are about *where in
+`bartleby/skill/SKILL.md`* to land each one, given the standing instruction
+to tighten existing prose rather than bolt on a disconnected section.
+
+**Contract tightening → the "you've reached a conclusion worth preserving"
+paragraph in `## Output`, not the `save_finding` table row.** The Available
+Scripts table row for `save_finding` is already dense with shell-safety and
+argument mechanics; it's the wrong place for a five-bullet "what counts as a
+finding" contract. The `## Output` section's closing paragraph — "When
+you've reached a conclusion worth preserving... call `save_finding`" — is the
+one spot in the file that already answers *when/what*, so the new material
+(one claim per finding, write for a zero-context reader, no correction
+narratives, no methodology/diary/self-assessment) extends that paragraph in
+place rather than opening a new heading.
+
+**FTS5-has-no-stemming → the end of "Zero-result diagnosis," not the `scan`
+table row.** The fact belongs wherever an agent is deciding whether a zero
+or low count means "absent." The Zero-result diagnosis section already walks
+that exact decision (`absent` / `out_of_scope` / `heading_only` /
+`filtered_out`) and ends on "the diagnosis is a hint, not a guarantee" —
+the stemming caveat is one more way a `scan`/FTS reading can mislead, so it
+reads as a continuation of that guidance rather than a new fact bolted onto
+the `scan` row's already-long matching-mechanics prose.
+
+**Chunk-boundary negatives → the end of "Citing chunks correctly," not a
+new subsection under "Reading search results."** That section already
+walks two failure modes for *positive* citations (snippet truncation,
+citing an unread chunk) and ends on "if a chunk_id never showed up earlier
+as something you read in full, you're guessing — stop and fetch." The
+chunk-boundary caveat is the mirror case for *negative* claims ("the
+document doesn't say X"), so it reads as a third failure mode in the same
+list rather than a standalone note elsewhere.
+
+**Scope of "one claim per finding": not read as forbidding the existing
+"save interim findings when the work is long" guidance (`## Default research
+loop`, step 5).** That step tells agents to persist accumulated `chunk_id`s
+as the session gets long; nothing there implies bundling multiple unrelated
+claims into one finding, and the new contract doesn't touch that step. If a
+long session surfaces several distinct claims, the tightened contract means
+several `save_finding` calls, not a slimmer or fewer one — this was left
+implicit rather than spelled out at both sites, to avoid restating the same
+rule twice.


### PR DESCRIPTION
Part of #702

## Summary
- An agent saved a session diary entry as a finding — a correction narrative for a mistake never itself saved, several unrelated claims bundled into one record, addressed to itself rather than a future reader — and the findings UI presented it with the same evidentiary chrome as a real finding, feeding forward into later sessions' memory search (#700).
- Tightens `bartleby/skill/SKILL.md`'s `save_finding` contract in place (the `## Output` section's existing "when you've reached a conclusion worth preserving" paragraph): a finding is one fact about the documents, one claim per finding, written for a reader with zero session context; no correction narratives for errors never saved (save the correct fact, plainly); no methodology/diary/self-assessment — that belongs in the reply to the human, not the findings table.
- Folds the corpus-agnostic tool knowledge buried in that same diary entry into the file's own guidance, once, rather than left to be rediscovered per-project: FTS5 has no stemming (singular/plural are different `scan`/FTS queries — added to "Zero-result diagnosis"), and a claim can straddle a chunk boundary, so don't record a negative from one chunk without reading its neighbors (added to "Citing chunks correctly").
- Docs-only diff (`*.md`); no schema or code changes.

## Test plan
- [x] `uv run pytest` — 1267 passed, 2 skipped
- [x] Read the full diff for voice/structure fit and to confirm no existing rule was dropped or weakened

🤖 Generated with [Claude Code](https://claude.com/claude-code)