### PR TITLE
fix(skill): warn on wrong-project reads, echo resolved project on every result

### DIFF
--- a/bartleby/skill_runner.py
+++ b/bartleby/skill_runner.py
@@ -148,6 +148,7 @@ def run(
     result: dict | None = None
     error_envelope: dict | None = None
     args_dict: dict[str, Any] = {}
+    project: str | None = None
 
     # Only the argparse call gets the USAGE_ERROR treatment: a non-zero
     # SystemExit from parse_args (argparse's usage error) becomes the JSON
@@ -176,6 +177,12 @@ def run(
                 "NO_ACTIVE_PROJECT",
                 "No active project. Run `bartleby project create <name>`.",
             )
+        # Echo the *resolved* name back onto args (issue #696): most calls omit
+        # --project and ride the active-project pointer, so args.project alone
+        # is usually None even once a project has resolved. A work() callback
+        # that needs to name the project it's reading — e.g. read_chunks'
+        # 100%-miss warning — reads it from here rather than re-resolving.
+        args.project = project
 
         conn = open_db(project)
         # A non-agent caller (the web UI) sets BARTLEBY_SESSION_NAME to pin its
@@ -245,7 +252,12 @@ def run(
         # envelope; the run row is committed by now (a mutating work's
         # `with conn:` has exited), so the read sees it.
         if error_envelope is None and isinstance(result, dict) and session_id is not None:
-            result = {**result, "run": run_echo(conn, session_id)}
+            # Also echo the resolved project name (issue #696): the active
+            # project is shared global state another process can repoint, so
+            # every result names which corpus it actually ran against — the
+            # one place to add it so all ~two-dozen skill scripts get it
+            # uniformly, rather than each script threading it through itself.
+            result = {**result, "run": run_echo(conn, session_id), "project": project}
         # log_call needs a resolved session_id (its FK target); close must run
         # on every opened path regardless, or the conn leaks. See module docstring.
         if session_id is not None:

--- a/bartleby/skill_scripts/read_chunks.py
+++ b/bartleby/skill_scripts/read_chunks.py
@@ -27,6 +27,13 @@ other modes are silently ignored (e.g. ``--window`` is read only in
 ``--around-chunk`` mode, ``--offset``/``--limit`` only in ``--document-id``
 mode).
 
+A ``--chunks`` lookup where every requested id comes back missing sets
+``warning`` naming the resolved project, and only then — a partial miss
+never sets it. A 100% miss on ids you just read is the tell for a wrong
+active project (shared global state another process can repoint), not a bad
+id; every successful call also echoes ``project`` (the resolved project
+name) in the top-level envelope regardless of mode. Exit stays 0 either way.
+
 In a memory-off session the finding wall (see ``read_finding``) extends here:
 finding-kind chunks authored by *another* session are walled off so an
 evaluation run can't read prior conclusions by chunk_id. ``--chunks`` drops
@@ -76,6 +83,7 @@ Direct-lookup output:
       "requested": ["chunk:<id>", ...],
       "missing": ["chunk:<id>", ...],
       "hints": {"chunk:<id>": str, ...},   # present only when a missing id is a live document_id
+      "warning": str,   # present only when EVERY requested id came back missing — see below
       "preview": int|null,
       "chunks": [{
         "chunk_id": "chunk:<id>",
@@ -208,7 +216,7 @@ def _chunks_from_rows(
 
 def _read_by_chunk_ids(
     conn, chunk_ids: list[int], preview: int | None, *, mem: bool, session_id: int,
-    returning=None,
+    returning=None, project: str | None = None,
 ) -> dict:
     ordered = list(dict.fromkeys(chunk_ids))  # dedup, preserve order
 
@@ -305,6 +313,20 @@ def _read_by_chunk_ids(
     }
     if hints:
         out["hints"] = hints
+    # A 100%-miss read is almost never a batch of bad ids — it's the tell for
+    # a wrong active project (issue #696): the active project is shared global
+    # state another process can repoint mid-session, so a total miss on ids
+    # that read fine minutes earlier means "check the project", not "check the
+    # ids". A partial miss stays a quiet, ordinary result. Exit stays 0 either
+    # way (a genuinely stale/typo'd id set is a legitimate result too) — this
+    # is a warning in the envelope, not an error.
+    if ordered and len(missing) == len(ordered):
+        out["warning"] = (
+            f"All {len(ordered)} requested chunk id(s) came back missing in "
+            f"project '{project}' — if that's not the project you meant, "
+            "check the active project (`bartleby project use <name>`) before "
+            "assuming the ids are wrong."
+        )
     return format_output_ids(out)
 
 
@@ -465,7 +487,7 @@ def work(*, conn, args, session_id) -> dict:
     if args.chunk_ids is not None:
         return _read_by_chunk_ids(
             conn, args.chunk_ids, args.preview, mem=mem, session_id=session_id,
-            returning=args.returning,
+            returning=args.returning, project=args.project,
         )
     if args.around_chunk is not None:
         return _read_around_chunk(conn, args, session_id=session_id)

--- a/docs/decisions/GH-0696-wrong-project-guardrails-0001.md
+++ b/docs/decisions/GH-0696-wrong-project-guardrails-0001.md
@@ -1,0 +1,54 @@
+# The project-name echo lives in `skill_runner.run()`, not `_common.py`'s `session_provenance` — and the resolved name reaches `work()` by mutating `args.project`, not by widening every script's signature.
+
+Issue #696 (robbarry's live incident, and the earlier repro in the issue
+body): `active_project` lives in the shared global `~/.bartleby/config.yaml`,
+so another process on a multi-agent machine can repoint it mid-session. When
+that happens, `read_chunks` reports every requested id as `missing` and
+exits 0 — no warning, nothing naming the resolved project — and a
+wrong-project `save_finding` can silently succeed against unrelated text.
+The issue asked for two behavior-preserving fixes: warn on a 100%-miss read,
+and have every skill script's output echo the resolved project. Two
+placement calls were made getting there.
+
+**The envelope addition goes in `skill_runner.run()`, not the
+`session_name`/`model`/`harness` helper in `_common.py`.** The issue's own
+text points at `_common.py`'s session-metadata helper (`session_provenance`)
+as the precedent, and it's used by `save_finding`/`edit_finding`/
+`read_finding`/`merge_findings` — but only those four, each opting in to
+per-finding authorship attribution. It is not a place that touches every
+skill script. `skill_runner.run()`, on the other hand, is the one function
+every skill script's `main()` already calls, and it already stamps a `"run"`
+key onto every successful result (the `run_key`/`model`/`harness` echo added
+for #547). That's the actual "common output envelope" for the ~two-dozen
+scripts, so `"project"` was added there, next to `"run"`, in the same
+`if error_envelope is None and isinstance(result, dict)...` branch — one
+line, uniform across every script, no per-script edits.
+
+**`read_chunks`'s 100%-miss warning reads the resolved project off
+`args.project`, which `run()` now overwrites with the resolved name — rather
+than widening `work()`'s call signature to take a `project` kwarg.** Before
+this change, `args.project` was `None` on the overwhelmingly common path (no
+`--project` flag, riding the active-project pointer) — exactly the case the
+incident describes, since nobody explicitly points at the wrong project;
+they just don't override an already-wrong active pointer. Passing `project`
+into `work(conn=conn, args=args, session_id=session_id)` as a new kwarg
+would break every other script's `work()` signature (`def work(*, conn,
+args, session_id)`, none accepting `**kwargs`) with a `TypeError`, forcing a
+signature edit across ~20 files for one caller that needs it. `args` is
+already threaded into every `work()`; mutating `args.project = project`
+right after resolution (before `open_db`) makes the resolved name available
+wherever `args` already reaches, at the cost of one attribute assignment.
+Nothing reads `args.project` today expecting the pre-resolution `None`,
+confirmed by grepping every `work()` in `bartleby/skill_scripts/` before
+making the change.
+
+**Scope confirmed narrow: only `read_chunks`'s `--chunks` (direct id lookup)
+mode gets the warning.** Its other two modes (`--document-id`,
+`--around-chunk`) already fail loudly on an unresolved id (`DOCUMENT_NOT_FOUND`
+/ `CHUNK_NOT_FOUND`), so they don't have the issue's silent-`missing`-with-
+exit-0 shape. `extract.py` also computes a `missing` list from a batch of
+chunk ids, but it's a mutating script whose richer per-id diagnostics
+(`no_match`/`cast_errors`/`conflicts`) already make an empty `stored` list
+visible, and the issue's repro and fix proposals are both `read_chunks`-
+specific — extending to `extract` was left out as broadening scope beyond
+what was asked.

--- a/tests/test_skill_read_chunks.py
+++ b/tests/test_skill_read_chunks.py
@@ -244,6 +244,25 @@ def test_read_chunks_by_id_reports_missing(seeded_project, capsys):
     out = json.loads(capsys.readouterr().out)
     assert out["missing"] == ["chunk:999999"]
     assert [c["chunk_id"] for c in out["chunks"]] == [f"chunk:{chunk_ids[0]}"]
+    # A partial miss is a legitimate, quiet result — no wrong-project warning.
+    assert "warning" not in out
+
+
+def test_read_chunks_by_id_total_miss_warns_naming_project(seeded_project, capsys):
+    """A 100%-miss read is the tell for a wrong active project (issue #696):
+    every requested id missing sets ``warning``, naming the resolved project,
+    so the agent can catch a repointed ``active_project`` instead of assuming
+    the ids are wrong. Exit still stays 0 — this is a warning, not an error."""
+    read_chunks.main([
+        "--project", seeded_project["project"],
+        "--chunks", "chunk:999999,chunk:999998",
+    ])
+    out = json.loads(capsys.readouterr().out)
+    assert out["missing"] == ["chunk:999999", "chunk:999998"]
+    assert "warning" in out
+    assert seeded_project["project"] in out["warning"]
+    # Also present at the top-level envelope (issue #696), independent of mode.
+    assert out["project"] == seeded_project["project"]
 
 
 def test_read_chunks_requires_document_or_chunks(seeded_project, capsys):

--- a/tests/test_skill_runner.py
+++ b/tests/test_skill_runner.py
@@ -416,3 +416,36 @@ def test_run_echo_present_on_every_result(project_env, capsys):
     assert set(out["run"]) >= {
         "run_key", "session_id", "session_name", "model", "model_set_by_llm",
     }
+
+
+# --- resolved-project echo, every result (issue #696) ------------------------
+
+
+def test_project_echoed_on_every_result(project_env, capsys):
+    """Every successful result names the project it actually resolved — added
+    once in the shared envelope (not per-script) so a repointed
+    ``active_project`` is visible on any skill call, not just reads that hit a
+    100%-miss warning."""
+    project = project_env
+
+    def work(*, conn, args, session_id) -> dict:
+        return {"ok": True}
+
+    run(tool_name="probe", parse_args=_parse_args, work=work,
+        argv=["--project", project])
+    out = json.loads(capsys.readouterr().out)
+    assert out["project"] == project
+
+
+def test_project_echoed_when_resolved_from_active_pointer(project_env, capsys):
+    """The echoed ``project`` is the *resolved* name even when the caller
+    omitted ``--project`` and rode the active-project pointer — the common
+    case, and the one the wrong-project incident (#696) actually hinges on."""
+    project = project_env
+
+    def work(*, conn, args, session_id) -> dict:
+        return {"ok": True}
+
+    run(tool_name="probe", parse_args=_parse_args, work=work, argv=[])
+    out = json.loads(capsys.readouterr().out)
+    assert out["project"] == project

--- a/tests/test_skill_tags.py
+++ b/tests/test_skill_tags.py
@@ -92,6 +92,7 @@ def test_read_tags_empty(seeded_project, capsys):
     read_tags.main(["--project", seeded_project["project"]])
     out = json.loads(capsys.readouterr().out)
     assert out.pop("run")["session_id"]  # every result echoes the run (#547)
+    assert out.pop("project") == seeded_project["project"]  # #696
     assert out == {"tags": []}
 
 
@@ -257,6 +258,7 @@ def test_rename_tag_renames_and_preserves_assignment(seeded_project, capsys):
     ])
     out = json.loads(capsys.readouterr().out)
     assert out.pop("run")["session_id"]  # every result echoes the run (#547)
+    assert out.pop("project") == seeded_project["project"]  # #696
     assert out == {
         "status": "renamed",
         "tag_id": f"tag:{tag_id}",
@@ -977,6 +979,7 @@ def test_assign_tag_creates_assignment(seeded_project, capsys):
     ])
     out = json.loads(capsys.readouterr().out)
     assert out.pop("run")["session_id"]  # every result echoes the run (#547)
+    assert out.pop("project") == seeded_project["project"]  # #696
     assert out == {
         "tag_id": f"tag:{tag_id}", "tag": "bad_ocr",
         "value": None, "chunk_id": None,


### PR DESCRIPTION
Part of #702

Implements the two behavior-preserving fixes proposed in #696: `active_project` lives in the shared global `~/.bartleby/config.yaml`, so another process on a multi-agent machine can repoint it mid-session. When that happens today, `read_chunks --chunks` reports every requested id as `missing` and exits 0 — nothing names the resolved project, and a wrong-project `save_finding` can silently succeed. (See robbarry's comment on #696 for a real incident this caused.)

## What changed

- `read_chunks`'s `--chunks` (direct id lookup) mode now sets a `"warning"` key, naming the resolved project, when **every** requested id comes back missing. A partial miss stays quiet, as today — exit code is unchanged (still 0); this is a warning in the envelope, not an error.
- `skill_runner.run()` — the one function every skill script's `main()` already calls — now echoes the resolved project name as a top-level `"project"` key on every successful result, next to the existing `"run"` echo (added for #547). One change in the shared envelope, so all ~two-dozen skill scripts get it uniformly rather than each script threading it through itself.
- The resolved project name reaches `read_chunks`'s `work()` by way of `run()` writing it back onto `args.project` (previously `None` unless `--project` was passed explicitly — not the common case this bug lives in) rather than widening every script's `work()` signature for one caller.

Out of scope, per the issue: no redesign of active-project resolution, no locking, no moving config.

## Files changed

- `bartleby/skill_runner.py` — resolved-project echo on `args` and in the shared result envelope
- `bartleby/skill_scripts/read_chunks.py` — 100%-miss warning + docstring/contract update
- `tests/test_skill_runner.py`, `tests/test_skill_read_chunks.py`, `tests/test_skill_tags.py` — new coverage + updates for the new envelope key
- `docs/decisions/GH-0696-wrong-project-guardrails-0001.md` — placement rationale (why the envelope change lives in `skill_runner.run()` rather than `_common.py`'s `session_provenance`, and why `args.project` mutation over a widened `work()` signature)

## Test plan

- [x] `uv run pytest` — 1273 passed, 2 skipped
- [x] New tests: 100%-miss read sets `warning` naming the project; partial miss does not; `skill_runner.run()`'s envelope carries `project` on every result, both when `--project` is passed explicitly and when it's resolved from the active-project pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)