### PR TITLE
fix(skill): actionable ModuleNotFoundError for stale editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ uv tool install '.[docling,sec2md]' --force
 bartleby ready
 ```
 
-Restart your harness afterward so it reloads the skill. (Editable installs — `--editable .` — pick up code changes automatically, so you can skip step 1; `bartleby ready` still re-stamps the skill, and `--check` tells you whether a `git pull` actually changed it.)
+Restart your harness afterward so it reloads the skill. (Editable installs — `--editable .` — pick up code changes automatically, so you can skip step 1 *for a plain code change*; `bartleby ready` still re-stamps the skill, and `--check` tells you whether a `git pull` actually changed it. **A new dependency is not a plain code change** — an editable/tool install just references your source tree, so it won't install anything newly added to `pyproject.toml` on its own. If a `git pull` bumped a dependency and you skipped the reinstall, the symptom is a stray `ModuleNotFoundError: No module named '<package>'` from a command that used to work fine ([#697](https://github.com/jswest/bartleby/issues/697)); fix it with `uv tool install --reinstall '.[docling,sec2md]'` — same as step 1, plus `--reinstall` to force the dependency resync.)
 
 **If the database schema changed**, existing projects won't open until they're brought up to date — a command will fail with a clear `schema version mismatch` message. Bring a project up to date with:
 

--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -227,6 +227,30 @@ def run(
             result = work(conn=conn, args=args, session_id=session_id)
     except SkillError as e:
         error_envelope = {"error": e.message, "code": e.code, **e.extra}
+    except ModuleNotFoundError as e:
+        # A dependency the installed code now imports isn't in the running
+        # environment. The common cause (issue #697) is a stale
+        # `uv tool install --editable` install: pulling new code picks it up
+        # immediately (it's just the source tree), but a newly added
+        # dependency does NOT get installed until the tool env is re-synced.
+        # That left users hitting a bare "ModuleNotFoundError: No module
+        # named 'filetype'" wrapped as an opaque INTERNAL_ERROR. Name the
+        # likely cause and the fix instead of guessing at the missing
+        # package or probing imports at startup — see
+        # docs/decisions/GH-0697-modulenotfound-stale-install-0001.md.
+        module = e.name or str(e)
+        error_envelope = {
+            "error": (
+                f"Missing dependency: {module}. The running environment doesn't "
+                "have a module the installed code now imports — most likely a "
+                "stale `uv tool install --editable` that hasn't picked up a "
+                "dependency added since you installed. Run "
+                "`uv tool install --reinstall <path-or-package>` (or otherwise "
+                "re-sync your environment) and retry. Original error: "
+                f"{type(e).__name__}: {e}"
+            ),
+            "code": "STALE_INSTALL",
+        }
     except Exception as e:  # noqa: BLE001 — catch-all by design
         error_envelope = {
             "error": f"{type(e).__name__}: {e}",

--- a/docs/decisions/GH-0697-modulenotfound-stale-install-0001.md
+++ b/docs/decisions/GH-0697-modulenotfound-stale-install-0001.md
@@ -1,0 +1,52 @@
+# ModuleNotFoundError gets its own actionable envelope, not a generic one (issue #697)
+
+> Source: [#697](https://github.com/jswest/bartleby/issues/697)
+
+`filetype` became a core dependency (`resolve_extension()` in
+`bartleby/ingest/chunk.py`), but a `uv tool install --editable` install only
+references the source tree — it picks up new *code* on `git pull` for free,
+but never installs a dependency added since the tool env was created. Anyone
+who installed before `filetype` landed hit a bare
+`INTERNAL_ERROR: ModuleNotFoundError: No module named 'filetype'` from
+`save_finding`, with nothing pointing at the actual fix.
+
+Fix is a single seam, same shape as the `USAGE_ERROR` precedent
+(`docs/decisions/GH-0402-argparse-json-envelope-0001.md`): `bartleby/skill_runner.py`'s
+`run()` already funnels every skill script's failure through one
+`try`/`except`. A new `except ModuleNotFoundError` arm sits ahead of the
+existing `except Exception` catch-all and emits a distinct `STALE_INSTALL`
+code with a message naming the missing module and the fix
+(`uv tool install --reinstall`). The JSON envelope shape
+(`{"error": ..., "code": ...}` on stdout, non-zero exit) is unchanged — only
+the code and message differ from the `INTERNAL_ERROR` catch-all.
+
+**Options considered:**
+
+- **Keep `INTERNAL_ERROR`, just improve the message.** Rejected: the
+  codebase already has a convention of distinct codes per recognizable error
+  class (`NO_ACTIVE_PROJECT`, `USAGE_ERROR`, `MEMORY_OFF`,
+  `DOCUMENT_TOO_LARGE`). A caller that wants to special-case "the
+  environment is broken" (e.g. surface a different retry/help path) can't
+  distinguish it from an arbitrary bug under one shared code. A new code
+  costs nothing and matches how every other recognizable failure class is
+  already handled.
+- **Probe for missing packages at import time / auto-install.** Rejected —
+  explicitly out of scope per the issue and the smallest-fix-that-fits
+  agreement. A generic `ModuleNotFoundError` catch at the one wrap site
+  covers the whole class of "environment is stale relative to the code" for
+  free, without guessing at which packages matter or reaching into the
+  user's environment to fix it for them.
+- **`e.name` vs. `str(e)` for the module name.** `ModuleNotFoundError.name`
+  is set by the real import machinery (i.e. for every actual failed
+  `import` in production code) but not guaranteed on a hand-built exception,
+  so the message falls back to `str(e)` when `.name` is empty — still names
+  the module either way.
+
+Deliberately **not** done: no attempt to catch this earlier (e.g. at CLI
+startup) or to special-case which specific packages are "core" — a stale
+install can be missing *any* dependency, and the wrap site is the one place
+every skill script's failure already funnels through. The README's
+"After updating Bartleby" section also got a note (no code change) since the
+existing editable-install callout was actively misleading: it told users
+they could "skip step 1" without qualifying that skipping only holds for
+plain code changes, not new dependencies — the exact trap #697 fell into.

--- a/tests/test_skill_runner.py
+++ b/tests/test_skill_runner.py
@@ -319,6 +319,38 @@ def test_error_is_echoed_to_stderr_without_changing_stdout_envelope(
     assert captured.err.strip() == "INTERNAL_ERROR: RuntimeError: boom in work"
 
 
+def test_module_not_found_in_work_becomes_actionable_stale_install_error(
+    seeded_project, capsys
+):
+    """A ``ModuleNotFoundError`` raised inside ``work()`` — the shape you get
+    from a stale ``uv tool install --editable`` that hasn't picked up a
+    dependency added since install (issue #697) — is special-cased ahead of
+    the generic ``INTERNAL_ERROR`` catch-all. The envelope stays
+    ``{"error", "code"}`` with a non-zero exit, but the code is the distinct
+    ``STALE_INSTALL`` and the message names the fix instead of just echoing
+    the bare exception."""
+    project = seeded_project["project"]
+
+    def work(*, conn, args, session_id) -> dict:
+        # A real failed import (rather than a hand-built exception) so
+        # ``e.name`` is populated the same way it would be from the actual
+        # ``resolve_extension()`` -> ``import filetype`` failure (#697).
+        import bartleby_test_dependency_that_does_not_exist  # noqa: F401
+
+    with pytest.raises(SystemExit) as exc:
+        run(
+            tool_name="stale_install_probe",
+            parse_args=_parse_args,
+            work=work,
+            argv=["--project", project],
+        )
+    assert exc.value.code == 1
+    out = json.loads(capsys.readouterr().out)
+    assert out["code"] == "STALE_INSTALL"
+    assert "bartleby_test_dependency_that_does_not_exist" in out["error"]
+    assert "uv tool install --reinstall" in out["error"]
+
+
 def test_usage_error_is_echoed_to_stderr(capsys):
     """The USAGE_ERROR path shares the same dual-channel emission: stdout keeps
     the envelope, stderr gets the ``code: message`` echo (issue #421)."""


### PR DESCRIPTION
Part of #702.

## Summary

- `filetype` became a core dependency (`resolve_extension()` in `bartleby/ingest/chunk.py`), but a `uv tool install --editable` install only re-syncs on code changes, not new dependencies — so a pre-existing install hits a bare `INTERNAL_ERROR: ModuleNotFoundError: No module named 'filetype'` on first write after `git pull` (#697).
- `bartleby/skill_runner.py`'s `run()` now special-cases `ModuleNotFoundError` ahead of the generic catch-all: same `{"error", "code"}` JSON envelope and non-zero exit, but a distinct `STALE_INSTALL` code and a message naming the missing module and the fix (`uv tool install --reinstall`).
- README's "After updating Bartleby" section gets a correction: the existing editable-install callout implied you could always skip the CLI reinstall step, without qualifying that a new dependency still requires one — the exact trap #697 fell into. The note also names the `ModuleNotFoundError` symptom so it's findable.
- Added a test exercising a skill script's `work()` raising `ModuleNotFoundError` through the real runner, asserting the `STALE_INSTALL` code and actionable message.

Deliberately out of scope (per the issue): no auto-install, no import-time probing of specific packages — the wrap site is the one place every skill script's failure already funnels through, so a generic `ModuleNotFoundError` catch there covers the whole class of "environment is stale relative to the code."

## Test plan

- [x] `uv run pytest` — 1271 passed, 2 skipped
- [x] New test: `test_module_not_found_in_work_becomes_actionable_stale_install_error` in `tests/test_skill_runner.py`

Decision doc: `docs/decisions/GH-0697-modulenotfound-stale-install-0001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)