### PR TITLE
Exempt [YYYY]-shaped neutral case citations from malformed-citation guard

### DIFF
--- a/bartleby/skill_scripts/_common.py
+++ b/bartleby/skill_scripts/_common.py
@@ -29,8 +29,18 @@ _FINDING_CITATION_MARKER = re.compile(r"\[\^finding:(\d+)\]")
 # Citation-shaped but untyped: caret-less ``[N]`` and the now-obsolete bare
 # ``[^N]`` chunk form. Both render as bracketed prose but are silently dropped by
 # the typed extractor, so both are rejected loudly — see
-# :func:`reject_malformed_citations`.
+# :func:`reject_malformed_citations`. Exception: a caret-less exactly-4-digit
+# bracket (``[1998]``) is exempted there — that's the neutral case-citation
+# year shape (#698), not a chunk-id marker in practice.
 _MALFORMED_MARKER = re.compile(r"\[\^?(\d+)\]")
+# A caret-less, exactly-4-digit bracket — ``[1998]`` — matching neutral case
+# citations (``[1998] HKLRD 771``), which are bracketed-year by construction.
+# Never a valid chunk-id marker in practice, so exempt from the untyped-marker
+# guard below (#698). The careted form (``[^1998]``) is deliberately NOT
+# exempted: case citations never carry a caret, and ``[^N]`` is still the
+# obsolete bare-chunk-citation shape the guard exists to catch — exempting it
+# too would silently swallow a real malformed citation.
+_BRACKETED_YEAR = re.compile(r"^\[\d{4}\]$")
 # Typed citation marker: ``[^<scheme>:<ref>]``. The scheme is an alpha word.
 # ``chunk`` is the internal corpus-chunk scheme (matched by ``_CITATION_MARKER``
 # above); ``finding`` is the finding-link scheme (#654); ``url`` / ``doc`` are
@@ -235,9 +245,16 @@ def reject_malformed_citations(body: str) -> None:
     is also the marker's — so scan a copy with typed markers masked out, else a
     valid ``[^chunk:N]`` / ``[^url:…]`` marker false-trips this guard. (Refs may not
     themselves contain ``]``; that terminates the marker — percent-encode it.)
+
+    A caret-less exactly-4-digit bracket (``[1998]``) is exempted — see
+    ``_BRACKETED_YEAR`` — so ordinary prose citing a neutral case citation
+    (``[1998] HKLRD 771``) doesn't trip the guard.
     """
     scrubbed = _EXTERNAL_MARKER.sub(" ", body)
-    bad = [m.group(0) for m in _MALFORMED_MARKER.finditer(scrubbed)]
+    bad = [
+        m.group(0) for m in _MALFORMED_MARKER.finditer(scrubbed)
+        if not _BRACKETED_YEAR.match(m.group(0))
+    ]
     if not bad:
         return
     deduped = list(dict.fromkeys(bad))

--- a/docs/decisions/GH-0698-bracket-year-citations-0001.md
+++ b/docs/decisions/GH-0698-bracket-year-citations-0001.md
@@ -1,0 +1,69 @@
+# Exempt `[YYYY]`-shaped neutral case citations from the malformed-citation guard (issue #698)
+
+> Source: [#698](https://github.com/jswest/bartleby/issues/698)
+
+## Problem
+
+`reject_malformed_citations` in `bartleby/skill_scripts/_common.py` treats any
+`\[\^?(\d+)\]` as a citation-shaped marker missing its `[^chunk:N]` / `[^finding:N]`
+type tag, and rejects the whole save with `MALFORMED_CITATION`. Common-law
+neutral case citations are bracketed-year by construction (`[1998] HKLRD 771`),
+so ordinary prose quoting case law false-trips the guard. The escaping
+workaround (`\[1998\]`) has a second-order failure: prose that explains the
+escape by quoting the bare form trips the same check again on the next save.
+
+## Fix
+
+Exempt the caret-less, exactly-4-digit bracket shape — `[1998]` — from the
+guard. That shape is never a valid chunk-id marker in practice (chunk ids
+climb well past 4 digits in any real corpus, and the untyped-marker convention
+this guard polices is `[N]` for an arbitrary-length id, not specifically
+4-digit ids). Implemented as a second regex, `_BRACKETED_YEAR = r"^\[\d{4}\]$"`,
+checked against each `_MALFORMED_MARKER` match before it's added to the `bad`
+list.
+
+## Design choice: the exemption is caret-less only
+
+The issue's repro and suggested fix only mention the bare `[1998]` form. The
+existing guard also catches `[^N]` — described in its own comment as "the
+now-obsolete bare chunk form" (pre-#624 syntax, before citations were required
+to carry a `[^chunk:N]` type tag). The question: does a 4-digit ref *with* a
+caret — `[^1998]` — get the same exemption?
+
+**Decision: no.** The exemption stays caret-less-only; `[^1998]` is still
+rejected as `MALFORMED_CITATION`.
+
+Reasoning:
+
+- Neutral case citations never carry a caret — `[1998] HKLRD 771` is the
+  entire real-world shape this issue is about. There's no case-law citation
+  convention that would produce `[^1998]`, so extending the exemption there
+  buys no prose-compatibility win.
+- `[^N]` is a *specific* legacy pattern (the pre-#624 bare-chunk-citation
+  syntax) that the guard exists to catch precisely because it's easy to type
+  by accident (muscle memory from the old convention) and would otherwise
+  silently drop the citation — the exact failure #624 was opened to kill.
+  Widening the exemption to `[^1998]` would silently swallow a real instance
+  of that failure whenever the stale chunk id happened to be 4 digits, which
+  is not a rare coincidence in a corpus with a few thousand chunks.
+- Asymmetric exemption (caret-less only) is the minimal-surprise reading of
+  the issue's own suggested fix, which names the bracket shape without a
+  caret, and it costs nothing in practice since no real citation format
+  produces the careted form.
+
+This is implemented as a side effect of the regex, not a separate branch:
+`_BRACKETED_YEAR` requires `\[` immediately followed by `\d{4}` and `\]`, so
+`_MALFORMED_MARKER`'s `[^1998]` match (whose `group(0)` is `"[^1998]"`, caret
+included) never matches `_BRACKETED_YEAR` — no extra caret-detection logic
+needed.
+
+## Regression coverage
+
+`tests/test_external_citations.py`:
+- `test_malformed_check_exempts_bracketed_year_neutral_citation` — bare
+  `[1998]` in prose alongside a valid `[^chunk:N]` citation is accepted.
+- `test_malformed_check_still_rejects_non_four_digit_bracket` — `[12]`
+  (non-4-digit) is still rejected.
+- `test_malformed_check_still_rejects_careted_four_digit_bracket` — `[^1998]`
+  (4-digit, with caret) is still rejected, pinning the asymmetric-exemption
+  decision above.

--- a/tests/test_external_citations.py
+++ b/tests/test_external_citations.py
@@ -90,6 +90,34 @@ def test_malformed_check_ignores_bracketed_digits_inside_external_ref():
     assert exc.value.code == "MALFORMED_CITATION"
 
 
+def test_malformed_check_exempts_bracketed_year_neutral_citation():
+    """A caret-less ``[YYYY]``-shaped neutral case citation (e.g.
+    ``Re Estate of Example [1998] HKLRD 771``) is ordinary prose, not a
+    citation-shaped marker — must not trip MALFORMED_CITATION. Regression
+    for #698."""
+    body = "Corpus claim[^chunk:42]. See Re Estate of Example [1998] HKLRD 771."
+    reject_malformed_citations(body)  # must not raise
+
+
+def test_malformed_check_still_rejects_non_four_digit_bracket():
+    """The exemption is narrowly the 4-digit year shape — a genuinely
+    malformed short marker like ``[12]`` is still rejected."""
+    with pytest.raises(SkillError) as exc:
+        reject_malformed_citations("Corpus claim[^chunk:42]. Bad cite [12] here.")
+    assert exc.value.code == "MALFORMED_CITATION"
+    assert "[12]" in exc.value.extra["malformed_markers"]
+
+
+def test_malformed_check_still_rejects_careted_four_digit_bracket():
+    """The 4-digit exemption is caret-less only: ``[^1998]`` is still the
+    obsolete bare-chunk-citation shape, not a case citation (those never
+    carry a caret) — still rejected."""
+    with pytest.raises(SkillError) as exc:
+        reject_malformed_citations("Corpus claim[^chunk:42]. Bad cite [^1998] here.")
+    assert exc.value.code == "MALFORMED_CITATION"
+    assert "[^1998]" in exc.value.extra["malformed_markers"]
+
+
 # --- integration: save / read ------------------------------------------------
 
 def _first_chunk_id(seeded_project) -> int:


### PR DESCRIPTION
Part of #702.

## Summary

`reject_malformed_citations` in `bartleby/skill_scripts/_common.py` matched any `\[\^?(\d+)\]` as an untyped citation-shaped marker and rejected the whole save with `MALFORMED_CITATION`. This collided with common-law neutral case citations (`[1998] HKLRD 771`, etc.), which are bracketed-year by construction — ordinary prose quoting case law tripped it, and the escaping workaround (`\[1998\]`) had a second-order failure (prose explaining the escape by quoting the bare form tripped it again).

Fix: exempt the caret-less, exactly-4-digit bracket shape (`[1998]`) from the guard — that shape is never a valid chunk-id marker in practice.

## Design note: caret asymmetry

The exemption is caret-less only. `[^1998]` (4-digit, *with* caret) is still rejected as `MALFORMED_CITATION`. Neutral case citations never carry a caret, so widening the exemption there buys no prose-compatibility win, while `[^N]` is still the obsolete pre-#624 bare-chunk-citation shape this guard specifically exists to catch (and a stale 4-digit chunk id is not a rare coincidence in a corpus with a few thousand chunks). Recorded in `docs/decisions/GH-0698-bracket-year-citations-0001.md`.

## Tests

Added to `tests/test_external_citations.py`:
- bare `[1998]`-style year in prose alongside a valid citation is accepted
- a genuine malformed marker like `[12]` (non-4-digit) is still rejected
- `[^1998]` (4-digit, with caret) is still rejected — pins the asymmetric-exemption decision

Full suite: `uv run pytest` — 1270 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)